### PR TITLE
Own nested playtest export nodes and add a player

### DIFF
--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -1964,7 +1964,7 @@ func export_playtest_scene(path: String) -> bool:
 			if child is Node3D:
 				var dup = child.duplicate()
 				scene_root.add_child(dup)
-				dup.owner = scene_root
+				_own_tree(dup, scene_root)
 
 	# Copy entities (spawn points, lights, etc.)
 	if entities_node:
@@ -1972,14 +1972,14 @@ func export_playtest_scene(path: String) -> bool:
 			if child is Node3D:
 				var dup = child.duplicate()
 				scene_root.add_child(dup)
-				dup.owner = scene_root
+				_own_tree(dup, scene_root)
 
 	# Copy DefaultSun if it exists (created by New HammerForge Level)
 	var default_sun = get_node_or_null("DefaultSun") as DirectionalLight3D
 	if default_sun:
 		var sun_dup = default_sun.duplicate()
 		scene_root.add_child(sun_dup)
-		sun_dup.owner = scene_root
+		_own_tree(sun_dup, scene_root)
 
 	# Add fallback light only if nothing provides one
 	var has_light := false
@@ -2013,7 +2013,14 @@ func export_playtest_scene(path: String) -> bool:
 		var io_dispatcher := HFIORuntime.new()
 		io_dispatcher.name = "HFIODispatcher"
 		scene_root.add_child(io_dispatcher)
-		io_dispatcher.owner = scene_root
+		_own_tree(io_dispatcher, scene_root)
+
+	var player := _make_playtest_player()
+	scene_root.add_child(player)
+	var pose := _resolve_playtest_spawn()
+	player.position = pose["position"]
+	player.rotation.y = pose["yaw"]
+	_own_tree(player, scene_root)
 
 	# Pack and save
 	var packed := PackedScene.new()
@@ -2038,6 +2045,48 @@ func _node_tree_has_io(node: Node) -> bool:
 		if _node_tree_has_io(child):
 			return true
 	return false
+
+
+func _own_tree(node: Node, scene_owner: Node) -> void:
+	if not node:
+		return
+	node.owner = scene_owner
+	for child in node.get_children():
+		_own_tree(child, scene_owner)
+
+
+func _resolve_playtest_spawn() -> Dictionary:
+	var spawn: Node3D = null
+	var spawn_yaw := 0.0
+	if spawn_system:
+		spawn = spawn_system.get_active_spawn()
+	if not spawn:
+		for node in _iter_pick_nodes():
+			if node is DraftEntity:
+				var draft_entity := node as DraftEntity
+				var ec := draft_entity.entity_class
+				if ec == "":
+					ec = draft_entity.entity_type
+				if ec == "player_start":
+					spawn = draft_entity
+					break
+	var spawn_pos := Vector3(0, 2, 0)
+	var found_spawn := spawn != null
+	var height_offset := 1.0
+	if found_spawn:
+		spawn_pos = (spawn.global_position if spawn.is_inside_tree() else spawn.position)
+		if spawn is DraftEntity:
+			spawn_yaw = deg_to_rad(float(spawn.entity_data.get("angle", 0.0)))
+			height_offset = float(spawn.entity_data.get("height_offset", 1.0))
+	var offset := Vector3(0, height_offset, 0) if found_spawn else Vector3.ZERO
+	return {"position": spawn_pos + offset, "yaw": spawn_yaw if found_spawn else 0.0}
+
+
+func _make_playtest_player() -> CharacterBody3D:
+	var player := CharacterBody3D.new()
+	player.name = "PlaytestPlayer"
+	player.set_script(PlaytestFPS)
+	return player
 
 
 # ===========================================================================
@@ -2501,39 +2550,11 @@ func _start_playtest() -> void:
 		if pending_node:
 			pending_node.visible = false
 
