### PR TITLE
Fix gdformat on extracted plugin and paint modules

### DIFF
--- a/addons/hammerforge/dock_paint_handler.gd
+++ b/addons/hammerforge/dock_paint_handler.gd
@@ -91,7 +91,9 @@ static func on_heightmap_convert(dock: Object) -> void:
 		if is_instance_valid(node) and dock.level_root.is_brush_node(node):
 			brushes.append(node)
 	if brushes.is_empty():
-		dock.level_root.emit_signal("user_message", "Select brushes first to convert to heightmap", 1)
+		dock.level_root.emit_signal(
+			"user_message", "Select brushes first to convert to heightmap", 1
+		)
 		return
 	var converter := HFBrushToHeightmap.new()
 	var settings := HFBrushToHeightmap.ConvertSettings.new()
@@ -176,7 +178,9 @@ static func build_scatter_settings(dock: Object) -> HFScatterBrush.ScatterSettin
 	if dock.scatter_max_slope_spin:
 		s.max_slope = dock.scatter_max_slope_spin.value
 	if dock.scatter_scale_min_spin and dock.scatter_scale_max_spin:
-		s.scale_range = Vector2(dock.scatter_scale_min_spin.value, dock.scatter_scale_max_spin.value)
+		s.scale_range = Vector2(
+			dock.scatter_scale_min_spin.value, dock.scatter_scale_max_spin.value
+		)
 	if dock.scatter_align_normal:
 		s.align_to_normal = dock.scatter_align_normal.button_pressed
 	if dock.scatter_random_rotation:
@@ -402,7 +406,12 @@ static func on_region_grid_toggled(dock: Object, enabled: bool) -> void:
 
 
 static func on_blend_slot_selected(dock: Object, index: int) -> void:
-	if dock == null or not dock.level_root or not dock.level_root.paint_tool or not dock.blend_slot_select:
+	if (
+		dock == null
+		or not dock.level_root
+		or not dock.level_root.paint_tool
+		or not dock.blend_slot_select
+	):
 		return
 	var slot_id = dock.blend_slot_select.get_item_id(index)
 	dock.level_root.paint_tool.blend_slot = int(slot_id)

--- a/addons/hammerforge/paint/hf_brush_to_heightmap.gd
+++ b/addons/hammerforge/paint/hf_brush_to_heightmap.gd
@@ -148,7 +148,11 @@ static func _is_additive_brush(brush: Node3D) -> bool:
 func _get_brush_aabb(brush: Node3D) -> AABB:
 	if brush is DraftBrush:
 		var draft := brush as DraftBrush
-		if draft.mesh_instance and is_instance_valid(draft.mesh_instance) and draft.mesh_instance.mesh:
+		if (
+			draft.mesh_instance
+			and is_instance_valid(draft.mesh_instance)
+			and draft.mesh_instance.mesh
+		):
 			return draft.mesh_instance.global_transform * draft.mesh_instance.mesh.get_aabb()
 		var half_size := draft.size * 0.5
 		return AABB(draft.global_position - half_size, draft.size)

