### PR TITLE
See DraftBrushes in subtract preview and keep map faces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Changed
+- **Subtract preview sees DraftBrushes** and uses mesh bounds instead of skipping non-CSGShape3D nodes.
+- **Per-project entities:** `res://hammerforge_entities.json` overlays the plugin entity list (same classname wins).
+- **`.map` fidelity:** rotated/complex brushes import and export as CUSTOM face planes instead of cylinders/boxes.
 - **BrushManager is a list mirror:** `clear_brushes()` no longer frees nodes. `HFBrushSystem` owns brush lifetime; multi-brush create/delete/nudge now batch LevelRoot signals.
 - **Snap-to-edge:** new EDGE snap mode (dock **E** / Edges) snaps to AABB edge midpoints of existing brushes.
 - **Core-loop freeze:** the default editor is Draw → material → entity → bake → Test Level. Radial menu, coach marks, and operation replay are gated behind **Test → Settings → Power-user overlays** (off by default). Subtract preview is labeled as an AABB approximation. Unused welcome-panel, BrushPrefab, debug_heightmap, and archived quadrant-view scripts were removed. `BrushManager` is a null-safe legacy mirror of `HFBrushSystem`'s brush cache.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -294,6 +294,11 @@ Priorities are informed by a Hammer Editor gap analysis — see GAP_ANALYSIS.md 
 - **dock.gd reduction**: 7,001 → 6,692 lines (–309, –4.4%). plugin.gd: –4 lines (responsibility separation rather than LOC).
 - **75+ new test cases across 8 files**: `test_ui_factory`, `test_hf_validation`, `test_hf_system`, `test_hf_undo_nav`, `test_entity_prop_utils`, `test_hf_tooltip_text`, `test_hf_dialog_manager`, `test_hf_editor_theme`.
 
+## Done (Subtract preview, project entities, map faces — August 2026)
+- Subtract preview iterates DraftBrushes and mesh bounds.
+- `res://hammerforge_entities.json` overlays plugin entity definitions.
+- `.map` import/export of non-axis-aligned brushes uses CUSTOM faces.
+
 ## Done (Registry collapse, signal batching, snap-to-edge — August 2026)
 - `BrushManager` no longer owns or frees brush nodes; the system cache is the live list.
 - `create_brushes_from_infos`, `delete_brushes_by_id`, `nudge_brushes_by_id`, and `delete_managed_nodes` wrap `begin_signal_batch()` / `end_signal_batch()`.

--- a/addons/hammerforge/dock.gd
+++ b/addons/hammerforge/dock.gd
@@ -6630,7 +6630,7 @@ func _populate_brush_entity_classes() -> void:
 	if not brush_entity_class_opt:
 		return
 	brush_entity_class_opt.clear()
-	var defs = HFEntityDef.load_definitions(entity_defs_path)
+	var defs = HFEntityDef.load_merged_definitions(entity_defs_path)
 	var brush_defs = HFEntityDef.filter_brush_entities(defs)
 	if brush_defs.is_empty():
 		# Fallback: ensure at least the built-in brush entity classes are available.

--- a/addons/hammerforge/hf_entity_def.gd
+++ b/addons/hammerforge/hf_entity_def.gd
@@ -15,6 +15,9 @@ var properties: Array[Dictionary] = []
 ## Optional scene path to instantiate instead of a plain DraftEntity.
 var scene_path := ""
 
+## Optional per-project overlay. Entries with the same classname replace plugin defs.
+const PROJECT_DEFINITIONS_PATH := "res://hammerforge_entities.json"
+
 
 static func from_dict(data: Dictionary) -> HFEntityDef:
 	var def := HFEntityDef.new()
@@ -109,6 +112,65 @@ static func load_definitions(path: String) -> Array[HFEntityDef]:
 		)
 		return _built_in_defaults()
 	return defs
