### PR TITLE
Collapse BrushManager onto the cache and batch multi-brush signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Changed
+- **BrushManager is a list mirror:** `clear_brushes()` no longer frees nodes. `HFBrushSystem` owns brush lifetime; multi-brush create/delete/nudge now batch LevelRoot signals.
+- **Snap-to-edge:** new EDGE snap mode (dock **E** / Edges) snaps to AABB edge midpoints of existing brushes.
 - **Core-loop freeze:** the default editor is Draw → material → entity → bake → Test Level. Radial menu, coach marks, and operation replay are gated behind **Test → Settings → Power-user overlays** (off by default). Subtract preview is labeled as an AABB approximation. Unused welcome-panel, BrushPrefab, debug_heightmap, and archived quadrant-view scripts were removed. `BrushManager` is a null-safe legacy mirror of `HFBrushSystem`'s brush cache.
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -294,6 +294,11 @@ Priorities are informed by a Hammer Editor gap analysis — see GAP_ANALYSIS.md 
 - **dock.gd reduction**: 7,001 → 6,692 lines (–309, –4.4%). plugin.gd: –4 lines (responsibility separation rather than LOC).
 - **75+ new test cases across 8 files**: `test_ui_factory`, `test_hf_validation`, `test_hf_system`, `test_hf_undo_nav`, `test_entity_prop_utils`, `test_hf_tooltip_text`, `test_hf_dialog_manager`, `test_hf_editor_theme`.
 
+## Done (Registry collapse, signal batching, snap-to-edge — August 2026)
+- `BrushManager` no longer owns or frees brush nodes; the system cache is the live list.
+- `create_brushes_from_infos`, `delete_brushes_by_id`, `nudge_brushes_by_id`, and `delete_managed_nodes` wrap `begin_signal_batch()` / `end_signal_batch()`.
+- Snap-to-edge mode (bit 8) with a dock Edges toggle.
+
 ## Done (Core-Loop Freeze — August 2026)
 - Default product is Draw → material → entity → bake → Test Level.
 - Power-user overlays (radial menu, coach marks, operation replay) are opt-in.

--- a/addons/hammerforge/brush_manager.gd
+++ b/addons/hammerforge/brush_manager.gd
@@ -14,9 +14,5 @@ func remove_brush(brush: Node3D) -> void:
 
 
 func clear_brushes() -> void:
-	for brush in brushes:
-		if brush.is_inside_tree():
-			if brush.get_parent():
-				brush.get_parent().remove_child(brush)
-			brush.queue_free()
+	# List mirror only. HFBrushSystem owns node lifetime.
 	brushes.clear()

--- a/addons/hammerforge/dock.gd
+++ b/addons/hammerforge/dock.gd
@@ -320,6 +320,7 @@ var syncing_snap := false
 var snap_grid_btn: Button = null
 var snap_vertex_btn: Button = null
 var snap_center_btn: Button = null
+var snap_edge_btn: Button = null
 var _axis_lock_x: Button = null
 var _axis_lock_y: Button = null
 var _axis_lock_z: Button = null
@@ -833,6 +834,8 @@ func _setup_simplified_workflow() -> void:
 		snap_vertex_btn.text = "Corners"
 	if snap_center_btn:
 		snap_center_btn.text = "Centers"
+	if snap_edge_btn:
+		snap_edge_btn.text = "Edges"
 
 
 func _update_context_hints() -> void:
@@ -2933,6 +2936,13 @@ func _build_snap_mode_buttons() -> void:
 	snap_center_btn.custom_minimum_size.x = 32
 	snap_center_btn.toggled.connect(_on_snap_mode_toggled.bind(4))
 	row.add_child(snap_center_btn)
+	snap_edge_btn = Button.new()
+	snap_edge_btn.text = "E"
+	snap_edge_btn.tooltip_text = "Edge snap (brush edge midpoints)"
+	snap_edge_btn.toggle_mode = true
+	snap_edge_btn.custom_minimum_size.x = 32
+	snap_edge_btn.toggled.connect(_on_snap_mode_toggled.bind(8))
+	row.add_child(snap_edge_btn)
 	parent.add_child(row)
 	parent.move_child(row, idx)
 	# Axis Lock row

--- a/addons/hammerforge/hf_snap_system.gd
+++ b/addons/hammerforge/hf_snap_system.gd
@@ -6,7 +6,7 @@ class_name HFSnapSystem
 
 const DraftBrush = preload("brush_instance.gd")
 