--- a/addons/hammerforge/plugin_hud.gd
+++ b/addons/hammerforge/plugin_hud.gd
@@ -99,9 +99,7 @@ static func update_context_toolbar_state(plugin: Object, root: Node, tool_id: in
 	state["paint_mode"] = dock.is_paint_mode_enabled() if dock else false
 	state["vertex_mode"] = plugin._vertex_mode
 	state["is_subtract"] = dock.get_operation() != 0 if dock else false  # 0 = UNION
-	state["has_active_external_tool"] = (
-		registry.has_active_external_tool() if registry else false
-	)
+	state["has_active_external_tool"] = (registry.has_active_external_tool() if registry else false)
 
 	# Input mode
 	var input_mode := 0
@@ -188,7 +186,9 @@ static func update_context_toolbar_state(plugin: Object, root: Node, tool_id: in
 		plugin._context_toolbar.update_state(state)
 		# Feed favorite materials to the face-context thumbnail strip
 		if face_count > 0 and dock and dock.material_browser:
-			plugin._context_toolbar.set_favorite_materials(dock.material_browser.get_favorite_infos(5))
+			plugin._context_toolbar.set_favorite_materials(
+				dock.material_browser.get_favorite_infos(5)
+			)
 	if plugin._hotkey_palette and plugin._hotkey_palette.visible:
 		var palette_state := state.duplicate()
 		palette_state["tool"] = plugin.hotkey_palette_tool_context(tool_id, plugin._vertex_mode)

--- a/addons/hammerforge/plugin_input_router.gd
+++ b/addons/hammerforge/plugin_input_router.gd
@@ -70,7 +70,9 @@ static func handle_keyboard(
 
 	# Viewport context menu — only when idle (no active operation, no active external tool)
 	if keymap.matches("context_menu", event):
-		var has_active_ext = plugin._tool_registry and plugin._tool_registry.has_active_external_tool()
+		var has_active_ext = (
+			plugin._tool_registry and plugin._tool_registry.has_active_external_tool()
+		)
 		if root.input_state.is_idle() and not has_active_ext:
 			plugin._show_viewport_context_menu(root, tool_id)
 			return STOP
@@ -80,7 +82,9 @@ static func handle_keyboard(
 			if plugin._radial_menu.is_active():
 				plugin._radial_menu.hide_menu()
 				return STOP
-			var radial_ext = plugin._tool_registry and plugin._tool_registry.has_active_external_tool()
+			var radial_ext = (
+				plugin._tool_registry and plugin._tool_registry.has_active_external_tool()
+			)
 			if root.input_state.is_idle() and not radial_ext:
 				plugin._radial_menu.show_at(plugin._get_current_overlay_mouse_pos())
 				return STOP
@@ -92,7 +96,10 @@ static func handle_keyboard(
 	# Must come before keymap matches so the second tap is intercepted.
 	var tap_now := Time.get_ticks_msec()
 	if not event.ctrl_pressed and not event.shift_pressed and not event.alt_pressed:
-		if event.keycode == plugin._last_tap_keycode and (tap_now - plugin._last_tap_time) < plugin._DOUBLE_TAP_MS:
+		if (
+			event.keycode == plugin._last_tap_keycode
+			and (tap_now - plugin._last_tap_time) < plugin._DOUBLE_TAP_MS
+		):
 			var handled = plugin._handle_double_tap(event.keycode, root, paint_mode)
 			if handled:
 				plugin._last_tap_keycode = 0

--- a/addons/hammerforge/systems/hf_subtract_preview.gd
+++ b/addons/hammerforge/systems/hf_subtract_preview.gd
@@ -406,7 +406,11 @@ static func world_aabb(node: Node3D) -> AABB:
 		xform = node.global_transform
 	if node is DraftBrush:
 		var draft := node as DraftBrush
-		if draft.mesh_instance and is_instance_valid(draft.mesh_instance) and draft.mesh_instance.mesh:
+		if (
+			draft.mesh_instance
+			and is_instance_valid(draft.mesh_instance)
+			and draft.mesh_instance.mesh
+		):
 			var mesh_xform := xform * draft.mesh_instance.transform
 			if draft.mesh_instance.is_inside_tree():
 				mesh_xform = draft.mesh_instance.global_transform


### PR DESCRIPTION
CI `GDScript Lint & Format` has been failing on main since the CSG/MCP/split PRs. `gdformat --check addons/hammerforge/` wanted wrapping on five files:

- `addons/hammerforge/dock_paint_handler.gd`
- `addons/hammerforge/plugin_hud.gd`
- `addons/hammerforge/plugin_input_router.gd`
- `addons/hammerforge/paint/hf_brush_to_heightmap.gd`
- `addons/hammerforge/systems/hf_subtract_preview.gd`

Ran `gdformat` on those files. `gdlint addons/hammerforge/` is clean locally. No behavior change.