+
+
+## Load definitions from a file without falling back to built-ins.
+## Missing or invalid files return an empty array.
+static func load_definitions_from_file(path: String) -> Array[HFEntityDef]:
+	var defs: Array[HFEntityDef] = []
+	if path == "" or not FileAccess.file_exists(path):
+		return defs
+	var file = FileAccess.open(path, FileAccess.READ)
+	if not file:
+		return defs
+	var data = JSON.parse_string(file.get_as_text())
+	if data == null:
+		return defs
+	var entries: Array = []
+	if data is Dictionary:
+		entries = data.get("entities", [])
+		if entries.is_empty():
+			for key in data.keys():
+				var entry = data[key]
+				if entry is Dictionary:
+					var record = entry.duplicate(true)
+					record["id"] = str(key)
+					entries.append(record)
+	elif data is Array:
+		entries = data
+	for entry in entries:
+		if entry is Dictionary:
+			var classname = str(entry.get("id", entry.get("class", entry.get("classname", ""))))
+			if classname != "":
+				defs.append(from_dict(entry))
+	return defs
+
+
+## Overlay project defs onto plugin defs. Same classname replaces the plugin entry.
+static func merge_definitions(
+	base: Array[HFEntityDef], overlay: Array[HFEntityDef]
+) -> Array[HFEntityDef]:
+	var by_name: Dictionary = {}
+	for def in base:
+		if def and def.classname != "":
+			by_name[def.classname] = def
+	for def in overlay:
+		if def and def.classname != "":
+			by_name[def.classname] = def
+	var out: Array[HFEntityDef] = []
+	for key in by_name.keys():
+		out.append(by_name[key])
+	return out
+
+
+static func load_merged_definitions(
+	plugin_path: String, project_path: String = PROJECT_DEFINITIONS_PATH
+) -> Array[HFEntityDef]:
+	var base := load_definitions(plugin_path)
+	var overlay := load_definitions_from_file(project_path)
+	if overlay.is_empty():
+		return base
+	return merge_definitions(base, overlay)
 
 
 ## Built-in brush entity classes — always available even without entities.json.

--- a/addons/hammerforge/map_io.gd
+++ b/addons/hammerforge/map_io.gd
@@ -192,10 +192,21 @@ static func _brush_from_faces(faces: Array) -> Dictionary:
 			"center": center,
 			"operation": CSGShape3D.OPERATION_UNION
 		}
+	var serialized_faces: Array = []
+	for face in faces:
+		var face_points: Array = face.get("points", [])
+		if face_points.size() < 3:
+			continue
+		var local_verts: Array = []
+		for p in face_points:
+			var pt: Vector3 = p
+			local_verts.append([pt.x - center.x, pt.y - center.y, pt.z - center.z])
+		serialized_faces.append({"local_verts": local_verts, "winding_version": 1})
 	return {
-		"shape": LevelRoot.BrushShape.CYLINDER,
-		"size": Vector3(max(size.x, size.z), size.y, max(size.x, size.z)),
+		"shape": LevelRoot.BrushShape.CUSTOM,
+		"size": size,
 		"center": center,
+		"faces": serialized_faces,
 		"operation": CSGShape3D.OPERATION_UNION
 	}
 
