### PR TITLE
Move Paint-tab handlers into dock_paint_handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Changed
+- **Paint-tab handlers live in `dock_paint_handler.gd`:** layer, heightmap, scatter, sculpt, region, and terrain-slot dock methods are thin wrappers around `HFDockPaintHandler`.
 - **HUD and context-toolbar state live in `plugin_hud.gd`:** `_update_hud_context()` and `_update_context_toolbar_state()` are thin wrappers around `HFPluginHud`.
 - **Vertex/edge input lives in `plugin_vertex_input.gd`:** `plugin._handle_vertex_input()` is a thin wrapper around `HFPluginVertexInput.handle()`.
 - **Viewport keymap lives in `plugin_input_router.gd`:** `plugin._handle_keyboard_input()` is a thin wrapper around `HFPluginInputRouter.handle_keyboard()`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,6 +34,7 @@ addons/hammerforge/
   input_state.gd         Drag/paint state machine (HFInputState)
   hf_selection_gesture.gd Select-mode LMB arbiter (native object selection, face marquee, gizmos)
   dock.gd + dock.tscn    UI dock (displayed as Build, Paint, Objects, Test), collapsible sections with persisted state
+  dock_paint_handler.gd  Paint-tab layer/heightmap/scatter/sculpt handlers
   shortcut_hud.gd        Context-sensitive shortcut overlay (dynamic per mode) + persistent grid size indicator with flash-on-change
   brush_instance.gd      DraftBrush node
   baker.gd               CSG -> mesh bake pipeline (per-face materials, atlas integration, snapshot-based non-blocking face bakes, convex collision shapes)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -328,7 +328,7 @@ The May 2026 simplification phase 1 landed shared utilities and migrated low-ris
 
 ### Continued dock.gd decomposition
 The remaining 6,692 lines are dominated by ~180 `_on_*` signal handlers wired to dock-internal state.
-- Split into per-tab handler files: `dock_brush_handler.gd`, `dock_paint_handler.gd`, `dock_entity_handler.gd`, `dock_manage_handler.gd`. Target dock.gd shell at ~1,500 lines.
+- Split into per-tab handler files: `dock_brush_handler.gd`, `dock_paint_handler.gd` (done), `dock_entity_handler.gd`, `dock_manage_handler.gd`. Target dock.gd shell at ~1,500 lines.
 - Extract signal-wiring into `dock_connections.gd`.
 - Consolidate the entity-properties UI builder and the external-tool-settings UI builder (both schema-driven; share ~100 lines of dispatch logic).
 - Migrate `paint_tab_builder.gd` (50 call sites) and `manage_tab_builder.gd` (58 call sites) from `dock._make_*` to direct `HFUIFactory` calls. Mechanical churn — wait until shared with another tab-builder change.

--- a/addons/hammerforge/dock.gd
+++ b/addons/hammerforge/dock.gd
@@ -34,6 +34,7 @@ const PaintTabBuilder = preload("ui/paint_tab_builder.gd")
 const EntityTabBuilder = preload("ui/entity_tab_builder.gd")
 const ManageTabBuilder = preload("ui/manage_tab_builder.gd")
 const SelectionToolsBuilder = preload("ui/selection_tools_builder.gd")
+const HFDockPaintHandler = preload("dock_paint_handler.gd")
 
 const PRESET_MENU_RENAME := 0
 const PRESET_MENU_DELETE := 1
@@ -4997,471 +4998,139 @@ func _refresh_surface_paint_layers() -> void:
 
 
 func _on_paint_layer_selected(index: int) -> void:
-	if not level_root:
-		return
-	level_root.set_active_paint_layer(index)
-	_refresh_paint_layers()
+	HFDockPaintHandler.on_paint_layer_selected(self, index)
 
 
 func _on_paint_layer_add() -> void:
-	if not level_root:
-		return
-	level_root.add_paint_layer()
-	_refresh_paint_layers()
+	HFDockPaintHandler.on_paint_layer_add(self)
 
 
 func _on_paint_layer_rename() -> void:
-	if not level_root or not paint_layer_select:
-		return
-	var idx = paint_layer_select.selected
-	if idx < 0:
-		return
-	var current_name = paint_layer_select.get_item_text(idx)
-	# Create inline rename dialog
-	var dialog = AcceptDialog.new()
-	dialog.title = "Rename Layer"
-	var line_edit = LineEdit.new()
-	line_edit.text = current_name
-	line_edit.select_all()
-	dialog.add_child(line_edit)
-	dialog.confirmed.connect(
-		func():
-			if not is_instance_valid(self):
-				return
-			var new_name = line_edit.text.strip_edges()
-			if new_name != "" and new_name != current_name:
-				level_root.rename_paint_layer(idx, new_name)
-				_refresh_paint_layers()
-	)
-	dialog.canceled.connect(func(): dialog.queue_free())
-	dialog.confirmed.connect(func(): dialog.queue_free(), CONNECT_DEFERRED)
-	add_child(dialog)
-	dialog.popup_centered(Vector2i(300, 80))
-	line_edit.grab_focus()
+	HFDockPaintHandler.on_paint_layer_rename(self)
 
 
 func _on_paint_layer_remove() -> void:
-	if not level_root:
-		return
-	level_root.remove_active_paint_layer()
-	_refresh_paint_layers()
+	HFDockPaintHandler.on_paint_layer_remove(self)
 
 
 func _on_heightmap_import() -> void:
-	if heightmap_import_dialog:
-		heightmap_import_dialog.popup_centered(Vector2i(600, 400))
+	HFDockPaintHandler.on_heightmap_import(self)
 
 
 func _on_heightmap_import_selected(path: String) -> void:
-	if not level_root:
-		return
-	level_root.import_heightmap(path)
+	HFDockPaintHandler.on_heightmap_import_selected(self, path)
 
 
 func _on_heightmap_generate() -> void:
-	if not level_root:
-		return
-	level_root.generate_heightmap_noise()
+	HFDockPaintHandler.on_heightmap_generate(self)
 
 
 func _on_heightmap_convert() -> void:
-	if not level_root:
-		return
-	if not _guard_selection_action("Convert to Heightmap", DockSelectionRequirement.BRUSHES_ONLY):
-		return
-	var brushes: Array = []
-	for node in _selection_nodes:
-		if is_instance_valid(node) and level_root.is_brush_node(node):
-			brushes.append(node)
-	if brushes.is_empty():
-		level_root.emit_signal("user_message", "Select brushes first to convert to heightmap", 1)
-		return
-	var converter := HFBrushToHeightmap.new()
-	var settings := HFBrushToHeightmap.ConvertSettings.new()
-	if level_root.get("grid_snap") and level_root.grid_snap > 0:
-		settings.cell_size = level_root.grid_snap
-	if height_scale_spin:
-		settings.height_scale = height_scale_spin.value
-	var result := converter.convert(brushes, settings)
-	if result.error != "":
-		level_root.emit_signal("user_message", "Convert failed: " + result.error, 2)
-		return
-	# Attach the converted layer via paint_layers (HFPaintLayerManager)
-	if not level_root.get("paint_layers") or not level_root.paint_layers:
-		level_root.emit_signal("user_message", "Convert failed: no paint layer manager", 2)
-		return
-	var mgr: HFPaintLayerManager = level_root.paint_layers
-	# Inherit base_grid properties (origin, basis) and chunk_size from manager
-	# so the converted layer is spatially consistent with normal paint layers.
-	if mgr.base_grid:
-		var grid := mgr.base_grid.duplicate() as HFPaintGrid
-		if grid:
-			grid.layer_y = result.layer.grid.layer_y if result.layer.grid else 0.0
-			grid.cell_size = result.layer.grid.cell_size if result.layer.grid else grid.cell_size
-			result.layer.grid = grid
-	result.layer.chunk_size = mgr.chunk_size
-	result.layer.name = "Layer_%s" % str(result.layer.layer_id)
-	mgr.add_child(result.layer)
-	mgr.layers.append(result.layer)
-	mgr.active_layer_index = mgr.layers.size() - 1
-	# Notify listeners (tutorial wizard, external UI) of the layer change
-	if level_root.has_signal("paint_layer_changed"):
-		level_root.paint_layer_changed.emit(mgr.active_layer_index)
-	# Regenerate geometry so the new terrain appears immediately
-	if (
-		level_root.get("paint_system")
-		and level_root.paint_system.has_method("regenerate_paint_layers")
-	):
-		level_root.paint_system.regenerate_paint_layers()
-	level_root.emit_signal(
-		"user_message",
-		(
-			"Converted %d brushes to heightmap layer '%s'"
-			% [result.brush_count, result.layer.display_name]
-		),
-		0
-	)
-	_refresh_paint_layers()
-
-
-# ---------------------------------------------------------------------------
-# Scatter / foliage handlers
-# ---------------------------------------------------------------------------
+	HFDockPaintHandler.on_heightmap_convert(self)
 
 
 func _on_scatter_mesh_pick() -> void:
-	if not level_root:
-		return
-	# Reuse the terrain slot texture dialog for mesh picking
-	var dialog := EditorFileDialog.new()
-	dialog.file_mode = EditorFileDialog.FILE_MODE_OPEN_FILE
-	dialog.access = EditorFileDialog.ACCESS_RESOURCES
-	dialog.add_filter("*.tres,*.res,*.obj,*.glb,*.gltf", "Mesh Resources")
-	dialog.file_selected.connect(
-		func(path: String) -> void:
-			if is_instance_valid(self):
-				_scatter_mesh_path = path
-				if scatter_mesh_btn:
-					var fname := path.get_file()
-					scatter_mesh_btn.text = fname if fname != "" else "Pick Mesh..."
-			dialog.queue_free()
-	)
-	dialog.canceled.connect(func() -> void: dialog.queue_free())
-	add_child(dialog)
-	dialog.popup_centered(Vector2i(600, 400))
+	HFDockPaintHandler.on_scatter_mesh_pick(self)
 
 
 func _build_scatter_settings() -> HFScatterBrush.ScatterSettings:
-	var s := HFScatterBrush.ScatterSettings.new()
-	if _scatter_mesh_path != "" and ResourceLoader.exists(_scatter_mesh_path):
-		var res = load(_scatter_mesh_path)
-		if res is Mesh:
-			s.mesh = res
-	if scatter_density_spin:
-		s.density = scatter_density_spin.value
-	if scatter_radius_spin:
-		s.radius = scatter_radius_spin.value
-	if scatter_min_height_spin:
-		s.min_height = scatter_min_height_spin.value
-	if scatter_max_height_spin:
-		s.max_height = scatter_max_height_spin.value
-	if scatter_max_slope_spin:
-		s.max_slope = scatter_max_slope_spin.value
-	if scatter_scale_min_spin and scatter_scale_max_spin:
-		s.scale_range = Vector2(scatter_scale_min_spin.value, scatter_scale_max_spin.value)
-	if scatter_align_normal:
-		s.align_to_normal = scatter_align_normal.button_pressed
-	if scatter_random_rotation:
-		s.random_rotation = scatter_random_rotation.button_pressed
-	if scatter_shape_select:
-		s.shape = scatter_shape_select.get_selected_id()
-	if scatter_spline_width_spin:
-		s.spline_width = scatter_spline_width_spin.value
-	if scatter_preview_select:
-		s.preview_mode = scatter_preview_select.get_selected_id()
-	# Build spline points from selected node positions (in selection order)
-	if s.shape == HFScatterBrush.BrushShape.SPLINE:
-		var pts := PackedVector3Array()
-		for node in _selection_nodes:
-			if is_instance_valid(node) and node is Node3D:
-				pts.append(node.global_position)
-		s.spline_points = pts
-	return s
+	return HFDockPaintHandler.build_scatter_settings(self)
 
 
 func _get_active_paint_layer() -> HFPaintLayer:
-	if not level_root:
-		return null
-	if level_root.get("paint_layers") and level_root.paint_layers:
-		return level_root.paint_layers.get_active_layer()
-	return null
+	return HFDockPaintHandler.get_active_paint_layer(self)
 
 
 func _on_scatter_preview() -> void:
-	if not level_root:
-		return
-	if not _guard_selection_action("Scatter Preview", DockSelectionRequirement.NATIVE_ALLOWED):
-		return
-	var layer := _get_active_paint_layer()
-	if not layer:
-		level_root.emit_signal("user_message", "No active paint layer — add one first", 1)
-		return
-	var settings := _build_scatter_settings()
-	var brush := HFScatterBrush.new()
-	var result: HFScatterBrush.ScatterResult
-	if settings.shape == HFScatterBrush.BrushShape.CIRCLE:
-		# Use camera look-at point or scene center
-		var center := Vector3.ZERO
-		if _selection_nodes.size() > 0 and is_instance_valid(_selection_nodes[0]):
-			center = _selection_nodes[0].global_position
-		result = brush.scatter_circle(center, layer, settings)
-	else:
-		if settings.spline_points.size() < 2:
-			_scatter_clear_preview()
-			_scatter_last_result = []
-			level_root.emit_signal(
-				"user_message", "Spline scatter requires 2+ selected nodes to define the path", 1
-			)
-			return
-		result = brush.scatter_spline(layer, settings)
-
-	_scatter_last_result = result.transforms
-	# Build preview MultiMesh
-	_scatter_clear_preview()
-	var mm := brush.build_preview(result.transforms, settings)
-	if mm:
-		var mmi := MultiMeshInstance3D.new()
-		mmi.multimesh = mm
-		mmi.name = "_ScatterPreview"
-		mmi.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-		var mat := StandardMaterial3D.new()
-		mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-		mat.vertex_color_use_as_albedo = true
-		mat.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-		mmi.material_override = mat
-		level_root.add_child(mmi)
-		_scatter_preview_node = mmi
-	var msg := "%d instances (%d filtered)" % [result.transforms.size(), result.rejected_count]
-	level_root.emit_signal("user_message", "Scatter preview: " + msg, 0)
+	HFDockPaintHandler.on_scatter_preview(self)
 
 
 func _on_scatter_commit() -> void:
-	if not level_root:
-		return
-	if not _guard_selection_action("Scatter Commit", DockSelectionRequirement.NATIVE_ALLOWED):
-		return
-	if _scatter_last_result.is_empty():
-		_on_scatter_preview()
-		if _scatter_last_result.is_empty():
-			level_root.emit_signal("user_message", "No scatter instances to commit", 1)
-			return
-	var settings := _build_scatter_settings()
-	if not settings.mesh:
-		level_root.emit_signal("user_message", "Pick a mesh first", 1)
-		return
-	var brush := HFScatterBrush.new()
-	_scatter_clear_preview()
-	var parent: Node3D = level_root
-	if level_root.get("generated_floors") and level_root.generated_floors:
-		parent = level_root.generated_floors.get_parent()
-	brush.commit(_scatter_last_result, settings, parent)
-	level_root.emit_signal(
-		"user_message", "Scattered %d instances" % _scatter_last_result.size(), 0
-	)
-	_scatter_last_result = []
+	HFDockPaintHandler.on_scatter_commit(self)
 
 
 func _on_scatter_clear() -> void:
-	_scatter_clear_preview()
-	_scatter_last_result = []
+	HFDockPaintHandler.on_scatter_clear(self)
 
 
 func _scatter_clear_preview() -> void:
-	if _scatter_preview_node and is_instance_valid(_scatter_preview_node):
-		if _scatter_preview_node.get_parent():
-			_scatter_preview_node.get_parent().remove_child(_scatter_preview_node)
-		_scatter_preview_node.queue_free()
-		_scatter_preview_node = null
+	HFDockPaintHandler.scatter_clear_preview(self)
 
 
 func _on_sculpt_tool_toggled(pressed: bool, tool_id: int) -> void:
-	if not level_root or not level_root.paint_tool:
-		return
-	# Unpress other sculpt buttons (radio behavior)
-	var btns = [_sculpt_raise_btn, _sculpt_lower_btn, _sculpt_smooth_btn, _sculpt_flatten_btn]
-	var ids = [
-		HFStroke.Tool.SCULPT_RAISE,
-		HFStroke.Tool.SCULPT_LOWER,
-		HFStroke.Tool.SCULPT_SMOOTH,
-		HFStroke.Tool.SCULPT_FLATTEN
-	]
-	if pressed:
-		for i in range(btns.size()):
-			if ids[i] != tool_id and btns[i]:
-				btns[i].set_pressed_no_signal(false)
-		level_root.paint_tool.tool = tool_id
-	else:
-		# If unpressing active sculpt, revert to PAINT
-		level_root.paint_tool.tool = HFStroke.Tool.PAINT
+	HFDockPaintHandler.on_sculpt_tool_toggled(self, pressed, tool_id)
 
 
 func _on_sculpt_strength_changed(value: float) -> void:
-	if level_root and level_root.paint_tool:
-		level_root.paint_tool.sculpt_strength = value
+	HFDockPaintHandler.on_sculpt_strength_changed(self, value)
 
 
 func _on_sculpt_radius_changed(value: float) -> void:
-	if level_root and level_root.paint_tool:
-		level_root.paint_tool.sculpt_radius = value
+	HFDockPaintHandler.on_sculpt_radius_changed(self, value)
 
 
 func _on_sculpt_falloff_changed(value: float) -> void:
-	if level_root and level_root.paint_tool:
-		level_root.paint_tool.sculpt_falloff = value
+	HFDockPaintHandler.on_sculpt_falloff_changed(self, value)
 
 
 func _on_height_scale_changed(value: float) -> void:
-	if not level_root:
-		return
-	level_root.set_heightmap_scale(value)
+	HFDockPaintHandler.on_height_scale_changed(self, value)
 
 
 func _on_layer_y_changed(value: float) -> void:
-	if not level_root:
-		return
-	level_root.set_layer_y(value)
+	HFDockPaintHandler.on_layer_y_changed(self, value)
 
 
 func _on_blend_strength_changed(value: float) -> void:
-	if not level_root or not level_root.paint_tool:
-		return
-	level_root.paint_tool.blend_strength = value
+	HFDockPaintHandler.on_blend_strength_changed(self, value)
 
 
 func _on_region_enable_toggled(enabled: bool) -> void:
-	if _region_settings_refreshing:
-		return
-	if not level_root:
-		return
-	level_root.set_region_streaming_enabled(enabled)
+	HFDockPaintHandler.on_region_enable_toggled(self, enabled)
 
 
 func _on_region_size_changed(value: float) -> void:
-	if _region_settings_refreshing:
-		return
-	if not level_root:
-		return
-	level_root.set_region_size_cells(int(value))
+	HFDockPaintHandler.on_region_size_changed(self, value)
 
 
 func _on_region_radius_changed(value: float) -> void:
-	if _region_settings_refreshing:
-		return
-	if not level_root:
-		return
-	level_root.set_region_streaming_radius(int(value))
+	HFDockPaintHandler.on_region_radius_changed(self, value)
 
 
 func _on_region_memory_changed(value: float) -> void:
-	if _region_settings_refreshing:
-		return
-	if not level_root:
-		return
-	level_root.set_region_memory_budget_mb(int(value))
+	HFDockPaintHandler.on_region_memory_changed(self, value)
 
 
 func _on_region_grid_toggled(enabled: bool) -> void:
-	if _region_settings_refreshing:
-		return
-	if not level_root:
-		return
-	level_root.set_region_show_grid(enabled)
+	HFDockPaintHandler.on_region_grid_toggled(self, enabled)
 
 
 func _on_blend_slot_selected(index: int) -> void:
-	if not level_root or not level_root.paint_tool or not blend_slot_select:
-		return
-	var slot_id = blend_slot_select.get_item_id(index)
-	level_root.paint_tool.blend_slot = int(slot_id)
+	HFDockPaintHandler.on_blend_slot_selected(self, index)
 
 
 func _on_terrain_slot_pressed(slot: int) -> void:
-	if not terrain_slot_texture_dialog:
-		return
-	_terrain_slot_pick_index = slot
-	terrain_slot_texture_dialog.popup_centered(Vector2i(600, 400))
+	HFDockPaintHandler.on_terrain_slot_pressed(self, slot)
 
 
 func _on_terrain_slot_texture_selected(path: String) -> void:
-	if _terrain_slot_pick_index < 0:
-		return
-	if not level_root or not level_root.paint_layers:
-		return
-	var layer = level_root.paint_layers.get_active_layer()
-	if not layer:
-		return
-	layer._ensure_terrain_slots()
-	layer.terrain_slot_paths[_terrain_slot_pick_index] = path
-	_refresh_terrain_slots()
-	level_root._regenerate_paint_layers()
+	HFDockPaintHandler.on_terrain_slot_texture_selected(self, path)
 
 
 func _on_terrain_slot_scale_changed(value: float, slot: int) -> void:
-	if _terrain_slot_refreshing:
-		return
-	if not level_root or not level_root.paint_layers:
-		return
-	var layer = level_root.paint_layers.get_active_layer()
-	if not layer:
-		return
-	layer._ensure_terrain_slots()
-	var current = float(layer.terrain_slot_uv_scales[slot])
-	if is_equal_approx(current, value):
-		return
-	layer.terrain_slot_uv_scales[slot] = float(value)
-	level_root._regenerate_paint_layers()
+	HFDockPaintHandler.on_terrain_slot_scale_changed(self, value, slot)
 
 
 func _refresh_terrain_slots() -> void:
-	_terrain_slot_refreshing = true
-	if not level_root or not level_root.paint_layers:
-		_set_terrain_slot_controls_enabled(false)
-		_terrain_slot_refreshing = false
-		return
-	var layer = level_root.paint_layers.get_active_layer()
-	if not layer:
-		_set_terrain_slot_controls_enabled(false)
-		_terrain_slot_refreshing = false
-		return
-	layer._ensure_terrain_slots()
-	_set_terrain_slot_controls_enabled(true)
-	for i in range(terrain_slot_buttons.size()):
-		var button = terrain_slot_buttons[i]
-		var scale = terrain_slot_scales[i]
-		if button:
-			var path = layer.terrain_slot_paths[i]
-			button.text = _terrain_slot_label(path)
-		if scale:
-			scale.value = float(layer.terrain_slot_uv_scales[i])
-	if blend_slot_select and level_root.paint_tool:
-		var slot = clamp(level_root.paint_tool.blend_slot, 1, 3)
-		_select_option_by_id(blend_slot_select, slot)
-	_terrain_slot_refreshing = false
+	HFDockPaintHandler.refresh_terrain_slots(self)
 
 
 func _terrain_slot_label(path: String) -> String:
-	if path == "":
-		return "Texture..."
-	return path.get_file()
+	return HFDockPaintHandler.terrain_slot_label(path)
 
 
 func _set_terrain_slot_controls_enabled(enabled: bool) -> void:
-	for button in terrain_slot_buttons:
-		if button:
-			button.disabled = not enabled
-	for spin in terrain_slot_scales:
-		if spin:
-			spin.editable = enabled
+	HFDockPaintHandler.set_terrain_slot_controls_enabled(self, enabled)
 
 
 func _on_material_selected(index: int) -> void:

--- a/addons/hammerforge/dock_paint_handler.gd
+++ b/addons/hammerforge/dock_paint_handler.gd
@@ -1,0 +1,491 @@
+@tool
+class_name HFDockPaintHandler
+extends RefCounted
+## Paint-tab handlers extracted from dock.gd (layers, heightmap, scatter, sculpt).
+
+const HFBrushToHeightmap = preload("paint/hf_brush_to_heightmap.gd")
+const HFScatterBrush = preload("paint/hf_scatter_brush.gd")
+const HFPaintLayer = preload("paint/hf_paint_layer.gd")
+const HFPaintLayerManager = preload("paint/hf_paint_layer_manager.gd")
+const HFPaintGrid = preload("paint/hf_paint_grid.gd")
+const HFStroke = preload("paint/hf_stroke.gd")
+const DraftBrush = preload("brush_instance.gd")
+
+
+static func on_paint_layer_selected(dock: Object, index: int) -> void:
+	if dock == null or not dock.level_root:
+		return
+	dock.level_root.set_active_paint_layer(index)
+	dock._refresh_paint_layers()
+
+
+static func on_paint_layer_add(dock: Object) -> void:
+	if dock == null or not dock.level_root:
+		return
+	dock.level_root.add_paint_layer()
+	dock._refresh_paint_layers()
+
+
+static func on_paint_layer_rename(dock: Object) -> void:
+	if dock == null or not dock.level_root or not dock.paint_layer_select:
+		return
+	var idx = dock.paint_layer_select.selected
+	if idx < 0:
+		return
+	var current_name = dock.paint_layer_select.get_item_text(idx)
+	var dialog = AcceptDialog.new()
+	dialog.title = "Rename Layer"
+	var line_edit = LineEdit.new()
+	line_edit.text = current_name
+	line_edit.select_all()
+	dialog.add_child(line_edit)
+	dialog.confirmed.connect(
+		func():
+			if not is_instance_valid(dock):
+				return
+			var new_name = line_edit.text.strip_edges()
+			if new_name != "" and new_name != current_name:
+				dock.level_root.rename_paint_layer(idx, new_name)
+				dock._refresh_paint_layers()
+	)
+	dialog.canceled.connect(func(): dialog.queue_free())
+	dialog.confirmed.connect(func(): dialog.queue_free(), CONNECT_DEFERRED)
+	dock.add_child(dialog)
+	dialog.popup_centered(Vector2i(300, 80))
+	line_edit.grab_focus()
+
+
+static func on_paint_layer_remove(dock: Object) -> void:
+	if dock == null or not dock.level_root:
+		return
+	dock.level_root.remove_active_paint_layer()
+	dock._refresh_paint_layers()
+
+
+static func on_heightmap_import(dock: Object) -> void:
+	if dock and dock.heightmap_import_dialog:
+		dock.heightmap_import_dialog.popup_centered(Vector2i(600, 400))
+
+
+static func on_heightmap_import_selected(dock: Object, path: String) -> void:
+	if dock == null or not dock.level_root:
+		return
+	dock.level_root.import_heightmap(path)
+
+
+static func on_heightmap_generate(dock: Object) -> void:
+	if dock == null or not dock.level_root:
+		return
+	dock.level_root.generate_heightmap_noise()
+
+
+static func on_heightmap_convert(dock: Object) -> void:
+	if dock == null or not dock.level_root:
+		return
+	if not dock._guard_selection_action(
+		"Convert to Heightmap", dock.DockSelectionRequirement.BRUSHES_ONLY
+	):
+		return
+	var brushes: Array = []
+	for node in dock._selection_nodes:
+		if is_instance_valid(node) and dock.level_root.is_brush_node(node):
+			brushes.append(node)
+	if brushes.is_empty():
+		dock.level_root.emit_signal("user_message", "Select brushes first to convert to heightmap", 1)
+		return
+	var converter := HFBrushToHeightmap.new()
+	var settings := HFBrushToHeightmap.ConvertSettings.new()
+	if dock.level_root.get("grid_snap") and dock.level_root.grid_snap > 0:
+		settings.cell_size = dock.level_root.grid_snap
+	if dock.height_scale_spin:
+		settings.height_scale = dock.height_scale_spin.value
+	var result := converter.convert(brushes, settings)
+	if result.error != "":
+		dock.level_root.emit_signal("user_message", "Convert failed: " + result.error, 2)
+		return
+	if not dock.level_root.get("paint_layers") or not dock.level_root.paint_layers:
+		dock.level_root.emit_signal("user_message", "Convert failed: no paint layer manager", 2)
+		return
+	var mgr: HFPaintLayerManager = dock.level_root.paint_layers
+	if mgr.base_grid:
+		var grid := mgr.base_grid.duplicate() as HFPaintGrid
+		if grid:
+			grid.layer_y = result.layer.grid.layer_y if result.layer.grid else 0.0
+			grid.cell_size = result.layer.grid.cell_size if result.layer.grid else grid.cell_size
+			result.layer.grid = grid
+	result.layer.chunk_size = mgr.chunk_size
+	result.layer.name = "Layer_%s" % str(result.layer.layer_id)
+	mgr.add_child(result.layer)
+	mgr.layers.append(result.layer)
+	mgr.active_layer_index = mgr.layers.size() - 1
+	if dock.level_root.has_signal("paint_layer_changed"):
+		dock.level_root.paint_layer_changed.emit(mgr.active_layer_index)
+	if (
+		dock.level_root.get("paint_system")
+		and dock.level_root.paint_system.has_method("regenerate_paint_layers")
+	):
+		dock.level_root.paint_system.regenerate_paint_layers()
+	dock.level_root.emit_signal(
+		"user_message",
+		(
+			"Converted %d brushes to heightmap layer '%s'"
+			% [result.brush_count, result.layer.display_name]
+		),
+		0
+	)
+	dock._refresh_paint_layers()
+
+
+static func on_scatter_mesh_pick(dock: Object) -> void:
+	if dock == null or not dock.level_root:
+		return
+	var dialog := EditorFileDialog.new()
+	dialog.file_mode = EditorFileDialog.FILE_MODE_OPEN_FILE
+	dialog.access = EditorFileDialog.ACCESS_RESOURCES
+	dialog.add_filter("*.tres,*.res,*.obj,*.glb,*.gltf", "Mesh Resources")
+	dialog.file_selected.connect(
+		func(path: String) -> void:
+			if is_instance_valid(dock):
+				dock._scatter_mesh_path = path
+				if dock.scatter_mesh_btn:
+					var fname := path.get_file()
+					dock.scatter_mesh_btn.text = fname if fname != "" else "Pick Mesh..."
+			dialog.queue_free()
+	)
+	dialog.canceled.connect(func() -> void: dialog.queue_free())
+	dock.add_child(dialog)
+	dialog.popup_centered(Vector2i(600, 400))
+
+
+static func build_scatter_settings(dock: Object) -> HFScatterBrush.ScatterSettings:
+	var s := HFScatterBrush.ScatterSettings.new()
+	if dock == null:
+		return s
+	if dock._scatter_mesh_path != "" and ResourceLoader.exists(dock._scatter_mesh_path):
+		var res = load(dock._scatter_mesh_path)
+		if res is Mesh:
+			s.mesh = res
+	if dock.scatter_density_spin:
+		s.density = dock.scatter_density_spin.value
+	if dock.scatter_radius_spin:
+		s.radius = dock.scatter_radius_spin.value
+	if dock.scatter_min_height_spin:
+		s.min_height = dock.scatter_min_height_spin.value
+	if dock.scatter_max_height_spin:
+		s.max_height = dock.scatter_max_height_spin.value
+	if dock.scatter_max_slope_spin:
+		s.max_slope = dock.scatter_max_slope_spin.value
+	if dock.scatter_scale_min_spin and dock.scatter_scale_max_spin:
+		s.scale_range = Vector2(dock.scatter_scale_min_spin.value, dock.scatter_scale_max_spin.value)
+	if dock.scatter_align_normal:
+		s.align_to_normal = dock.scatter_align_normal.button_pressed
+	if dock.scatter_random_rotation:
+		s.random_rotation = dock.scatter_random_rotation.button_pressed
+	if dock.scatter_shape_select:
+		s.shape = dock.scatter_shape_select.get_selected_id()
+	if dock.scatter_spline_width_spin:
+		s.spline_width = dock.scatter_spline_width_spin.value
+	if dock.scatter_preview_select:
+		s.preview_mode = dock.scatter_preview_select.get_selected_id()
+	if s.shape == HFScatterBrush.BrushShape.SPLINE:
+		var pts := PackedVector3Array()
+		for node in dock._selection_nodes:
+			if is_instance_valid(node) and node is Node3D:
+				pts.append(node.global_position)
+		s.spline_points = pts
+	return s
+
+
+static func get_active_paint_layer(dock: Object) -> HFPaintLayer:
+	if dock == null or not dock.level_root:
+		return null
+	if dock.level_root.get("paint_layers") and dock.level_root.paint_layers:
+		return dock.level_root.paint_layers.get_active_layer()
+	return null
+
+
+static func on_scatter_preview(dock: Object) -> void:
+	if dock == null or not dock.level_root:
+		return
+	if not dock._guard_selection_action(
+		"Scatter Preview", dock.DockSelectionRequirement.NATIVE_ALLOWED
+	):
+		return
+	var layer = get_active_paint_layer(dock)
+	if not layer:
+		dock.level_root.emit_signal("user_message", "No active paint layer — add one first", 1)
+		return
+	var settings = build_scatter_settings(dock)
+	var brush := HFScatterBrush.new()
+	var result: HFScatterBrush.ScatterResult
+	if settings.shape == HFScatterBrush.BrushShape.CIRCLE:
+		var center := Vector3.ZERO
+		if dock._selection_nodes.size() > 0 and is_instance_valid(dock._selection_nodes[0]):
+			center = dock._selection_nodes[0].global_position
+		result = brush.scatter_circle(center, layer, settings)
+	else:
+		if settings.spline_points.size() < 2:
+			scatter_clear_preview(dock)
+			_set_scatter_result(dock, [])
+			dock.level_root.emit_signal(
+				"user_message", "Spline scatter requires 2+ selected nodes to define the path", 1
+			)
+			return
+		result = brush.scatter_spline(layer, settings)
+
+	_set_scatter_result(dock, result.transforms)
+	scatter_clear_preview(dock)
+	var mm := brush.build_preview(result.transforms, settings)
+	if mm:
+		var mmi := MultiMeshInstance3D.new()
+		mmi.multimesh = mm
+		mmi.name = "_ScatterPreview"
+		mmi.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+		var mat := StandardMaterial3D.new()
+		mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+		mat.vertex_color_use_as_albedo = true
+		mat.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+		mmi.material_override = mat
+		dock.level_root.add_child(mmi)
+		dock._scatter_preview_node = mmi
+	var msg := "%d instances (%d filtered)" % [result.transforms.size(), result.rejected_count]
+	dock.level_root.emit_signal("user_message", "Scatter preview: " + msg, 0)
+
+
+static func on_scatter_commit(dock: Object) -> void:
+	if dock == null or not dock.level_root:
+		return
+	if not dock._guard_selection_action(
+		"Scatter Commit", dock.DockSelectionRequirement.NATIVE_ALLOWED
+	):
+		return
+	if dock._scatter_last_result.is_empty():
+		on_scatter_preview(dock)
+		if dock._scatter_last_result.is_empty():
+			dock.level_root.emit_signal("user_message", "No scatter instances to commit", 1)
+			return
+	var settings = build_scatter_settings(dock)
+	if not settings.mesh:
+		dock.level_root.emit_signal("user_message", "Pick a mesh first", 1)
+		return
+	var brush := HFScatterBrush.new()
+	scatter_clear_preview(dock)
+	var parent: Node3D = dock.level_root
+	if dock.level_root.get("generated_floors") and dock.level_root.generated_floors:
+		parent = dock.level_root.generated_floors.get_parent()
+	brush.commit(dock._scatter_last_result, settings, parent)
+	dock.level_root.emit_signal(
+		"user_message", "Scattered %d instances" % dock._scatter_last_result.size(), 0
+	)
+	_set_scatter_result(dock, [])
+
+
+static func on_scatter_clear(dock: Object) -> void:
+	if dock == null:
+		return
+	scatter_clear_preview(dock)
+	_set_scatter_result(dock, [])
+
+
+static func _set_scatter_result(dock: Object, transforms) -> void:
+	var typed: Array[Transform3D] = []
+	for t in transforms:
+		typed.append(t)
+	dock._scatter_last_result = typed
+
+
+static func scatter_clear_preview(dock: Object) -> void:
+	if dock == null:
+		return
+	if dock._scatter_preview_node and is_instance_valid(dock._scatter_preview_node):
+		if dock._scatter_preview_node.get_parent():
+			dock._scatter_preview_node.get_parent().remove_child(dock._scatter_preview_node)
+		dock._scatter_preview_node.queue_free()
+		dock._scatter_preview_node = null
+
+
+static func on_sculpt_tool_toggled(dock: Object, pressed: bool, tool_id: int) -> void:
+	if dock == null or not dock.level_root or not dock.level_root.paint_tool:
+		return
+	var btns = [
+		dock._sculpt_raise_btn,
+		dock._sculpt_lower_btn,
+		dock._sculpt_smooth_btn,
+		dock._sculpt_flatten_btn
+	]
+	var ids = [
+		HFStroke.Tool.SCULPT_RAISE,
+		HFStroke.Tool.SCULPT_LOWER,
+		HFStroke.Tool.SCULPT_SMOOTH,
+		HFStroke.Tool.SCULPT_FLATTEN
+	]
+	if pressed:
+		for i in range(btns.size()):
+			if ids[i] != tool_id and btns[i]:
+				btns[i].set_pressed_no_signal(false)
+		dock.level_root.paint_tool.tool = tool_id
+	else:
+		dock.level_root.paint_tool.tool = HFStroke.Tool.PAINT
+
+
+static func on_sculpt_strength_changed(dock: Object, value: float) -> void:
+	if dock and dock.level_root and dock.level_root.paint_tool:
+		dock.level_root.paint_tool.sculpt_strength = value
+
+
+static func on_sculpt_radius_changed(dock: Object, value: float) -> void:
+	if dock and dock.level_root and dock.level_root.paint_tool:
+		dock.level_root.paint_tool.sculpt_radius = value
+
+
+static func on_sculpt_falloff_changed(dock: Object, value: float) -> void:
+	if dock and dock.level_root and dock.level_root.paint_tool:
+		dock.level_root.paint_tool.sculpt_falloff = value
+
+
+static func on_height_scale_changed(dock: Object, value: float) -> void:
+	if dock == null or not dock.level_root:
+		return
+	dock.level_root.set_heightmap_scale(value)
+
+
+static func on_layer_y_changed(dock: Object, value: float) -> void:
+	if dock == null or not dock.level_root:
+		return
+	dock.level_root.set_layer_y(value)
+
+
+static func on_blend_strength_changed(dock: Object, value: float) -> void:
+	if dock == null or not dock.level_root or not dock.level_root.paint_tool:
+		return
+	dock.level_root.paint_tool.blend_strength = value
+
+
+static func on_region_enable_toggled(dock: Object, enabled: bool) -> void:
+	if dock == null or dock._region_settings_refreshing:
+		return
+	if not dock.level_root:
+		return
+	dock.level_root.set_region_streaming_enabled(enabled)
+
+
+static func on_region_size_changed(dock: Object, value: float) -> void:
+	if dock == null or dock._region_settings_refreshing:
+		return
+	if not dock.level_root:
+		return
+	dock.level_root.set_region_size_cells(int(value))
+
+
+static func on_region_radius_changed(dock: Object, value: float) -> void:
+	if dock == null or dock._region_settings_refreshing:
+		return
+	if not dock.level_root:
+		return
+	dock.level_root.set_region_streaming_radius(int(value))
+
+
+static func on_region_memory_changed(dock: Object, value: float) -> void:
+	if dock == null or dock._region_settings_refreshing:
+		return
+	if not dock.level_root:
+		return
+	dock.level_root.set_region_memory_budget_mb(int(value))
+
+
+static func on_region_grid_toggled(dock: Object, enabled: bool) -> void:
+	if dock == null or dock._region_settings_refreshing:
+		return
+	if not dock.level_root:
+		return
+	dock.level_root.set_region_show_grid(enabled)
+
+
+static func on_blend_slot_selected(dock: Object, index: int) -> void:
+	if dock == null or not dock.level_root or not dock.level_root.paint_tool or not dock.blend_slot_select:
+		return
+	var slot_id = dock.blend_slot_select.get_item_id(index)
+	dock.level_root.paint_tool.blend_slot = int(slot_id)
+
+
+static func on_terrain_slot_pressed(dock: Object, slot: int) -> void:
+	if dock == null or not dock.terrain_slot_texture_dialog:
+		return
+	dock._terrain_slot_pick_index = slot
+	dock.terrain_slot_texture_dialog.popup_centered(Vector2i(600, 400))
+
+
+static func on_terrain_slot_texture_selected(dock: Object, path: String) -> void:
+	if dock == null or dock._terrain_slot_pick_index < 0:
+		return
+	if not dock.level_root or not dock.level_root.paint_layers:
+		return
+	var layer = dock.level_root.paint_layers.get_active_layer()
+	if not layer:
+		return
+	layer._ensure_terrain_slots()
+	layer.terrain_slot_paths[dock._terrain_slot_pick_index] = path
+	refresh_terrain_slots(dock)
+	dock.level_root._regenerate_paint_layers()
+
+
+static func on_terrain_slot_scale_changed(dock: Object, value: float, slot: int) -> void:
+	if dock == null or dock._terrain_slot_refreshing:
+		return
+	if not dock.level_root or not dock.level_root.paint_layers:
+		return
+	var layer = dock.level_root.paint_layers.get_active_layer()
+	if not layer:
+		return
+	layer._ensure_terrain_slots()
+	var current = float(layer.terrain_slot_uv_scales[slot])
+	if is_equal_approx(current, value):
+		return
+	layer.terrain_slot_uv_scales[slot] = float(value)
+	dock.level_root._regenerate_paint_layers()
+
+
+static func refresh_terrain_slots(dock: Object) -> void:
+	if dock == null:
+		return
+	dock._terrain_slot_refreshing = true
+	if not dock.level_root or not dock.level_root.paint_layers:
+		set_terrain_slot_controls_enabled(dock, false)
+		dock._terrain_slot_refreshing = false
+		return
+	var layer = dock.level_root.paint_layers.get_active_layer()
+	if not layer:
+		set_terrain_slot_controls_enabled(dock, false)
+		dock._terrain_slot_refreshing = false
+		return
+	layer._ensure_terrain_slots()
+	set_terrain_slot_controls_enabled(dock, true)
+	for i in range(dock.terrain_slot_buttons.size()):
+		var button = dock.terrain_slot_buttons[i]
+		var scale = dock.terrain_slot_scales[i]
+		if button:
+			var path = layer.terrain_slot_paths[i]
+			button.text = terrain_slot_label(path)
+		if scale:
+			scale.value = float(layer.terrain_slot_uv_scales[i])
+	if dock.blend_slot_select and dock.level_root.paint_tool:
+		var slot = clamp(dock.level_root.paint_tool.blend_slot, 1, 3)
+		dock._select_option_by_id(dock.blend_slot_select, slot)
+	dock._terrain_slot_refreshing = false
+
+
+static func terrain_slot_label(path: String) -> String:
+	if path == "":
+		return "Texture..."
+	return path.get_file()
+
+
+static func set_terrain_slot_controls_enabled(dock: Object, enabled: bool) -> void:
+	if dock == null:
+		return
+	for button in dock.terrain_slot_buttons:
+		if button:
+			button.disabled = not enabled
+	for spin in dock.terrain_slot_scales:
+		if spin:
+			spin.editable = enabled

