### PR TITLE
Move Build-tab brush handlers into dock_brush_handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Changed
+- **Build-tab brush handlers live in `dock_brush_handler.gd`:** displacement, bevel, hollow, clip, floor/ceiling, duplicate-array, and tie/untie dock methods are thin wrappers around `HFDockBrushHandler`.
 - **Paint-tab handlers live in `dock_paint_handler.gd`:** layer, heightmap, scatter, sculpt, region, and terrain-slot dock methods are thin wrappers around `HFDockPaintHandler`.
 - **HUD and context-toolbar state live in `plugin_hud.gd`:** `_update_hud_context()` and `_update_context_toolbar_state()` are thin wrappers around `HFPluginHud`.
 - **Vertex/edge input lives in `plugin_vertex_input.gd`:** `plugin._handle_vertex_input()` is a thin wrapper around `HFPluginVertexInput.handle()`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,6 +34,7 @@ addons/hammerforge/
   input_state.gd         Drag/paint state machine (HFInputState)
   hf_selection_gesture.gd Select-mode LMB arbiter (native object selection, face marquee, gizmos)
   dock.gd + dock.tscn    UI dock (displayed as Build, Paint, Objects, Test), collapsible sections with persisted state
+  dock_brush_handler.gd  Build-tab displacement/bevel/hollow/clip/tie handlers
   dock_paint_handler.gd  Paint-tab layer/heightmap/scatter/sculpt handlers
   shortcut_hud.gd        Context-sensitive shortcut overlay (dynamic per mode) + persistent grid size indicator with flash-on-change
   brush_instance.gd      DraftBrush node

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -328,7 +328,7 @@ The May 2026 simplification phase 1 landed shared utilities and migrated low-ris
 
 ### Continued dock.gd decomposition
 The remaining 6,692 lines are dominated by ~180 `_on_*` signal handlers wired to dock-internal state.
-- Split into per-tab handler files: `dock_brush_handler.gd`, `dock_paint_handler.gd` (done), `dock_entity_handler.gd`, `dock_manage_handler.gd`. Target dock.gd shell at ~1,500 lines.
+- Split into per-tab handler files: `dock_brush_handler.gd` (done), `dock_paint_handler.gd` (done), `dock_entity_handler.gd`, `dock_manage_handler.gd`. Target dock.gd shell at ~1,500 lines.
 - Extract signal-wiring into `dock_connections.gd`.
 - Consolidate the entity-properties UI builder and the external-tool-settings UI builder (both schema-driven; share ~100 lines of dispatch logic).
 - Migrate `paint_tab_builder.gd` (50 call sites) and `manage_tab_builder.gd` (58 call sites) from `dock._make_*` to direct `HFUIFactory` calls. Mechanical churn — wait until shared with another tab-builder change.

--- a/addons/hammerforge/dock.gd
+++ b/addons/hammerforge/dock.gd
@@ -35,6 +35,7 @@ const EntityTabBuilder = preload("ui/entity_tab_builder.gd")
 const ManageTabBuilder = preload("ui/manage_tab_builder.gd")
 const SelectionToolsBuilder = preload("ui/selection_tools_builder.gd")
 const HFDockPaintHandler = preload("dock_paint_handler.gd")
+const HFDockBrushHandler = preload("dock_brush_handler.gd")
 
 const PRESET_MENU_RENAME := 0
 const PRESET_MENU_DELETE := 1