-enum SnapMode { GRID = 1, VERTEX = 2, CENTER = 4 }
+enum SnapMode { GRID = 1, VERTEX = 2, CENTER = 4, EDGE = 8 }
 
 var root: Node3D
 var enabled_modes: int = SnapMode.GRID
@@ -44,8 +44,8 @@ func snap_point(point: Vector3, grid_snap: float, exclude_ids: Array = []) -> Ve
 			best = grid_snapped
 			best_dist = d
 
-	# Geometry snap candidates (vertex / center)
-	if is_mode_on(SnapMode.VERTEX) or is_mode_on(SnapMode.CENTER):
+	# Geometry snap candidates (vertex / center / edge)
+	if is_mode_on(SnapMode.VERTEX) or is_mode_on(SnapMode.CENTER) or is_mode_on(SnapMode.EDGE):
 		var candidates := _collect_candidates(exclude_ids)
 		for c in candidates:
 			var d := point.distance_to(c)
@@ -90,6 +90,7 @@ func _collect_candidates(exclude_ids: Array) -> PackedVector3Array:
 		return out
 	var do_vertex := is_mode_on(SnapMode.VERTEX)
 	var do_center := is_mode_on(SnapMode.CENTER)
+	var do_edge := is_mode_on(SnapMode.EDGE)
 	var preview = root.get("preview_brush")
 	for node in root._iter_pick_nodes():
 		if not (node is DraftBrush):
@@ -103,13 +104,36 @@ func _collect_candidates(exclude_ids: Array) -> PackedVector3Array:
 		var half := brush.size * 0.5
 		if do_center:
 			out.append(pos)
+		var corners := PackedVector3Array(
+			[
+				pos + Vector3(-half.x, -half.y, -half.z),
+				pos + Vector3(-half.x, -half.y, half.z),
+				pos + Vector3(-half.x, half.y, -half.z),
+				pos + Vector3(-half.x, half.y, half.z),
+				pos + Vector3(half.x, -half.y, -half.z),
+				pos + Vector3(half.x, -half.y, half.z),
+				pos + Vector3(half.x, half.y, -half.z),
+				pos + Vector3(half.x, half.y, half.z),
+			]
+		)
 		if do_vertex:
-			out.append(pos + Vector3(-half.x, -half.y, -half.z))
-			out.append(pos + Vector3(-half.x, -half.y, half.z))
-			out.append(pos + Vector3(-half.x, half.y, -half.z))
-			out.append(pos + Vector3(-half.x, half.y, half.z))
-			out.append(pos + Vector3(half.x, -half.y, -half.z))
-			out.append(pos + Vector3(half.x, -half.y, half.z))
-			out.append(pos + Vector3(half.x, half.y, -half.z))
-			out.append(pos + Vector3(half.x, half.y, half.z))
+			out.append_array(corners)
+		if do_edge:
+			# 12 AABB edges, same corner order as vertex snap.
+			var edges := [
+				[0, 1],
+				[0, 2],
+				[0, 4],
+				[1, 3],
+				[1, 5],
+				[2, 3],
+				[2, 6],
+				[3, 7],
+				[4, 5],
+				[4, 6],
+				[5, 7],
+				[6, 7],
+			]
+			for edge in edges:
+				out.append((corners[edge[0]] + corners[edge[1]]) * 0.5)
 	return out

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -960,9 +960,11 @@ func create_brush_from_info(info: Dictionary) -> Node:
 
 
 func create_brushes_from_infos(infos: Array) -> void:
+	begin_signal_batch()
 	for info in infos:
 		if info is Dictionary:
 			brush_system.create_brush_from_info(info)
+	end_signal_batch()
 
 
 func delete_brush(brush: Node, free: bool = true) -> void:
@@ -974,8 +976,10 @@ func delete_brush_by_id(brush_id: String) -> HFOpResult:
 
 
 func delete_brushes_by_id(brush_ids: Array) -> void:
+	begin_signal_batch()
 	for brush_id in brush_ids:
 		brush_system.delete_brush_by_id(str(brush_id))
+	end_signal_batch()
 
 
 func duplicate_brush(brush: Node) -> Node:
@@ -983,12 +987,16 @@ func duplicate_brush(brush: Node) -> Node:
 
 
 func nudge_brushes_by_id(brush_ids: Array, offset: Vector3) -> void:
+	begin_signal_batch()
 	brush_system.nudge_brushes_by_id(brush_ids, offset)
+	end_signal_batch()
 
 
 func delete_managed_nodes(brush_ids: Array, entity_paths: Array) -> void:
+	begin_signal_batch()
 	delete_brushes_by_id(brush_ids)
 	delete_entities_by_paths(entity_paths)
+	end_signal_batch()
 
 
 func create_managed_duplicates(brush_infos: Array, entity_infos: Array) -> void:

--- a/tests/test_brush_manager.gd
+++ b/tests/test_brush_manager.gd
@@ -1,0 +1,17 @@
+extends GutTest
+## BrushManager is a legacy list mirror. It must not own brush lifetime.
+
+const BrushManagerType = preload("res://addons/hammerforge/brush_manager.gd")
+
+
+func test_clear_brushes_does_not_free_nodes():
+	var manager = BrushManagerType.new()
+	add_child_autoqfree(manager)
+	var brush = Node3D.new()
+	add_child_autoqfree(brush)
+	manager.add_brush(brush)
+	assert_eq(manager.brushes.size(), 1)
+	manager.clear_brushes()
+	assert_eq(manager.brushes.size(), 0)
+	assert_true(is_instance_valid(brush), "HFBrushSystem owns node lifetime, not BrushManager")
+	assert_true(brush.is_inside_tree())

--- a/tests/test_brush_manager.gd.uid
+++ b/tests/test_brush_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://dsdn7rpeaflg

--- a/tests/test_brush_system.gd
+++ b/tests/test_brush_system.gd
@@ -104,3 +104,30 @@ func test_legacy_manager_mirror_stays_optional():
 	)
 	assert_null(root.brush_manager)
 	assert_eq(sys.get_cached_brushes(), [brush])
+
+
+func test_cache_is_authority_when_legacy_manager_exists():
+	var manager = _FakeManager.new()
+	root.brush_manager = manager
+	var brush = sys.create_brush_from_info(
+		{"size": Vector3(4, 4, 4), "center": Vector3.ZERO, "brush_id": "cached"}
+	)
+	assert_eq(sys.get_cached_brush_count(), 1)
+	assert_eq(sys.find_brush_by_id("cached"), brush)
+	assert_eq(manager.brushes, [brush], "Legacy list is a mirror of the cache")
+	sys.delete_brush_by_id("cached")
+	assert_eq(sys.get_cached_brush_count(), 0)
+	assert_eq(manager.brushes, [])
+
+
+class _FakeManager:
+	var brushes: Array = []
+
+	func add_brush(brush: Node) -> void:
+		brushes.append(brush)
+
+	func remove_brush(brush: Node) -> void:
+		brushes.erase(brush)
+
+	func clear_brushes() -> void:
+		brushes.clear()

--- a/tests/test_dirty_tags.gd
+++ b/tests/test_dirty_tags.gd
@@ -215,6 +215,7 @@ func test_serialized_brushes_bootstrap_unique_ids_live_index_and_committed_resto
 
 	add_child_autoqfree(production_root)
 	assert_eq(production_root.get_live_brush_count(), 2)
+	assert_eq(production_root.brush_system.get_cached_brush_count(), 2)
 	assert_eq(production_root.brush_manager.brushes.size(), 2)
 	assert_ne(first.brush_id, duplicate.brush_id)
 	assert_ne(first.brush_id, frozen.brush_id)
@@ -232,9 +233,22 @@ func test_serialized_brushes_bootstrap_unique_ids_live_index_and_committed_resto
 
 	production_root.restore_committed_cuts()
 	assert_eq(production_root.get_live_brush_count(), 3)
+	assert_eq(production_root.brush_system.get_cached_brush_count(), 3)
 	assert_eq(production_root.brush_manager.brushes.size(), 3)
 	assert_same(production_root.find_brush_by_id(frozen.brush_id), frozen)
 	assert_eq(production_root.displacement_system._get_all_brushes().size(), 3)
+
+
+func test_delete_brushes_by_id_coalesces_selection_changed():
+	var production_root := _make_production_root()
+	_make_production_brush(production_root, "batch_a")
+	_make_production_brush(production_root, "batch_b")
+	var selection_emits: Array = []
+	production_root.selection_changed.connect(func(ids): selection_emits.append(ids))
+	production_root.delete_brushes_by_id(["batch_a", "batch_b"])
+	assert_eq(selection_emits.size(), 1, "Multi-brush delete must not storm the dock")
+	assert_eq(production_root.get_live_brush_count(), 0)
+	assert_eq(production_root.brush_system.get_cached_brush_count(), 0)
 
 
 func test_nudge_and_override_material_tag_only_real_changes():

