### PR TITLE
Scan brush entities for I/O outputs

### DIFF
--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -2006,12 +2006,9 @@ func export_playtest_scene(path: String) -> bool:
 	scene_root.add_child(env)
 	env.owner = scene_root
 
-	# Wire entity I/O connections into Godot signals
-	var has_io := false
-	for child in scene_root.get_children():
-		if not child.get_meta("entity_io_outputs", []).is_empty():
-			has_io = true
-			break
+	# Wire entity I/O connections into Godot signals. Trigger volumes sit
+	# under a Nonstructural holder, so scan the packed tree, not only roots.
+	var has_io := _node_tree_has_io(scene_root)
 	if has_io:
 		var io_dispatcher := HFIORuntime.new()
 		io_dispatcher.name = "HFIODispatcher"
@@ -2032,6 +2029,15 @@ func export_playtest_scene(path: String) -> bool:
 		return false
 
 	return true
+
+
+func _node_tree_has_io(node: Node) -> bool:
+	if not node.get_meta("entity_io_outputs", []).is_empty():
+		return true
+	for child in node.get_children():
+		if _node_tree_has_io(child):
+			return true
+	return false
 
 
 # ===========================================================================

--- a/addons/hammerforge/systems/hf_bake_system.gd
+++ b/addons/hammerforge/systems/hf_bake_system.gd
@@ -790,32 +790,37 @@ func postprocess_bake(
 ## connections are wired as live Godot signals at runtime.  The dispatcher is
 ## parented under the baked container but also scans entities_node (a sibling
 ## subtree) via extra_scan_roots.
-func _attach_io_dispatcher(container: Node3D) -> void:
-	# Only attach if there are entities with I/O connections
-	if not root.entities_node:
-		return
-	var has_io := false
-	for child in root.entities_node.get_children():
+func _direct_child_has_io(parent: Node) -> bool:
+	if not parent:
+		return false
+	for child in parent.get_children():
 		if not child.get_meta("entity_io_outputs", []).is_empty():
-			has_io = true
-			break
+			return true
+	return false
+
+
+func _attach_io_dispatcher(container: Node3D) -> void:
+	# Point entities and brush entities (triggers, buttons) both store outputs.
+	var has_io := (
+		_direct_child_has_io(root.entities_node) or _direct_child_has_io(root.draft_brushes_node)
+	)
 	if not has_io:
 		return
 	# Remove any existing dispatcher
-	var existing: Node = container.find_child("HFIODispatcher", false)
+	var existing: Node = container.get_node_or_null("HFIODispatcher")
 	if existing:
 		container.remove_child(existing)
 		existing.free()
 	var dispatcher := HFIORuntime.new()
 	dispatcher.name = "HFIODispatcher"
-	# The dispatcher lives under the baked container, but entities live under
-	# root.entities_node (a sibling).  Tell it to scan both subtrees.
-	# Set the transient ref for the live session:
-	dispatcher.extra_scan_roots.append(root.entities_node)
+	# The dispatcher lives under the baked container, but point entities live
+	# under root.entities_node (a sibling). Tell it to scan that subtree too.
+	if root.entities_node:
+		dispatcher.extra_scan_roots.append(root.entities_node)
 	container.add_child(dispatcher)
-	# Also store the serializable NodePath so the scan survives scene save/reload:
-	var entities_path: NodePath = dispatcher.get_path_to(root.entities_node)
-	dispatcher.extra_scan_root_paths.append(entities_path)
+	if root.entities_node:
+		var entities_path: NodePath = dispatcher.get_path_to(root.entities_node)
+		dispatcher.extra_scan_root_paths.append(entities_path)
 	root._assign_owner_recursive(dispatcher)
 
 

--- a/addons/hammerforge/systems/hf_entity_system.gd
+++ b/addons/hammerforge/systems/hf_entity_system.gd
@@ -288,9 +288,9 @@ func get_entity_outputs(entity: Node) -> Array:
 ## Returns the number of connections removed.
 func cleanup_dangling_connections(deleted_name: String) -> int:
 	var removed := 0
-	if deleted_name == "" or not root.entities_node:
+	if deleted_name == "":
 		return removed
-	for child in root.entities_node.get_children():
+	for child in _iter_io_sources():
 		var outputs: Array = child.get_meta("entity_io_outputs", [])
 		if outputs.is_empty():
 			continue
@@ -354,10 +354,10 @@ func reconcile_external_names(previous_names: Dictionary, current_names: Diction
 			and owners.has(instance_id)
 		):
 			name_map[old_name] = new_name
-	if name_map.is_empty() or not root.entities_node:
+	if name_map.is_empty():
 		return 0
 	var remapped := 0
-	for source in root.entities_node.get_children():
+	for source in _iter_io_sources():
 		var outputs: Array = source.get_meta("entity_io_outputs", [])
 		for connection in outputs:
 			if connection is Dictionary and name_map.has(str(connection.get("target_name", ""))):
@@ -398,12 +398,19 @@ static func is_brush_io_target(node: Node) -> bool:
 	)
 
 
+func _iter_io_sources() -> Array:
+	var nodes: Array = []
+	if root.entities_node:
+		nodes.append_array(root.entities_node.get_children())
+	if root.draft_brushes_node:
+		nodes.append_array(root.draft_brushes_node.get_children())
+	return nodes
+
+
 ## Get all I/O connections in the scene (for visualization).
 func get_all_connections() -> Array:
 	var connections: Array = []