--- a/tests/test_selection_features.gd
+++ b/tests/test_selection_features.gd
@@ -483,6 +483,19 @@ func test_heterogeneous_managed_selection_disables_type_specific_controls() -> v
 	dock.free()
 
 
+func _dock_or_paint_function_source(
+	dock_source: String, paint_source: String, function_name: String
+) -> String:
+	var block := _function_source(dock_source, function_name)
+	if block.contains("_guard_selection_action("):
+		return block
+	var handler_name := function_name.trim_prefix("_")
+	var handler_block := _function_source(paint_source, handler_name)
+	if handler_block != "":
+		return handler_block
+	return block
+
+
 func _function_source(source: String, function_name: String) -> String:
 	var start := source.find("func %s(" % function_name)
 	if start < 0:
@@ -495,6 +508,9 @@ func _function_source(source: String, function_name: String) -> String:
 
 func test_all_dock_selection_mutators_share_the_scope_guard() -> void:
 	var source := FileAccess.get_file_as_string("res://addons/hammerforge/dock.gd")
+	var paint_source := FileAccess.get_file_as_string(
+		"res://addons/hammerforge/dock_paint_handler.gd"
+	)
 	var guarded_functions := [
 		"_on_prefab_save_requested",
 		"_on_prefab_save_linked_requested",
@@ -524,7 +540,7 @@ func test_all_dock_selection_mutators_share_the_scope_guard() -> void:
 		"_apply_material_to_whole_brush",
 	]
 	for function_name in guarded_functions:
-		var block := _function_source(source, function_name)
+		var block := _dock_or_paint_function_source(source, paint_source, function_name)
 		assert_ne(block, "", "%s must exist" % function_name)
 		assert_true(
 			block.contains("_guard_selection_action("),
@@ -546,7 +562,7 @@ func test_all_dock_selection_mutators_share_the_scope_guard() -> void:
 		"_apply_material_to_whole_brush",
 	]:
 		assert_true(
-			_function_source(source, function_name).contains(
+			_dock_or_paint_function_source(source, paint_source, function_name).contains(
 				"DockSelectionRequirement.BRUSHES_ONLY"
 			),
 			"%s must reject entities instead of filtering them out" % function_name,


### PR DESCRIPTION
Next dock/plugin split from the original review.

Paint-tab layer, heightmap, scatter, sculpt, region, and terrain-slot methods now live in `HFDockPaintHandler`. `dock.gd` keeps thin wrappers so existing call sites and selection-guard audits still work.

GUT: **1729 tests, 1722 passing, 0 failing** (7 pre-existing risky).

Still open: remaining dock brush/entity/manage handlers, profiling.