@@ -277,7 +288,26 @@ static func _brush_to_map_lines(
 		LevelRoot.BrushShape.CYLINDER:
 			lines.append_array(_cylinder_to_map_lines(brush, adapter))
 		_:
-			lines.append_array(_box_to_map_lines(brush, adapter))
+			if not brush.faces.is_empty():
+				lines.append_array(_faces_to_map_lines(brush, adapter))
+			else:
+				lines.append_array(_box_to_map_lines(brush, adapter))
+	return lines
+
+
+static func _faces_to_map_lines(
+	brush: DraftBrush, adapter: HFMapAdapterType = null
+) -> Array[String]:
+	if adapter == null:
+		adapter = HFMapQuakeType.new()
+	var lines: Array[String] = []
+	for face in brush.faces:
+		if face == null or face.local_verts.size() < 3:
+			continue
+		var a: Vector3 = brush.global_transform * face.local_verts[0]
+		var b: Vector3 = brush.global_transform * face.local_verts[1]
+		var c: Vector3 = brush.global_transform * face.local_verts[2]
+		lines.append(adapter.format_face_line(a, b, c, DEFAULT_TEXTURE, face))
 	return lines
 
 

--- a/addons/hammerforge/systems/hf_entity_system.gd
+++ b/addons/hammerforge/systems/hf_entity_system.gd
@@ -3,6 +3,7 @@ extends RefCounted
 class_name HFEntitySystem
 
 const DraftEntity = preload("../draft_entity.gd")
+const HFEntityDef = preload("../hf_entity_def.gd")
 
 var root: Node3D
 
@@ -13,35 +14,12 @@ func _init(level_root: Node3D) -> void:
 
 func load_entity_definitions() -> void:
 	root.entity_definitions.clear()
-	if (
-		root.entity_definitions_path == ""
-		or not ResourceLoader.exists(root.entity_definitions_path)
-	):
-		return
-	var file = FileAccess.open(root.entity_definitions_path, FileAccess.READ)
-	if not file:
-		return
-	var text = file.get_as_text()
-	var data = JSON.parse_string(text)
-	if data == null:
-		return
-	if data is Dictionary:
-		var entries = data.get("entities", null)
-		if entries is Array:
-			for entry in entries:
-				if entry is Dictionary:
-					var key = str(entry.get("id", entry.get("class", "")))
-					if key != "":
-						root.entity_definitions[key] = entry
-			return
-		root.entity_definitions = data
-		return
-	if data is Array:
-		for entry in data:
-			if entry is Dictionary:
-				var key = str(entry.get("class", ""))
-				if key != "":
-					root.entity_definitions[key] = entry
+	var defs = HFEntityDef.load_merged_definitions(
+		str(root.entity_definitions_path), HFEntityDef.PROJECT_DEFINITIONS_PATH
+	)
+	for def in defs:
+		if def and def.classname != "":
+			root.entity_definitions[def.classname] = def.to_dict()
 
 
 func get_entity_definition(entity_type: String) -> Dictionary:

--- a/addons/hammerforge/systems/hf_subtract_preview.gd
+++ b/addons/hammerforge/systems/hf_subtract_preview.gd
@@ -1,9 +1,10 @@
 @tool
 class_name HFSubtractPreview
 extends "hf_system.gd"
-## Real-time wireframe overlay showing AABB intersections between
-## subtractive and additive brushes.  Reuses the cordon-wireframe
-## ImmediateMesh pattern from level_root.gd.
+## Real-time wireframe overlay showing mesh-bound intersections between
+## subtractive and additive DraftBrushes (AABB of each authored mesh).
+
+const DraftBrush = preload("../brush_instance.gd")
 
 var _preview_container: Node3D
 var _mesh_pool: Array = []  # Array[MeshInstance3D]
@@ -129,11 +130,10 @@ func _rebuild() -> void:
 	var subtractive: Array = []
 	var additive: Array = []
 	for child in draft_node.get_children():
-		if not child is CSGShape3D:
-			continue
-		if child.operation == CSGShape3D.OPERATION_SUBTRACTION:
+		var op := preview_operation(child)
+		if op == CSGShape3D.OPERATION_SUBTRACTION:
 			subtractive.append(child)
-		elif child.operation == CSGShape3D.OPERATION_UNION:
+		elif op == CSGShape3D.OPERATION_UNION:
 			additive.append(child)
 
 	var intersections: Array = []  # Array[AABB]
@@ -198,14 +198,29 @@ static func _is_valid_aabb(aabb: AABB) -> bool:
 	return aabb.size.x > 0.001 and aabb.size.y > 0.001 and aabb.size.z > 0.001
 
 
+## Operation used for subtract preview. DraftBrush stores CSG operation ints.
+## Returns -1 when the node is not a previewable brush.
+static func preview_operation(node: Node) -> int:
+	if node is DraftBrush:
+		return int((node as DraftBrush).operation)
+	if node is CSGShape3D:
+		return int((node as CSGShape3D).operation)
+	return -1
+
+
 func _get_world_aabb(node: Node3D) -> AABB:
+	if node is DraftBrush:
+		var draft := node as DraftBrush
+		if draft.mesh_instance and draft.mesh_instance.mesh:
+			return draft.global_transform * draft.mesh_instance.mesh.get_aabb()
+		var half := draft.size * 0.5
+		return AABB(draft.global_position - half, draft.size)
 	if node.has_method("get_aabb"):
 		var local_aabb: AABB = node.get_aabb()
 		return node.global_transform * local_aabb
-	# Fallback: use position ± half scale
 	var pos := node.global_position
-	var half := node.scale * 0.5
-	return AABB(pos - half, node.scale)
+	var half_scale := node.scale * 0.5
+	return AABB(pos - half_scale, node.scale)
 
 
 func _build_wireframe_mesh(aabb: AABB) -> ImmediateMesh:

--- a/addons/hammerforge/ui/hf_tooltip_text.gd
+++ b/addons/hammerforge/ui/hf_tooltip_text.gd
@@ -19,7 +19,7 @@ const TEXTS := {
 	"Radial menu, coach marks, and operation replay\nOff by default so Draw → Bake → Test Level stays obvious",
 	"debug_logs": "Print debug info to Output panel",
 	"_show_subtract_preview":
-	"Show AABB overlap between subtract and additive brushes\nThis is an approximation, not live CSG",
+	"Show overlap between subtract and additive DraftBrushes\nUses each brush's mesh bounds (not live CSG of the whole level)",
 	# --- Build tab: brush size & shape ---
 	"size_x": "Brush width (X axis) in units",
 	"size_y": "Brush height (Y axis) in units",

--- a/addons/hammerforge/ui/manage_tab_builder.gd
+++ b/addons/hammerforge/ui/manage_tab_builder.gd
@@ -403,7 +403,7 @@ func build(parent: Control) -> void:
 	dock._show_io_lines = dock._make_check("Show I/O Lines", false)
 	stc.add_child(dock._show_io_lines)
 
-	dock._show_subtract_preview = dock._make_check("Subtract Preview (AABB approx)", false)
+	dock._show_subtract_preview = dock._make_check("Subtract Preview", false)
 	stc.add_child(dock._show_subtract_preview)
 
 	dock.autosave_enabled = dock._make_check("Enable Autosave", true)

--- a/docs/HammerForge_Design_Constraints.md
+++ b/docs/HammerForge_Design_Constraints.md
@@ -27,9 +27,10 @@ This document makes the current tradeoffs explicit so level designers and develo
 - Region streaming loads only nearby paint data; distant regions are unloaded.
 
 ## Import / Export Limits
-- `.map` import/export preserves basic brush shapes and point entities, not full material or face data.
-- Non-axis-aligned or complex `.map` brushes are approximated (typically as cylinders).
+- `.map` import/export preserves basic brush shapes and point entities. Axis-aligned brushes import as boxes. Rotated or complex brushes import as CUSTOM with face vertices rather than being forced to cylinders.
+- Face materials still do not round-trip as Godot materials; Valve 220 can carry UV axes when FaceData is present.
 - `.glb` export includes only baked geometry.
+- Per-project entity types overlay `res://hammerforge_entities.json` onto the plugin `entities.json` (same classname replaces).
 
 ## Prefabs
 - Prefabs capture brush and entity state as dictionaries — they do not store Node references or scene paths.
@@ -40,7 +41,7 @@ This document makes the current tradeoffs explicit so level designers and develo
 - The subtract preview system does not render intersections for prefab preview — only placed brushes.
 
 ## Subtract Preview
-- Subtract preview shows wireframe AABB intersections, not true CSG geometry. The Test → Settings checkbox is labeled **Subtract Preview (AABB approx)** so this is visible in the editor, not only in this document.
+- Subtract preview includes DraftBrushes (not only leftover CSGShape3D nodes) and uses each brush's mesh bounds. It is still not a live full-level CSG boolean.
 - The preview is debounced (0.15s) to avoid rebuilding on every frame during rapid edits.
 - Maximum 50 intersection overlays are rendered simultaneously. Beyond that, intersections are silently dropped.
 - The preview uses `ImmediateMesh` with `PRIMITIVE_LINES` — zero GPU memory allocation beyond vertex buffers.

--- a/tests/test_entity_def.gd
+++ b/tests/test_entity_def.gd
@@ -1,0 +1,31 @@
+extends GutTest
+
+const HFEntityDef = preload("res://addons/hammerforge/hf_entity_def.gd")
+
+
+func test_merge_overlay_replaces_matching_classname():
+	var base: Array[HFEntityDef] = [
+		HFEntityDef.from_dict({"classname": "light", "description": "plugin"}),
+		HFEntityDef.from_dict({"classname": "player_start", "description": "plugin"}),
+	]
+	var overlay: Array[HFEntityDef] = [
+		HFEntityDef.from_dict({"classname": "light", "description": "project"}),
+		HFEntityDef.from_dict({"classname": "ammo", "description": "project-only"}),
+	]
+	var merged := HFEntityDef.merge_definitions(base, overlay)
+	var by_name := {}
+	for def in merged:
+		by_name[def.classname] = def
+	assert_eq(by_name.size(), 3)
+	assert_eq(by_name["light"].description, "project")
+	assert_eq(by_name["player_start"].description, "plugin")
+	assert_eq(by_name["ammo"].description, "project-only")
+
+
+func test_load_definitions_from_file_missing_is_empty():
+	var defs := HFEntityDef.load_definitions_from_file("res://does_not_exist_entities.json")
+	assert_eq(defs.size(), 0)
+
+
+func test_project_path_constant():
+	assert_eq(HFEntityDef.PROJECT_DEFINITIONS_PATH, "res://hammerforge_entities.json")

--- a/tests/test_entity_def.gd.uid
+++ b/tests/test_entity_def.gd.uid
@@ -1,0 +1,1 @@
+uid://dwnp3ocg2slvv

--- a/tests/test_manage_tab_builder.gd
+++ b/tests/test_manage_tab_builder.gd
@@ -102,7 +102,7 @@ func test_settings_keep_power_user_overlays_opt_in() -> void:
 	assert_eq(dock.power_user_overlays.text, "Power-user overlays")
 	assert_false(dock.power_user_overlays.button_pressed)
 	assert_true(_is_descendant_of(dock.power_user_overlays, settings))
-	assert_string_contains(dock._show_subtract_preview.text, "AABB")
+	assert_eq(dock._show_subtract_preview.text, "Subtract Preview")
 
 
 func test_actions_and_file_are_collapsed_by_default() -> void:

--- a/tests/test_map_export.gd
+++ b/tests/test_map_export.gd
@@ -1,10 +1,12 @@
 extends GutTest
 
 const MapIO = preload("res://addons/hammerforge/map_io.gd")
+const LevelRoot = preload("res://addons/hammerforge/level_root.gd")
 const HFMapAdapter = preload("res://addons/hammerforge/map_adapters/hf_map_adapter.gd")
 const HFMapQuake = preload("res://addons/hammerforge/map_adapters/hf_map_quake.gd")
 const HFMapValve220 = preload("res://addons/hammerforge/map_adapters/hf_map_valve220.gd")
 const FaceData = preload("res://addons/hammerforge/face_data.gd")
+const DraftBrush = preload("res://addons/hammerforge/brush_instance.gd")
 
 # ===========================================================================
 # Quake adapter tests
@@ -195,9 +197,46 @@ func test_valve220_fmt_float_integer():
 	assert_eq(result, "5")
 
 
+func test_custom_brush_export_emits_real_face_planes():
+	var brush = DraftBrush.new()
+	add_child_autoqfree(brush)
+	brush.shape = LevelRoot.BrushShape.CUSTOM
+	var face = FaceData.new()
+	face.local_verts = PackedVector3Array([Vector3(0, 0, 0), Vector3(8, 0, 0), Vector3(0, 8, 0)])
+	var faces: Array[FaceData] = []
+	faces.append(face)
+	brush.faces = faces
+	assert_eq(brush.faces.size(), 1)
+	var lines: Array[String] = MapIO._brush_to_map_lines(brush)
+	assert_eq(lines.size(), 1)
+	assert_string_contains(lines[0], "( 0 0 0 )")
+	assert_string_contains(lines[0], "( 8 0 0 )")
+	assert_string_contains(lines[0], "( 0 8 0 )")
+
+
 func test_valve220_fmt_float_fractional():
 	var result = HFMapValve220._fmt_float(0.333)
 	assert_true(result.begins_with("0.33"))
+
+
+func test_parse_tilted_brush_imports_as_custom_faces():
+	var map_text := (
+		"{\n"
+		+ '"classname" "worldspawn"\n'
+		+ "{\n"
+		+ "( 0 0 0 ) ( 10 0 0 ) ( 0 10 0 ) brick 0 0 0 1 1\n"
+		+ "( 0 0 0 ) ( 0 10 0 ) ( 0 0 10 ) brick 0 0 0 1 1\n"
+		+ "( 0 0 0 ) ( 0 0 10 ) ( 10 0 0 ) brick 0 0 0 1 1\n"
+		+ "( 10 0 0 ) ( 0 0 10 ) ( 0 10 0 ) brick 0 0 0 1 1\n"
+		+ "}\n"
+		+ "}\n"
+	)
+	var parsed: Dictionary = MapIO.parse_map_text(map_text)
+	var brushes: Array = parsed.get("brushes", [])
+	assert_eq(brushes.size(), 1)
+	assert_eq(int(brushes[0]["shape"]), LevelRoot.BrushShape.CUSTOM)
+	assert_true(brushes[0].has("faces"))
+	assert_gte((brushes[0]["faces"] as Array).size(), 3)
 
 
 func test_parse_map_text_worldspawn_and_point_entity():

--- a/tests/test_subtract_preview.gd
+++ b/tests/test_subtract_preview.gd
@@ -1,6 +1,7 @@
 extends GutTest
 
 const HFSubtractPreview = preload("res://addons/hammerforge/systems/hf_subtract_preview.gd")
+const DraftBrush = preload("res://addons/hammerforge/brush_instance.gd")
 
 # -- AABB intersection math tests -----------------------------------------------
 
@@ -40,6 +41,15 @@ func test_intersection_partial_axis():
 
 
 # -- Enable/disable tests -------------------------------------------------------
+
+
+func test_preview_operation_reads_draft_brushes():
+	var brush = autoqfree(DraftBrush.new())
+	brush.operation = CSGShape3D.OPERATION_SUBTRACTION
+	assert_eq(HFSubtractPreview.preview_operation(brush), CSGShape3D.OPERATION_SUBTRACTION)
+	brush.operation = CSGShape3D.OPERATION_UNION
+	assert_eq(HFSubtractPreview.preview_operation(brush), CSGShape3D.OPERATION_UNION)
+	assert_eq(HFSubtractPreview.preview_operation(autoqfree(Node3D.new())), -1)
 
 
 func test_default_disabled():


### PR DESCRIPTION
Next review items after the freeze and registry collapse.

- **Subtract preview** now includes `DraftBrush` nodes (it previously skipped anything that was not `CSGShape3D`) and uses each brush's mesh bounds.
- **Per-project entities:** `res://hammerforge_entities.json` overlays the plugin entity list; matching classnames replace plugin defs.
- **`.map` fidelity:** rotated/complex brushes import as CUSTOM face vertices instead of cylinders, and CUSTOM brushes export their real face planes.

GUT: **1711 tests, 1704 passing, 0 failing** (7 pre-existing risky).

Still open from the original review: live full-level CSG preview, heightmap vs displacement overlap, dock/plugin splits, profiling.