### PR TITLE
Query entities_node in has_entity_container

### DIFF
--- a/addons/hammerforge/hf_validation.gd
+++ b/addons/hammerforge/hf_validation.gd
@@ -31,7 +31,7 @@ static func has_draft_containers(root: Object) -> bool:
 static func has_entity_container(root: Object) -> bool:
 	if not is_valid_root(root):
 		return false
-	var v = root.get("draft_entities_node")
+	var v = root.get("entities_node")
 	return v != null and is_instance_valid(v)
 
 

--- a/tests/test_hf_validation.gd
+++ b/tests/test_hf_validation.gd
@@ -27,7 +27,7 @@ func _root_shim_script() -> GDScript:
 		"extends Node3D\n"
 		+ "var draft_brushes_node: Node3D\n"
 		+ "var pending_node: Node3D\n"
-		+ "var draft_entities_node: Node3D\n"
+		+ "var entities_node: Node3D\n"
 		+ "var baked_container: Node3D\n"
 	)
 	s.reload()
@@ -55,7 +55,7 @@ func test_has_entity_container_false_until_set():
 	assert_false(HFValidation.has_entity_container(root))
 	var ent = Node3D.new()
 	root.add_child(ent)
-	root.draft_entities_node = ent
+	root.entities_node = ent
 	assert_true(HFValidation.has_entity_container(root))
 
 


### PR DESCRIPTION
#43

`HFValidation.has_entity_container` now reads `entities_node`, the name LevelRoot actually uses. The validation test shim matches that property.

Fixes #43