-	if not root.entities_node:
-		return connections
-	for child in root.entities_node.get_children():
+	for child in _iter_io_sources():
 		var outputs = get_entity_outputs(child)
 		for conn in outputs:
 			if not (conn is Dictionary):

--- a/tests/test_bake_system.gd
+++ b/tests/test_bake_system.gd
@@ -2346,6 +2346,28 @@ func test_append_trigger_creates_area_volume():
 	assert_eq(str(outputs[0].get("output_name", "")), "OnTrigger")
 
 
+func test_attach_io_dispatcher_when_only_brush_entity_has_outputs():
+	var trigger := _make_brush(root.draft_brushes_node)
+	trigger.set_meta("brush_entity_class", "trigger_once")
+	trigger.set_meta(
+		"entity_io_outputs",
+		[{"output_name": "OnTrigger", "target_name": "door", "input_name": "Open"}]
+	)
+	var container := Node3D.new()
+	add_child_autoqfree(container)
+	bake_sys._attach_io_dispatcher(container)
+	var dispatcher: Node = container.get_node_or_null("HFIODispatcher")
+	assert_not_null(dispatcher, "Brush-only I/O should still attach HFIORuntime")
+
+
+func test_attach_io_dispatcher_skips_when_no_outputs():
+	_make_brush(root.draft_brushes_node)
+	var container := Node3D.new()
+	add_child_autoqfree(container)
+	bake_sys._attach_io_dispatcher(container)
+	assert_null(container.get_node_or_null("HFIODispatcher"))
+
+
 func test_append_skips_worldspawn_brushes():
 	_make_brush(root.draft_brushes_node)
 	var container := Node3D.new()

--- a/tests/test_entity_io.gd
+++ b/tests/test_entity_io.gd
@@ -243,6 +243,53 @@ func test_get_all_connections_includes_source_info():
 	assert_true(conn["fire_once"])
 
 
+func _make_brush_entity(entity_name: String, entity_class: String = "trigger_once") -> DraftBrush:
+	var brush := DraftBrush.new()
+	brush.name = entity_name
+	brush.set_meta("brush_entity_class", entity_class)
+	root.draft_brushes_node.add_child(brush)
+	return brush
+
+
+func test_get_all_connections_includes_brush_entity_outputs():
+	var brush := _make_brush_entity("trigger_once")
+	sys.add_entity_output(brush, "OnTrigger", "door_1", "Open")
+	var conns = sys.get_all_connections()
+	assert_eq(conns.size(), 1, "Brush entity outputs should be listed")
+	assert_eq(conns[0]["source"], brush)
+	assert_eq(conns[0]["source_name"], "trigger_once")
+	assert_eq(conns[0]["target_name"], "door_1")
+
+
+func test_cleanup_dangling_connections_from_brush_entity():
+	var brush := _make_brush_entity("trigger_once")
+	sys.add_entity_output(brush, "OnTrigger", "door_1", "Open")
+	sys.add_entity_output(brush, "OnTrigger", "light_1", "TurnOn")
+	var removed := sys.cleanup_dangling_connections("door_1")
+	assert_eq(removed, 1)
+	var outputs = sys.get_entity_outputs(brush)
+	assert_eq(outputs.size(), 1)
+	assert_eq(outputs[0]["target_name"], "light_1")
+
+
+func test_reconcile_external_names_remaps_brush_entity_outputs():
+	var brush := _make_brush_entity("trigger_once")
+	var target := _make_entity("Door")
+	sys.add_entity_output(brush, "OnTrigger", "Door", "Open")
+	target.name = "MainDoor"
+	assert_eq(
+		(
+			sys
+			. reconcile_external_names(
+				{target.get_instance_id(): "Door"},
+				{target.get_instance_id(): "MainDoor"},
+			)
+		),
+		1,
+	)
+	assert_eq(sys.get_entity_outputs(brush)[0]["target_name"], "MainDoor")
+
+
 # ===========================================================================
 # Serialization round-trip
 # ===========================================================================

--- a/tests/test_export_playtest.gd
+++ b/tests/test_export_playtest.gd
@@ -63,3 +63,29 @@ func test_export_playtest_scene_includes_environment():
 		assert_true(has_env, "Should have a WorldEnvironment")
 		scene.free()
 	DirAccess.remove_absolute(path)
+
+
+func test_export_playtest_scene_wires_nested_brush_io():
+	var baked := Node3D.new()
+	baked.name = "BakedGeometry"
+	root.add_child(baked)
+	root.baked_container = baked
+	var holder := Node3D.new()
+	holder.name = "Nonstructural"
+	baked.add_child(holder)
+	var trigger := Area3D.new()
+	trigger.name = "Trigger_0"
+	trigger.set_meta(
+		"entity_io_outputs",
+		[{"output_name": "OnTrigger", "target_name": "door", "input_name": "Open"}]
+	)
+	holder.add_child(trigger)
+	var path := "user://test_playtest_nested_io.tscn"
+	assert_true(root.export_playtest_scene(path))
+	var packed: PackedScene = ResourceLoader.load(path)
+	assert_not_null(packed)
+	var scene: Node = packed.instantiate()
+	var dispatcher: Node = scene.find_child("HFIODispatcher", true, false)
+	assert_not_null(dispatcher, "Nested trigger I/O should attach HFIORuntime")
+	scene.free()
+	DirAccess.remove_absolute(path)


### PR DESCRIPTION
#44

Bake now attaches HFIORuntime when only trigger brushes have outputs. Connection list, dangling cleanup, and rename remap also scan draft brushes. Test Level export walks nested trigger volumes.

Fixes #44