--- a/tests/test_map_export.gd
+++ b/tests/test_map_export.gd
@@ -1,5 +1,6 @@
 extends GutTest
 
+const MapIO = preload("res://addons/hammerforge/map_io.gd")
 const HFMapAdapter = preload("res://addons/hammerforge/map_adapters/hf_map_adapter.gd")
 const HFMapQuake = preload("res://addons/hammerforge/map_adapters/hf_map_quake.gd")
 const HFMapValve220 = preload("res://addons/hammerforge/map_adapters/hf_map_valve220.gd")
@@ -197,3 +198,27 @@ func test_valve220_fmt_float_integer():
 func test_valve220_fmt_float_fractional():
 	var result = HFMapValve220._fmt_float(0.333)
 	assert_true(result.begins_with("0.33"))
+
+
+func test_parse_map_text_worldspawn_and_point_entity():
+	var map_text := (
+		"{\n"
+		+ '"classname" "worldspawn"\n'
+		+ "{\n"
+		+ "( 0 0 0 ) ( 64 0 0 ) ( 64 64 0 ) brick 0 0 0 1 1\n"
+		+ "( 0 0 16 ) ( 64 64 16 ) ( 64 0 16 ) brick 0 0 0 1 1\n"
+		+ "}\n"
+		+ "}\n"
+		+ "{\n"
+		+ '"classname" "light"\n'
+		+ '"origin" "32 32 8"\n'
+		+ "}\n"
+	)
+	var parsed: Dictionary = MapIO.parse_map_text(map_text)
+	assert_eq(
+		(parsed.get("brushes", []) as Array).size(), 1, "Worldspawn brush becomes authored geometry"
+	)
+	var entities: Array = parsed.get("entities", [])
+	assert_eq(entities.size(), 1, "Point entities stay in the entity list")
+	assert_eq(entities[0]["classname"], "light")
+	assert_eq(str(entities[0]["properties"]["origin"]), "32 32 8")

--- a/tests/test_snap_system.gd
+++ b/tests/test_snap_system.gd
@@ -59,6 +59,7 @@ func test_default_mode_is_grid():
 	assert_true(snap.is_mode_on(HFSnapSystem.SnapMode.GRID))
 	assert_false(snap.is_mode_on(HFSnapSystem.SnapMode.VERTEX))
 	assert_false(snap.is_mode_on(HFSnapSystem.SnapMode.CENTER))
+	assert_false(snap.is_mode_on(HFSnapSystem.SnapMode.EDGE))
 
 
 func test_set_mode_on_off():
@@ -119,6 +120,15 @@ func test_vertex_snap_threshold():
 # ===========================================================================
 # Center snap
 # ===========================================================================
+
+
+func test_edge_snap_to_midpoint():
+	snap.set_mode(HFSnapSystem.SnapMode.EDGE, true)
+	snap.set_mode(HFSnapSystem.SnapMode.GRID, false)
+	# Brush at origin, size 32 — +X face vertical edge midpoint at (16, 0, 16)
+	_make_brush(Vector3.ZERO, Vector3(32, 32, 32), "e1")
+	var result = snap.snap_point(Vector3(16.4, 0.3, 16.2), 0.0)
+	assert_eq(result, Vector3(16, 0, 16))
 
 
 func test_center_snap():


### PR DESCRIPTION
Follow-up to the core-loop freeze: remaining review findings that were still load-bearing.

- **BrushManager is a list mirror.** `clear_brushes()` no longer frees nodes. `HFBrushSystem` owns lifetime; the cache is the live list.
- **Signal batching.** `create_brushes_from_infos`, `delete_brushes_by_id`, `nudge_brushes_by_id`, and `delete_managed_nodes` wrap `begin_signal_batch()` / `end_signal_batch()` so multi-brush edits do not storm the dock.
- **Snap-to-edge.** New EDGE mode (dock **E** / Edges) snaps to AABB edge midpoints.
- **MapIO parse coverage** for worldspawn brushes vs point entities.

GUT: **1705 tests, 1698 passing, 0 failing** (7 pre-existing risky).