@@ -1897,220 +1898,39 @@ func _try_undoable_action(action_name: String, method_name: String, args: Array 
 
 
 func _on_disp_create() -> void:
-	if not level_root:
-		return
-	if not _guard_selection_action("Create Displacement", DockSelectionRequirement.BRUSHES_ONLY):
-		return
-	var info: Dictionary = _get_selected_face_info()
-	if info.is_empty():
-		show_toast("Select a quad face first", 1)
-		return
-	var power: int = int(_disp_power_spin.value) if _disp_power_spin else 3
-	var ok: bool = _try_undoable_action(
-		"Create Displacement", "create_displacement", [info["brush_id"], info["face_index"], power]
-	)
-	if ok:
-		show_toast("Displacement created (power %d)" % power, 0)
-	else:
-		show_toast("Failed — face must be a quad (4 vertices)", 2)
+	HFDockBrushHandler.on_disp_create(self)
 
 
 func _on_disp_destroy() -> void:
-	if not level_root:
-		return
-	if not _guard_selection_action("Destroy Displacement", DockSelectionRequirement.BRUSHES_ONLY):
-		return
-	var info: Dictionary = _get_selected_face_info()
-	if info.is_empty():
-		show_toast("Select a displaced face first", 1)
-		return
-	var ok: bool = _try_undoable_action(
-		"Destroy Displacement", "destroy_displacement", [info["brush_id"], info["face_index"]]
-	)
-	if ok:
-		show_toast("Displacement removed", 0)
-	else:
-		show_toast("Face has no displacement to remove", 2)
+	HFDockBrushHandler.on_disp_destroy(self)
 
 
 func _on_disp_elevation_changed(value: float) -> void:
-	if not level_root:
-		return
-	if not _guard_selection_action("Edit Displacement", DockSelectionRequirement.BRUSHES_ONLY):
-		return
-	var info: Dictionary = _get_selected_face_info()
-	if info.is_empty():
-		return
-	if not _selected_face_has_displacement(info):
-		return
-	var brush_id: String = info["brush_id"]
-	var face_idx: int = info["face_index"]
-	HFUndoHelper.commit(
-		undo_redo,
-		level_root,
-		"Set Displacement Elevation",
-		"set_displacement_elevation",
-		[brush_id, face_idx, value],
-		false,
-		Callable(self, "record_history"),
-		"disp_elevation_%s_%d" % [brush_id, face_idx]
-	)
+	HFDockBrushHandler.on_disp_elevation_changed(self, value)
 
 
 func _on_disp_smooth() -> void:
-	if not level_root:
-		return
-	if not _guard_selection_action("Smooth Displacement", DockSelectionRequirement.BRUSHES_ONLY):
-		return
-	var info: Dictionary = _get_selected_face_info()
-	if info.is_empty():
-		show_toast("Select a displaced face first", 1)
-		return
-	var strength: float = _disp_strength_spin.value if _disp_strength_spin else 0.5
-	var ok: bool = _try_undoable_action(
-		"Smooth Displacement",
-		"smooth_displacement",
-		[info["brush_id"], info["face_index"], strength]
-	)
-	if ok:
-		show_toast("Displacement smoothed", 0)
-	else:
-		show_toast("Smooth failed — face has no displacement", 2)
+	HFDockBrushHandler.on_disp_smooth(self)
 
 
 func _on_disp_noise() -> void:
-	if not level_root:
-		return
-	if not _guard_selection_action("Noise Displacement", DockSelectionRequirement.BRUSHES_ONLY):
-		return
-	var info: Dictionary = _get_selected_face_info()
-	if info.is_empty():
-		show_toast("Select a displaced face first", 1)
-		return
-	var scale: float = _disp_strength_spin.value if _disp_strength_spin else 1.0
-	var ok: bool = _try_undoable_action(
-		"Noise Displacement", "noise_displacement", [info["brush_id"], info["face_index"], scale]
-	)
-	if ok:
-		show_toast("Noise applied to displacement", 0)
-	else:
-		show_toast("Noise failed — face has no displacement", 2)
+	HFDockBrushHandler.on_disp_noise(self)
 
 
 func _on_disp_sew() -> void:
-	if not level_root:
-		return
-	# Capture state, execute, then commit undo only if vertices were actually sewn.
-	var pre_state: Dictionary = (
-		level_root.capture_state() if level_root.has_method("capture_state") else {}
-	)
-	var count: int = level_root.sew_all_displacements()
-	if count > 0 and undo_redo and not pre_state.is_empty():
-		var post_state: Dictionary = level_root.capture_state()
-		undo_redo.create_action("Sew Displacements", 0, null, false)
-		undo_redo.add_do_method(level_root, "restore_state", post_state)
-		undo_redo.add_undo_method(level_root, "restore_state", pre_state)
-		undo_redo.commit_action(false)
-		record_history("Sew Displacements")
-	show_toast("Sewn %d boundary vertices" % count, 0)
+	HFDockBrushHandler.on_disp_sew(self)
 
 
 func _on_disp_sew_group_changed(value: float) -> void:
-	if not level_root:
-		return
-	if not _guard_selection_action(
-		"Edit Displacement Sew Group", DockSelectionRequirement.BRUSHES_ONLY
-	):
-		return
-	var info: Dictionary = _get_selected_face_info()
-	if info.is_empty():
-		return
-	if not _selected_face_has_displacement(info):
-		return
-	var brush_id: String = info["brush_id"]
-	var face_idx: int = info["face_index"]
-	HFUndoHelper.commit(
-		undo_redo,
-		level_root,
-		"Set Sew Group",
-		"set_displacement_sew_group",
-		[brush_id, face_idx, int(value)],
-		false,
-		Callable(self, "record_history"),
-		"disp_sew_group_%s_%d" % [brush_id, face_idx]
-	)
-
-
-# --- Bevel callbacks ---
+	HFDockBrushHandler.on_disp_sew_group_changed(self, value)
 
 
 func _on_bevel_edge() -> void:
-	if not level_root:
-		return
-	if not _guard_selection_action("Bevel Edge", DockSelectionRequirement.BRUSHES_ONLY):
-		return
-	var plugin_ref = level_root.get_meta("_hf_plugin", null)
-	if not plugin_ref:
-		show_toast("No plugin reference", 2)
-		return
-	if not plugin_ref.get("_vertex_mode") or not level_root.vertex_system:
-		show_toast("Enter vertex/edge mode first (V key)", 1)
-		return
-	var vs = level_root.vertex_system
-	if vs.selected_edges.is_empty():
-		show_toast("Select an edge first (edge sub-mode)", 1)
-		return
-	var segments: int = int(_bevel_segments_spin.value) if _bevel_segments_spin else 2
-	var radius: float = _bevel_radius_spin.value if _bevel_radius_spin else 2.0
-	# Capture state once before the batch, call each bevel, track actual successes.
-	var pre_state: Dictionary = (
-		level_root.capture_state() if level_root.has_method("capture_state") else {}
-	)
-	var count := 0
-	for brush_id in vs.selected_edges:
-		var edges: Array = vs.selected_edges[brush_id]
-		for edge in edges:
-			if level_root.bevel_edge(brush_id, edge, segments, radius):
-				count += 1
-	if count > 0:
-		if undo_redo and not pre_state.is_empty():
-			var post_state: Dictionary = level_root.capture_state()
-			undo_redo.create_action("Bevel Edge", 0, null, false)
-			undo_redo.add_do_method(level_root, "restore_state", post_state)
-			undo_redo.add_undo_method(level_root, "restore_state", pre_state)
-			undo_redo.commit_action(false)
-			record_history("Bevel Edge")
-		show_toast("Beveled %d edge(s)" % count, 0)
-	else:
-		show_toast("Bevel failed — check edge selection", 2)
+	HFDockBrushHandler.on_bevel_edge(self)
 
 
 func _on_bevel_inset() -> void:
-	if not level_root:
-		return
-	if not _guard_selection_action("Inset Face", DockSelectionRequirement.BRUSHES_ONLY):
-		return
-	var info: Dictionary = _get_selected_face_info()
-	if info.is_empty():
-		show_toast("Select a face first", 1)
-		return
-	var inset_dist: float = _bevel_inset_dist_spin.value if _bevel_inset_dist_spin else 2.0
-	var height: float = _bevel_inset_height_spin.value if _bevel_inset_height_spin else 0.0
-	var pre_state: Dictionary = (
-		level_root.capture_state() if level_root.has_method("capture_state") else {}
-	)
-	var ok: bool = level_root.inset_face(info["brush_id"], info["face_index"], inset_dist, height)
-	if ok:
-		if undo_redo and not pre_state.is_empty():
-			var post_state: Dictionary = level_root.capture_state()
-			undo_redo.create_action("Inset Face", 0, null, false)
-			undo_redo.add_do_method(level_root, "restore_state", post_state)
-			undo_redo.add_undo_method(level_root, "restore_state", pre_state)
-			undo_redo.commit_action(false)
-			record_history("Inset Face")
-		show_toast("Face inset applied", 0)
-	else:
-		show_toast("Inset failed — distance too large or face too small", 2)
+	HFDockBrushHandler.on_bevel_inset(self)
 
 
 func _ready():
@@ -3503,172 +3323,31 @@ func _on_restore_cuts():
 
 
 func _on_hollow() -> void:
-	if not level_root or _selection_nodes.is_empty():
-		_set_status("Select a brush to hollow", true)
-		return
-	if not _guard_selection_action("Hollow", DockSelectionRequirement.BRUSHES_ONLY):
-		return
-	var brush = _first_selected_brush()
-	if not brush:
-		_set_status("Select a brush to hollow", true)
-		return
-	var info = level_root.get_brush_info_from_node(brush)
-	var brush_id = str(info.get("brush_id", ""))
-	if brush_id == "":
-		return
-	var thickness = hollow_thickness.value if hollow_thickness else 4.0
-	var check: HFOpResult = level_root.can_hollow_brush(brush_id, thickness)
-	if not check.ok:
-		show_toast(check.user_text(), 1)
-		return
-	# Show geometry preview and confirm
-	level_root.hollow_preview.show_preview(brush_id, thickness)
-	var dlg = ConfirmationDialog.new()
-	dlg.title = "Hollow Brush"
-	dlg.dialog_text = (
-		"Hollow with wall thickness %.1f?\n(Yellow wireframe shows resulting walls)" % thickness
-	)
-	dlg.min_size = Vector2i(300, 100)
-	add_child(dlg)
-	dlg.confirmed.connect(
-		func():
-			if not is_instance_valid(self):
-				return
-			if level_root and level_root.hollow_preview:
-				level_root.hollow_preview.clear()
-			if not _guard_selection_action("Hollow", DockSelectionRequirement.BRUSHES_ONLY):
-				dlg.queue_free()
-				return
-			_commit_state_action("Hollow", "hollow_brush_by_id", [brush_id, thickness])
-			dlg.queue_free()
-	)
-	dlg.canceled.connect(
-		func():
-			if not is_instance_valid(self):
-				return
-			if level_root and level_root.hollow_preview:
-				level_root.hollow_preview.clear()
-			dlg.queue_free()
-	)
-	dlg.popup_centered()
+	HFDockBrushHandler.on_hollow(self)
 
 
 func _on_move_to_floor() -> void:
-	if not level_root or _selection_nodes.is_empty():
-		return
-	if not _guard_selection_action("Move to Floor", DockSelectionRequirement.BRUSHES_ONLY):
-		return
-	var brush_ids: Array = []
-	for node in _selection_nodes:
-		if level_root.is_brush_node(node):
-			var info = level_root.get_brush_info_from_node(node)
-			var bid = str(info.get("brush_id", ""))
-			if bid != "":
-				brush_ids.append(bid)
-	if brush_ids.is_empty():
-		return
-	_commit_state_action("Move to Floor", "move_brushes_to_floor", [brush_ids])
+	HFDockBrushHandler.on_move_to_floor(self)
 
 
 func _on_move_to_ceiling() -> void:
-	if not level_root or _selection_nodes.is_empty():
-		return
-	if not _guard_selection_action("Move to Ceiling", DockSelectionRequirement.BRUSHES_ONLY):
-		return
-	var brush_ids: Array = []
-	for node in _selection_nodes:
-		if level_root.is_brush_node(node):
-			var info = level_root.get_brush_info_from_node(node)
-			var bid = str(info.get("brush_id", ""))
-			if bid != "":
-				brush_ids.append(bid)
-	if brush_ids.is_empty():
-		return
-	_commit_state_action("Move to Ceiling", "move_brushes_to_ceiling", [brush_ids])
+	HFDockBrushHandler.on_move_to_ceiling(self)
 
 
 func _on_create_duplicate_array() -> void:
-	if not level_root or _selection_nodes.is_empty():
-		_set_status("Select brushes first", true)
-		return
-	if not _guard_selection_action("Create Duplicate Array", DockSelectionRequirement.BRUSHES_ONLY):
-		return
-	var brush_ids = PackedStringArray()
-	for node in _selection_nodes:
-		if level_root.is_brush_node(node):
-			var info = level_root.get_brush_info_from_node(node)
-			if info and info.has("brush_id"):
-				brush_ids.append(info["brush_id"])
-	if brush_ids.is_empty():
-		_set_status("No brushes selected", true)
-		return
-	var cnt = int(dup_count_spin.value) if dup_count_spin else 3
-	var off = Vector3(
-		dup_offset_x.value if dup_offset_x else 8,
-		dup_offset_y.value if dup_offset_y else 0,
-		dup_offset_z.value if dup_offset_z else 0,
-	)
-	_commit_state_action("Create Duplicate Array", "create_duplicate_array", [brush_ids, cnt, off])
-	_set_status("Created %d copies" % cnt)
+	HFDockBrushHandler.on_create_duplicate_array(self)
 
 
 func _on_remove_duplicate_array() -> void:
-	if not level_root or _selection_nodes.is_empty():
-		_set_status("Select a duplicator source brush", true)
-		return
-	if not _guard_selection_action("Remove Duplicate Array", DockSelectionRequirement.BRUSHES_ONLY):
-		return
-	for node in _selection_nodes:
-		if not level_root.is_brush_node(node):
-			continue
-		var dup_id: String = str(node.get_meta("duplicator_id", ""))
-		if dup_id != "":
-			_commit_state_action("Remove Duplicate Array", "remove_duplicate_array", [dup_id])
-			_set_status("Removed duplicate array")
-			return
-	_set_status("Selected brush is not a duplicator source", true)
+	HFDockBrushHandler.on_remove_duplicate_array(self)
 
 
 func _on_tie_entity() -> void:
-	if not level_root or _selection_nodes.is_empty():
-		_set_status("Select brushes to tie", true)
-		return
-	if not _guard_selection_action("Tie to Entity", DockSelectionRequirement.BRUSHES_ONLY):
-		return
-	var class_name_str := "func_detail"
-	if (
-		brush_entity_class_opt
-		and brush_entity_class_opt.item_count > 0
-		and brush_entity_class_opt.selected >= 0
-	):
-		class_name_str = brush_entity_class_opt.get_item_text(brush_entity_class_opt.selected)
-	var brush_ids: Array = []
-	for node in _selection_nodes:
-		if level_root.is_brush_node(node):
-			var info = level_root.get_brush_info_from_node(node)
-			var bid = str(info.get("brush_id", ""))
-			if bid != "":
-				brush_ids.append(bid)
-	if brush_ids.is_empty():
-		return
-	_commit_state_action("Tie to Entity", "tie_brushes_to_entity", [brush_ids, class_name_str])
+	HFDockBrushHandler.on_tie_entity(self)
 
 
 func _on_untie_entity() -> void:
-	if not level_root or _selection_nodes.is_empty():
-		return
-	if not _guard_selection_action("Untie Entity", DockSelectionRequirement.BRUSHES_ONLY):
-		return
-	var brush_ids: Array = []
-	for node in _selection_nodes:
-		if level_root.is_brush_node(node):
-			var info = level_root.get_brush_info_from_node(node)
-			var bid = str(info.get("brush_id", ""))
-			if bid != "":
-				brush_ids.append(bid)
-	if brush_ids.is_empty():
-		return
-	_commit_state_action("Untie Entity", "untie_brushes_from_entity", [brush_ids])
+	HFDockBrushHandler.on_untie_entity(self)
 
 
 func _on_justify(mode: String) -> void:
@@ -3681,7 +3360,7 @@ func _on_justify(mode: String) -> void:
 
 
 func get_hollow_thickness() -> float:
-	return hollow_thickness.value if hollow_thickness else 4.0
+	return HFDockBrushHandler.get_hollow_thickness(self)
 
 
 func _on_create_entity() -> void:
@@ -6948,56 +6627,7 @@ func _on_cordon_from_selection() -> void:
 
 
 func _on_clip() -> void:
-	if not level_root or _selection_nodes.is_empty():
-		_set_status("Select a brush to clip", true)
-		return
-	if not _guard_selection_action("Clip", DockSelectionRequirement.BRUSHES_ONLY):
-		return
-	var brush = _first_selected_brush()
-	if not brush:
-		_set_status("Select a brush to clip", true)
-		return
-	var info = level_root.get_brush_info_from_node(brush)
-	var brush_id = str(info.get("brush_id", ""))
-	if brush_id == "":
-		return
-	# Default clip: split along Y axis at center
-	var center = info.get("center", Vector3.ZERO)
-	var split_pos: float = center.y if center is Vector3 else 0.0
-	var check: HFOpResult = level_root.can_clip_brush(brush_id, 1, split_pos)
-	if not check.ok:
-		show_toast(check.user_text(), 1)
-		return
-	# Show geometry preview and confirm
-	level_root.clip_preview.show_preview(brush_id, 1, split_pos)
-	var dlg = ConfirmationDialog.new()
-	dlg.title = "Clip Brush"
-	dlg.dialog_text = (
-		"Split brush along Y axis at %.1f?\n(Cyan wireframe shows resulting pieces)" % split_pos
-	)
-	dlg.min_size = Vector2i(300, 100)
-	add_child(dlg)
-	dlg.confirmed.connect(
-		func():
-			if not is_instance_valid(self):
-				return
-			if level_root and level_root.clip_preview:
-				level_root.clip_preview.clear()
-			if not _guard_selection_action("Clip", DockSelectionRequirement.BRUSHES_ONLY):
-				dlg.queue_free()
-				return
-			_commit_state_action("Clip Brush", "clip_brush_by_id", [brush_id, 1, split_pos])
-			dlg.queue_free()
-	)
-	dlg.canceled.connect(
-		func():
-			if not is_instance_valid(self):
-				return
-			if level_root and level_root.clip_preview:
-				level_root.clip_preview.clear()
-			dlg.queue_free()
-	)
-	dlg.popup_centered()
+	HFDockBrushHandler.on_clip(self)
 
 
 func _on_io_add() -> void:

--- a/addons/hammerforge/dock_brush_handler.gd
+++ b/addons/hammerforge/dock_brush_handler.gd
@@ -1,0 +1,486 @@
+@tool
+class_name HFDockBrushHandler
+extends RefCounted
+## Build-tab brush handlers extracted from dock.gd (displacement, bevel,
+## hollow, clip, floor/ceiling, duplicate array, tie/untie).
+
+const HFUndoHelper = preload("undo_helper.gd")
+
+
+static func on_disp_create(dock: Object) -> void:
+	if dock == null or not dock.level_root:
+		return
+	if not dock._guard_selection_action(
+		"Create Displacement", dock.DockSelectionRequirement.BRUSHES_ONLY
+	):
+		return
+	var info: Dictionary = dock._get_selected_face_info()
+	if info.is_empty():
+		dock.show_toast("Select a quad face first", 1)
+		return
+	var power: int = int(dock._disp_power_spin.value) if dock._disp_power_spin else 3
+	var ok: bool = dock._try_undoable_action(
+		"Create Displacement", "create_displacement", [info["brush_id"], info["face_index"], power]
+	)
+	if ok:
+		dock.show_toast("Displacement created (power %d)" % power, 0)
+	else:
+		dock.show_toast("Failed — face must be a quad (4 vertices)", 2)
+
+
+static func on_disp_destroy(dock: Object) -> void:
+	if dock == null or not dock.level_root:
+		return
+	if not dock._guard_selection_action(
+		"Destroy Displacement", dock.DockSelectionRequirement.BRUSHES_ONLY
+	):
+		return
+	var info: Dictionary = dock._get_selected_face_info()
+	if info.is_empty():
+		dock.show_toast("Select a displaced face first", 1)
+		return
+	var ok: bool = dock._try_undoable_action(
+		"Destroy Displacement", "destroy_displacement", [info["brush_id"], info["face_index"]]
+	)
+	if ok:
+		dock.show_toast("Displacement removed", 0)
+	else:
+		dock.show_toast("Face has no displacement to remove", 2)
+
+
+static func on_disp_elevation_changed(dock: Object, value: float) -> void:
+	if dock == null or not dock.level_root:
+		return
+	if not dock._guard_selection_action(
+		"Edit Displacement", dock.DockSelectionRequirement.BRUSHES_ONLY
+	):
+		return
+	var info: Dictionary = dock._get_selected_face_info()
+	if info.is_empty():
+		return
+	if not dock._selected_face_has_displacement(info):
+		return
+	var brush_id: String = info["brush_id"]
+	var face_idx: int = info["face_index"]
+	HFUndoHelper.commit(
+		dock.undo_redo,
+		dock.level_root,
+		"Set Displacement Elevation",
+		"set_displacement_elevation",
+		[brush_id, face_idx, value],
+		false,
+		Callable(dock, "record_history"),
+		"disp_elevation_%s_%d" % [brush_id, face_idx]
+	)
+
+
+static func on_disp_smooth(dock: Object) -> void:
+	if dock == null or not dock.level_root:
+		return
+	if not dock._guard_selection_action(
+		"Smooth Displacement", dock.DockSelectionRequirement.BRUSHES_ONLY
+	):
+		return
+	var info: Dictionary = dock._get_selected_face_info()
+	if info.is_empty():
+		dock.show_toast("Select a displaced face first", 1)
+		return
+	var strength: float = dock._disp_strength_spin.value if dock._disp_strength_spin else 0.5
+	var ok: bool = dock._try_undoable_action(
+		"Smooth Displacement",
+		"smooth_displacement",
+		[info["brush_id"], info["face_index"], strength]
+	)
+	if ok:
+		dock.show_toast("Displacement smoothed", 0)
+	else:
+		dock.show_toast("Smooth failed — face has no displacement", 2)
+
+
+static func on_disp_noise(dock: Object) -> void:
+	if dock == null or not dock.level_root:
+		return
+	if not dock._guard_selection_action(
+		"Noise Displacement", dock.DockSelectionRequirement.BRUSHES_ONLY
+	):
+		return
+	var info: Dictionary = dock._get_selected_face_info()
+	if info.is_empty():
+		dock.show_toast("Select a displaced face first", 1)
+		return
+	var scale: float = dock._disp_strength_spin.value if dock._disp_strength_spin else 1.0
+	var ok: bool = dock._try_undoable_action(
+		"Noise Displacement", "noise_displacement", [info["brush_id"], info["face_index"], scale]
+	)
+	if ok:
+		dock.show_toast("Noise applied to displacement", 0)
+	else:
+		dock.show_toast("Noise failed — face has no displacement", 2)
+
+
+static func on_disp_sew(dock: Object) -> void:
+	if dock == null or not dock.level_root:
+		return
+	# Capture state, execute, then commit undo only if vertices were actually sewn.
+	var pre_state: Dictionary = (
+		dock.level_root.capture_state() if dock.level_root.has_method("capture_state") else {}
+	)
+	var count: int = dock.level_root.sew_all_displacements()
+	if count > 0 and dock.undo_redo and not pre_state.is_empty():
+		var post_state: Dictionary = dock.level_root.capture_state()
+		dock.undo_redo.create_action("Sew Displacements", 0, null, false)
+		dock.undo_redo.add_do_method(dock.level_root, "restore_state", post_state)
+		dock.undo_redo.add_undo_method(dock.level_root, "restore_state", pre_state)
+		dock.undo_redo.commit_action(false)
+		dock.record_history("Sew Displacements")
+	dock.show_toast("Sewn %d boundary vertices" % count, 0)
+
+
+static func on_disp_sew_group_changed(dock: Object, value: float) -> void:
+	if dock == null or not dock.level_root:
+		return
+	if not dock._guard_selection_action(
+		"Edit Displacement Sew Group", dock.DockSelectionRequirement.BRUSHES_ONLY
+	):
+		return
+	var info: Dictionary = dock._get_selected_face_info()
+	if info.is_empty():
+		return
+	if not dock._selected_face_has_displacement(info):
+		return
+	var brush_id: String = info["brush_id"]
+	var face_idx: int = info["face_index"]
+	HFUndoHelper.commit(
+		dock.undo_redo,
+		dock.level_root,
+		"Set Sew Group",
+		"set_displacement_sew_group",
+		[brush_id, face_idx, int(value)],
+		false,
+		Callable(dock, "record_history"),
+		"disp_sew_group_%s_%d" % [brush_id, face_idx]
+	)
+
+
+static func on_bevel_edge(dock: Object) -> void:
+	if dock == null or not dock.level_root:
+		return
+	if not dock._guard_selection_action("Bevel Edge", dock.DockSelectionRequirement.BRUSHES_ONLY):
+		return
+	var plugin_ref = dock.level_root.get_meta("_hf_plugin", null)
+	if not plugin_ref:
+		dock.show_toast("No plugin reference", 2)
+		return
+	if not plugin_ref.get("_vertex_mode") or not dock.level_root.vertex_system:
+		dock.show_toast("Enter vertex/edge mode first (V key)", 1)
+		return
+	var vs = dock.level_root.vertex_system
+	if vs.selected_edges.is_empty():
+		dock.show_toast("Select an edge first (edge sub-mode)", 1)
+		return
+	var segments: int = int(dock._bevel_segments_spin.value) if dock._bevel_segments_spin else 2
+	var radius: float = dock._bevel_radius_spin.value if dock._bevel_radius_spin else 2.0
+	# Capture state once before the batch, call each bevel, track actual successes.
+	var pre_state: Dictionary = (
+		dock.level_root.capture_state() if dock.level_root.has_method("capture_state") else {}
+	)
+	var count := 0
+	for brush_id in vs.selected_edges:
+		var edges: Array = vs.selected_edges[brush_id]
+		for edge in edges:
+			if dock.level_root.bevel_edge(brush_id, edge, segments, radius):
+				count += 1
+	if count > 0:
+		if dock.undo_redo and not pre_state.is_empty():
+			var post_state: Dictionary = dock.level_root.capture_state()
+			dock.undo_redo.create_action("Bevel Edge", 0, null, false)
+			dock.undo_redo.add_do_method(dock.level_root, "restore_state", post_state)
+			dock.undo_redo.add_undo_method(dock.level_root, "restore_state", pre_state)
+			dock.undo_redo.commit_action(false)
+			dock.record_history("Bevel Edge")
+		dock.show_toast("Beveled %d edge(s)" % count, 0)
+	else:
+		dock.show_toast("Bevel failed — check edge selection", 2)
+
+
+static func on_bevel_inset(dock: Object) -> void:
+	if dock == null or not dock.level_root:
+		return
+	if not dock._guard_selection_action("Inset Face", dock.DockSelectionRequirement.BRUSHES_ONLY):
+		return
+	var info: Dictionary = dock._get_selected_face_info()
+	if info.is_empty():
+		dock.show_toast("Select a face first", 1)
+		return
+	var inset_dist: float = (
+		dock._bevel_inset_dist_spin.value if dock._bevel_inset_dist_spin else 2.0
+	)
+	var height: float = (
+		dock._bevel_inset_height_spin.value if dock._bevel_inset_height_spin else 0.0
+	)
+	var pre_state: Dictionary = (
+		dock.level_root.capture_state() if dock.level_root.has_method("capture_state") else {}
+	)
+	var ok: bool = dock.level_root.inset_face(
+		info["brush_id"], info["face_index"], inset_dist, height
+	)
+	if ok:
+		if dock.undo_redo and not pre_state.is_empty():
+			var post_state: Dictionary = dock.level_root.capture_state()
+			dock.undo_redo.create_action("Inset Face", 0, null, false)
+			dock.undo_redo.add_do_method(dock.level_root, "restore_state", post_state)
+			dock.undo_redo.add_undo_method(dock.level_root, "restore_state", pre_state)
+			dock.undo_redo.commit_action(false)
+			dock.record_history("Inset Face")
+		dock.show_toast("Face inset applied", 0)
+	else:
+		dock.show_toast("Inset failed — distance too large or face too small", 2)
+
+
+static func on_hollow(dock: Object) -> void:
+	if dock == null or not dock.level_root or dock._selection_nodes.is_empty():
+		if dock:
+			dock._set_status("Select a brush to hollow", true)
+		return
+	if not dock._guard_selection_action("Hollow", dock.DockSelectionRequirement.BRUSHES_ONLY):
+		return
+	var brush = dock._first_selected_brush()
+	if not brush:
+		dock._set_status("Select a brush to hollow", true)
+		return
+	var info = dock.level_root.get_brush_info_from_node(brush)
+	var brush_id = str(info.get("brush_id", ""))
+	if brush_id == "":
+		return
+	var thickness = dock.hollow_thickness.value if dock.hollow_thickness else 4.0
+	var check: HFOpResult = dock.level_root.can_hollow_brush(brush_id, thickness)
+	if not check.ok:
+		dock.show_toast(check.user_text(), 1)
+		return
+	# Show geometry preview and confirm
+	dock.level_root.hollow_preview.show_preview(brush_id, thickness)
+	var dlg = ConfirmationDialog.new()
+	dlg.title = "Hollow Brush"
+	dlg.dialog_text = (
+		"Hollow with wall thickness %.1f?\n(Yellow wireframe shows resulting walls)" % thickness
+	)
+	dlg.min_size = Vector2i(300, 100)
+	dock.add_child(dlg)
+	dlg.confirmed.connect(
+		func():
+			if not is_instance_valid(dock):
+				return
+			if dock.level_root and dock.level_root.hollow_preview:
+				dock.level_root.hollow_preview.clear()
+			if not dock._guard_selection_action(
+				"Hollow", dock.DockSelectionRequirement.BRUSHES_ONLY
+			):
+				dlg.queue_free()
+				return
+			dock._commit_state_action("Hollow", "hollow_brush_by_id", [brush_id, thickness])
+			dlg.queue_free()
+	)
+	dlg.canceled.connect(
+		func():
+			if not is_instance_valid(dock):
+				return
+			if dock.level_root and dock.level_root.hollow_preview:
+				dock.level_root.hollow_preview.clear()
+			dlg.queue_free()
+	)
+	dlg.popup_centered()
+
+
+static func on_move_to_floor(dock: Object) -> void:
+	if dock == null or not dock.level_root or dock._selection_nodes.is_empty():
+		return
+	if not dock._guard_selection_action(
+		"Move to Floor", dock.DockSelectionRequirement.BRUSHES_ONLY
+	):
+		return
+	var brush_ids: Array = []
+	for node in dock._selection_nodes:
+		if dock.level_root.is_brush_node(node):
+			var info = dock.level_root.get_brush_info_from_node(node)
+			var bid = str(info.get("brush_id", ""))
+			if bid != "":
+				brush_ids.append(bid)
+	if brush_ids.is_empty():
+		return
+	dock._commit_state_action("Move to Floor", "move_brushes_to_floor", [brush_ids])
+
+
+static func on_move_to_ceiling(dock: Object) -> void:
+	if dock == null or not dock.level_root or dock._selection_nodes.is_empty():
+		return
+	if not dock._guard_selection_action(
+		"Move to Ceiling", dock.DockSelectionRequirement.BRUSHES_ONLY
+	):
+		return
+	var brush_ids: Array = []
+	for node in dock._selection_nodes:
+		if dock.level_root.is_brush_node(node):
+			var info = dock.level_root.get_brush_info_from_node(node)
+			var bid = str(info.get("brush_id", ""))
+			if bid != "":
+				brush_ids.append(bid)
+	if brush_ids.is_empty():
+		return
+	dock._commit_state_action("Move to Ceiling", "move_brushes_to_ceiling", [brush_ids])
+
+
+static func on_create_duplicate_array(dock: Object) -> void:
+	if dock == null or not dock.level_root or dock._selection_nodes.is_empty():
+		if dock:
+			dock._set_status("Select brushes first", true)
+		return
+	if not dock._guard_selection_action(
+		"Create Duplicate Array", dock.DockSelectionRequirement.BRUSHES_ONLY
+	):
+		return
+	var brush_ids = PackedStringArray()
+	for node in dock._selection_nodes:
+		if dock.level_root.is_brush_node(node):
+			var info = dock.level_root.get_brush_info_from_node(node)
+			if info and info.has("brush_id"):
+				brush_ids.append(info["brush_id"])
+	if brush_ids.is_empty():
+		dock._set_status("No brushes selected", true)
+		return
+	var cnt = int(dock.dup_count_spin.value) if dock.dup_count_spin else 3
+	var off = Vector3(
+		dock.dup_offset_x.value if dock.dup_offset_x else 8,
+		dock.dup_offset_y.value if dock.dup_offset_y else 0,
+		dock.dup_offset_z.value if dock.dup_offset_z else 0,
+	)
+	dock._commit_state_action(
+		"Create Duplicate Array", "create_duplicate_array", [brush_ids, cnt, off]
+	)
+	dock._set_status("Created %d copies" % cnt)
+
+
+static func on_remove_duplicate_array(dock: Object) -> void:
+	if dock == null or not dock.level_root or dock._selection_nodes.is_empty():
+		if dock:
+			dock._set_status("Select a duplicator source brush", true)
+		return
+	if not dock._guard_selection_action(
+		"Remove Duplicate Array", dock.DockSelectionRequirement.BRUSHES_ONLY
+	):
+		return
+	for node in dock._selection_nodes:
+		if not dock.level_root.is_brush_node(node):
+			continue
+		var dup_id: String = str(node.get_meta("duplicator_id", ""))
+		if dup_id != "":
+			dock._commit_state_action("Remove Duplicate Array", "remove_duplicate_array", [dup_id])
+			dock._set_status("Removed duplicate array")
+			return
+	dock._set_status("Selected brush is not a duplicator source", true)
+
+
+static func on_tie_entity(dock: Object) -> void:
+	if dock == null or not dock.level_root or dock._selection_nodes.is_empty():
+		if dock:
+			dock._set_status("Select brushes to tie", true)
+		return
+	if not dock._guard_selection_action(
+		"Tie to Entity", dock.DockSelectionRequirement.BRUSHES_ONLY
+	):
+		return
+	var class_name_str := "func_detail"
+	if (
+		dock.brush_entity_class_opt
+		and dock.brush_entity_class_opt.item_count > 0
+		and dock.brush_entity_class_opt.selected >= 0
+	):
+		class_name_str = dock.brush_entity_class_opt.get_item_text(
+			dock.brush_entity_class_opt.selected
+		)
+	var brush_ids: Array = []
+	for node in dock._selection_nodes:
+		if dock.level_root.is_brush_node(node):
+			var info = dock.level_root.get_brush_info_from_node(node)
+			var bid = str(info.get("brush_id", ""))
+			if bid != "":
+				brush_ids.append(bid)
+	if brush_ids.is_empty():
+		return
+	dock._commit_state_action("Tie to Entity", "tie_brushes_to_entity", [brush_ids, class_name_str])
+
+
+static func on_untie_entity(dock: Object) -> void:
+	if dock == null or not dock.level_root or dock._selection_nodes.is_empty():
+		return
+	if not dock._guard_selection_action("Untie Entity", dock.DockSelectionRequirement.BRUSHES_ONLY):
+		return
+	var brush_ids: Array = []
+	for node in dock._selection_nodes:
+		if dock.level_root.is_brush_node(node):
+			var info = dock.level_root.get_brush_info_from_node(node)
+			var bid = str(info.get("brush_id", ""))
+			if bid != "":
+				brush_ids.append(bid)
+	if brush_ids.is_empty():
+		return
+	dock._commit_state_action("Untie Entity", "untie_brushes_from_entity", [brush_ids])
+
+
+static func get_hollow_thickness(dock: Object) -> float:
+	if dock == null:
+		return 4.0
+	return dock.hollow_thickness.value if dock.hollow_thickness else 4.0
+
+
+static func on_clip(dock: Object) -> void:
+	if dock == null or not dock.level_root or dock._selection_nodes.is_empty():
+		if dock:
+			dock._set_status("Select a brush to clip", true)
+		return
+	if not dock._guard_selection_action("Clip", dock.DockSelectionRequirement.BRUSHES_ONLY):
+		return
+	var brush = dock._first_selected_brush()
+	if not brush:
+		dock._set_status("Select a brush to clip", true)
+		return
+	var info = dock.level_root.get_brush_info_from_node(brush)
+	var brush_id = str(info.get("brush_id", ""))
+	if brush_id == "":
+		return
+	# Default clip: split along Y axis at center
+	var center = info.get("center", Vector3.ZERO)
+	var split_pos: float = center.y if center is Vector3 else 0.0
+	var check: HFOpResult = dock.level_root.can_clip_brush(brush_id, 1, split_pos)
+	if not check.ok:
+		dock.show_toast(check.user_text(), 1)
+		return
+	# Show geometry preview and confirm
+	dock.level_root.clip_preview.show_preview(brush_id, 1, split_pos)
+	var dlg = ConfirmationDialog.new()
+	dlg.title = "Clip Brush"
+	dlg.dialog_text = (
+		"Split brush along Y axis at %.1f?\n(Cyan wireframe shows resulting pieces)" % split_pos
+	)
+	dlg.min_size = Vector2i(300, 100)
+	dock.add_child(dlg)
+	dlg.confirmed.connect(
+		func():
+			if not is_instance_valid(dock):
+				return
+			if dock.level_root and dock.level_root.clip_preview:
+				dock.level_root.clip_preview.clear()
+			if not dock._guard_selection_action("Clip", dock.DockSelectionRequirement.BRUSHES_ONLY):
+				dlg.queue_free()
+				return
+			dock._commit_state_action("Clip Brush", "clip_brush_by_id", [brush_id, 1, split_pos])
+			dlg.queue_free()
+	)
+	dlg.canceled.connect(
+		func():
+			if not is_instance_valid(dock):
+				return
+			if dock.level_root and dock.level_root.clip_preview:
+				dock.level_root.clip_preview.clear()
+			dlg.queue_free()
+	)
+	dlg.popup_centered()

--- a/tests/test_dock_brush_handler.gd
+++ b/tests/test_dock_brush_handler.gd
@@ -1,0 +1,67 @@
+extends GutTest
+
+const HFDockBrushHandler = preload("res://addons/hammerforge/dock_brush_handler.gd")
+
+
+func test_handlers_are_noop_without_dock():
+	HFDockBrushHandler.on_disp_create(null)
+	HFDockBrushHandler.on_hollow(null)
+	HFDockBrushHandler.on_clip(null)
+	HFDockBrushHandler.on_tie_entity(null)
+	assert_eq(HFDockBrushHandler.get_hollow_thickness(null), 4.0)
+
+
+func test_dock_wrappers_delegate_to_brush_handler():
+	var source := FileAccess.get_file_as_string("res://addons/hammerforge/dock.gd")
+	for method_name in [
+		"_on_disp_create",
+		"_on_disp_destroy",
+		"_on_hollow",
+		"_on_clip",
+		"_on_move_to_floor",
+		"_on_tie_entity",
+		"_on_bevel_edge",
+	]:
+		var block := _function_source(source, method_name)
+		assert_true(
+			block.contains("HFDockBrushHandler."),
+			"%s must delegate to HFDockBrushHandler" % method_name
+		)
+		assert_false(
+			block.contains("_guard_selection_action("),
+			"%s must keep selection guards in the handler" % method_name
+		)
+
+
+func test_brush_handler_keeps_brushes_only_guards():
+	var source := FileAccess.get_file_as_string("res://addons/hammerforge/dock_brush_handler.gd")
+	assert_false(source.is_empty(), "dock_brush_handler.gd must be readable")
+	for method_name in [
+		"on_hollow",
+		"on_clip",
+		"on_move_to_floor",
+		"on_move_to_ceiling",
+		"on_create_duplicate_array",
+		"on_remove_duplicate_array",
+		"on_tie_entity",
+		"on_untie_entity",
+		"on_disp_create",
+		"on_bevel_edge",
+	]:
+		var block := _function_source(source, method_name)
+		assert_true(
+			block.contains("DockSelectionRequirement.BRUSHES_ONLY"),
+			"%s must reject entities instead of filtering them out" % method_name
+		)
+
+
+func _function_source(source: String, function_name: String) -> String:
+	var start := source.find("func %s(" % function_name)
+	if start < 0:
+		return ""
+	var next_function := source.find("\nstatic func ", start + 1)
+	if next_function < 0:
+		next_function = source.find("\nfunc ", start + 1)
+	return (
+		source.substr(start) if next_function < 0 else source.substr(start, next_function - start)
+	)

--- a/tests/test_selection_features.gd
+++ b/tests/test_selection_features.gd
@@ -483,16 +483,17 @@ func test_heterogeneous_managed_selection_disables_type_specific_controls() -> v
 	dock.free()
 
 
-func _dock_or_paint_function_source(
-	dock_source: String, paint_source: String, function_name: String
+func _dock_or_handler_function_source(
+	dock_source: String, handler_sources: Array, function_name: String
 ) -> String:
 	var block := _function_source(dock_source, function_name)
 	if block.contains("_guard_selection_action("):
 		return block
 	var handler_name := function_name.trim_prefix("_")
-	var handler_block := _function_source(paint_source, handler_name)
-	if handler_block != "":
-		return handler_block
+	for handler_source in handler_sources:
+		var handler_block := _function_source(str(handler_source), handler_name)
+		if handler_block != "":
+			return handler_block
 	return block
 
 
@@ -500,7 +501,9 @@ func _function_source(source: String, function_name: String) -> String:
 	var start := source.find("func %s(" % function_name)
 	if start < 0:
 		return ""
-	var next_function := source.find("\nfunc ", start + 1)
+	var next_function := source.find("\nstatic func ", start + 1)
+	if next_function < 0:
+		next_function = source.find("\nfunc ", start + 1)
 	return (
 		source.substr(start) if next_function < 0 else source.substr(start, next_function - start)
 	)
@@ -508,9 +511,10 @@ func _function_source(source: String, function_name: String) -> String:
 
 func test_all_dock_selection_mutators_share_the_scope_guard() -> void:
 	var source := FileAccess.get_file_as_string("res://addons/hammerforge/dock.gd")
-	var paint_source := FileAccess.get_file_as_string(
-		"res://addons/hammerforge/dock_paint_handler.gd"
-	)
+	var handler_sources := [
+		FileAccess.get_file_as_string("res://addons/hammerforge/dock_paint_handler.gd"),
+		FileAccess.get_file_as_string("res://addons/hammerforge/dock_brush_handler.gd"),
+	]
 	var guarded_functions := [
 		"_on_prefab_save_requested",
 		"_on_prefab_save_linked_requested",
@@ -540,7 +544,7 @@ func test_all_dock_selection_mutators_share_the_scope_guard() -> void:
 		"_apply_material_to_whole_brush",
 	]
 	for function_name in guarded_functions:
-		var block := _dock_or_paint_function_source(source, paint_source, function_name)
+		var block := _dock_or_handler_function_source(source, handler_sources, function_name)
 		assert_ne(block, "", "%s must exist" % function_name)
 		assert_true(
 			block.contains("_guard_selection_action("),
@@ -562,7 +566,7 @@ func test_all_dock_selection_mutators_share_the_scope_guard() -> void:
 		"_apply_material_to_whole_brush",
 	]:
 		assert_true(
-			_dock_or_paint_function_source(source, paint_source, function_name).contains(
+			_dock_or_handler_function_source(source, handler_sources, function_name).contains(
 				"DockSelectionRequirement.BRUSHES_ONLY"
 			),
 			"%s must reject entities instead of filtering them out" % function_name,


### PR DESCRIPTION
Next ROADMAP dock split after Paint. Displacement, bevel, hollow, clip, floor/ceiling, duplicate-array, and tie/untie dock methods now live in `HFDockBrushHandler`. `dock.gd` keeps thin wrappers so existing call sites and selection-guard tests still apply.

- No behavior change
- `tests/test_dock_brush_handler.gd` checks wrappers and `BRUSHES_ONLY` guards
- `test_selection_features.gd` now scans both paint and brush handler files
- Local `gdformat`/`gdlint` clean; GUT `test_dock_brush` and `test_selection_features` passed