-	var spawn: Node3D = null
-	var spawn_yaw := 0.0
-	if spawn_system:
-		spawn = spawn_system.get_active_spawn()
-	if not spawn:
-		# Legacy fallback — scan entities directly
-		for node in _iter_pick_nodes():
-			if node is DraftEntity:
-				var draft_entity := node as DraftEntity
-				var ec := draft_entity.entity_class
-				if ec == "":
-					ec = draft_entity.entity_type
-				if ec == "player_start":
-					spawn = draft_entity
-					break
-
-	var spawn_pos := Vector3(0, 2, 0)
-	var found_spawn := spawn != null
-	var height_offset := 1.0
-	if found_spawn:
-		spawn_pos = (spawn.global_position if spawn.is_inside_tree() else spawn.position)
-		if spawn is DraftEntity:
-			spawn_yaw = deg_to_rad(float(spawn.entity_data.get("angle", 0.0)))
-			height_offset = float(spawn.entity_data.get("height_offset", 1.0))
-
-	var player = CharacterBody3D.new()
-	player.name = "PlaytestPlayer"
-	player.set_script(PlaytestFPS)
-	var offset = Vector3(0, height_offset, 0) if found_spawn else Vector3.ZERO
+	var pose := _resolve_playtest_spawn()
+	var player := _make_playtest_player()
 	add_child(player)
-	player.global_position = spawn_pos + offset
-	if found_spawn:
-		player.rotation.y = spawn_yaw
+	player.global_position = pose["position"]
+	player.rotation.y = pose["yaw"]
 
 
 # ===========================================================================

--- a/tests/test_export_playtest.gd
+++ b/tests/test_export_playtest.gd
@@ -65,6 +65,53 @@ func test_export_playtest_scene_includes_environment():
 	DirAccess.remove_absolute(path)
 
 
+func test_export_playtest_scene_includes_player():
+	var path := "user://test_playtest_player.tscn"
+	assert_true(root.export_playtest_scene(path))
+	var packed: PackedScene = ResourceLoader.load(path)
+	assert_not_null(packed)
+	var scene: Node = packed.instantiate()
+	add_child_autoqfree(scene)
+	var player: Node = scene.get_node_or_null("PlaytestPlayer")
+	assert_not_null(player, "Exported scene needs a PlaytestPlayer")
+	if player == null:
+		return
+	assert_true(player is CharacterBody3D)
+	assert_not_null(player.get_script(), "PlaytestPlayer needs PlaytestFPS")
+	var camera: Node = scene.find_child("MainCamera", true, false)
+	assert_not_null(camera, "PlaytestPlayer should create a camera at runtime")
+
+
+func test_export_playtest_scene_keeps_nested_baked_geometry():
+	var baked := Node3D.new()
+	baked.name = "BakedGeometry"
+	root.add_child(baked)
+	root.baked_container = baked
+	var chunk := Node3D.new()
+	chunk.name = "BakedChunk_0"
+	baked.add_child(chunk)
+	var mesh := MeshInstance3D.new()
+	mesh.name = "NestedMesh"
+	mesh.mesh = BoxMesh.new()
+	chunk.add_child(mesh)
+	var body := StaticBody3D.new()
+	body.name = "Collision"
+	chunk.add_child(body)
+	var col := CollisionShape3D.new()
+	col.name = "Shape"
+	col.shape = BoxShape3D.new()
+	body.add_child(col)
+	var path := "user://test_playtest_nested_geo.tscn"
+	assert_true(root.export_playtest_scene(path))
+	var packed: PackedScene = ResourceLoader.load(path)
+	assert_not_null(packed)
+	var scene: Node = packed.instantiate()
+	assert_not_null(scene.find_child("NestedMesh", true, false), "Nested mesh must survive pack")
+	assert_not_null(scene.find_child("Shape", true, false), "Nested collision must survive pack")
+	scene.free()
+	DirAccess.remove_absolute(path)
+
+
 func test_export_playtest_scene_wires_nested_brush_io():
 	var baked := Node3D.new()
 	baked.name = "BakedGeometry"


### PR DESCRIPTION
#48 #49

Export Playtest now packs a PlaytestPlayer using the same spawn pose as Test Level. Duplicated baked and entity trees get recursive owners so nested mesh and collision survive pack.

Fixes #48
Fixes #49