### PR TITLE
Preserve transforms across bake and playtest export

### DIFF
--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -1964,6 +1964,7 @@ func export_playtest_scene(path: String) -> bool:
 			if child is Node3D:
 				var dup = child.duplicate()
 				scene_root.add_child(dup)
+				dup.transform = child.global_transform
 				_own_tree(dup, scene_root)
 
 	# Copy entities (spawn points, lights, etc.)
@@ -1972,6 +1973,7 @@ func export_playtest_scene(path: String) -> bool:
 			if child is Node3D:
 				var dup = child.duplicate()
 				scene_root.add_child(dup)
+				dup.transform = child.global_transform
 				_own_tree(dup, scene_root)
 
 	# Copy DefaultSun if it exists (created by New HammerForge Level)
@@ -1979,6 +1981,7 @@ func export_playtest_scene(path: String) -> bool:
 	if default_sun:
 		var sun_dup = default_sun.duplicate()
 		scene_root.add_child(sun_dup)
+		sun_dup.transform = default_sun.global_transform
 		_own_tree(sun_dup, scene_root)
 
 	# Add fallback light only if nothing provides one

--- a/addons/hammerforge/systems/hf_bake_system.gd
+++ b/addons/hammerforge/systems/hf_bake_system.gd
@@ -1608,12 +1608,12 @@ func _consolidate_to_multimesh(container: Node3D) -> void:
 			continue
 		# Build MultiMesh
 		var mm = MultiMesh.new()
-		mm.mesh = mesh_key
 		mm.transform_format = MultiMesh.TRANSFORM_3D
+		mm.mesh = mesh_key
 		mm.instance_count = instances.size()
 		for i in range(instances.size()):
 			var mi: MeshInstance3D = instances[i]
-			mm.set_instance_transform(i, mi.global_transform)
+			mm.set_instance_transform(i, _multimesh_transform(mi, container))
 		# Carry material from first instance
 		var mmi = MultiMeshInstance3D.new()
 		mmi.multimesh = mm
@@ -1633,6 +1633,10 @@ func _consolidate_to_multimesh(container: Node3D) -> void:
 		consolidated += 1
 	if consolidated > 0:
 		root._log("MultiMesh: consolidated %d groups" % consolidated)
+
+
+static func _multimesh_transform(instance: Node3D, container: Node3D) -> Transform3D:
+	return container.global_transform.affine_inverse() * instance.global_transform
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bake_system.gd
+++ b/tests/test_bake_system.gd
@@ -902,6 +902,49 @@ func test_apply_preview_visuals_multimesh_in_chunk():
 	)
 
 
+func test_multimesh_consolidation_preserves_world_transforms():
+	root.position = Vector3(100, 0, 0)
+	root.rotation_degrees = Vector3(0, 30, 0)
+	var container := Node3D.new()
+	container.position = Vector3(10, 0, 0)
+	container.rotation_degrees = Vector3(0, 15, 0)
+	root.add_child(container)
+	var shared_mesh := BoxMesh.new()
+	var first := MeshInstance3D.new()
+	first.mesh = shared_mesh
+	first.position = Vector3(1, 2, 3)
+	first.scale = Vector3(2, 1, 1)
+	container.add_child(first)
+	var second := MeshInstance3D.new()
+	second.mesh = shared_mesh
+	second.position = Vector3(4, 5, 6)
+	container.add_child(second)
+	var expected := [first.global_transform, second.global_transform]
+	assert_true(
+		(
+			(container.global_transform * HFBakeSystem._multimesh_transform(first, container))
+			. is_equal_approx(expected[0])
+		)
+	)
+	assert_true(
+		(
+			(container.global_transform * HFBakeSystem._multimesh_transform(second, container))
+			. is_equal_approx(expected[1])
+		)
+	)
+	bake_sys._consolidate_to_multimesh(container)
+	var mmi: MultiMeshInstance3D = null
+	for child in container.get_children():
+		if child is MultiMeshInstance3D:
+			mmi = child
+			break
+	assert_not_null(mmi)
+	if mmi == null:
+		return
+	assert_eq(mmi.multimesh.transform_format, MultiMesh.TRANSFORM_3D)
+	assert_eq(mmi.multimesh.instance_count, 2)
+
+
 func test_apply_preview_visuals_full_mode_skips_chunks():
 	## Full mode should not apply any override, even to nested children.
 	var container = Node3D.new()

--- a/tests/test_export_playtest.gd
+++ b/tests/test_export_playtest.gd
@@ -112,6 +112,49 @@ func test_export_playtest_scene_keeps_nested_baked_geometry():
 	DirAccess.remove_absolute(path)
 
 
+func test_export_playtest_scene_preserves_source_world_transforms():
+	root.position = Vector3(100, 0, 0)
+	root.rotation_degrees = Vector3(0, 30, 0)
+	root.scale = Vector3(1.5, 1.5, 1.5)
+	var baked := Node3D.new()
+	baked.name = "BakedGeometry"
+	baked.position = Vector3(10, 0, 0)
+	baked.rotation_degrees = Vector3(0, 15, 0)
+	root.add_child(baked)
+	root.baked_container = baked
+	var chunk := Node3D.new()
+	chunk.name = "MovedChunk"
+	chunk.position = Vector3(1, 0, 0)
+	baked.add_child(chunk)
+	var mesh := MeshInstance3D.new()
+	mesh.name = "MovedMesh"
+	mesh.position = Vector3(2, 0, 0)
+	mesh.scale = Vector3(2, 1, 1)
+	mesh.mesh = BoxMesh.new()
+	chunk.add_child(mesh)
+	var entity := Node3D.new()
+	entity.name = "MovedEntity"
+	entity.position = Vector3(3, 0, 0)
+	root.entities_node.position = Vector3(20, 0, 0)
+	root.entities_node.add_child(entity)
+	var expected_mesh_transform := mesh.global_transform
+	var expected_entity_transform := entity.global_transform
+	var path := "user://test_playtest_transforms.tscn"
+	assert_true(root.export_playtest_scene(path))
+	var packed: PackedScene = ResourceLoader.load(path)
+	assert_not_null(packed)
+	var scene: Node = packed.instantiate()
+	add_child_autoqfree(scene)
+	var exported_mesh := scene.find_child("MovedMesh", true, false) as Node3D
+	var exported_entity := scene.find_child("MovedEntity", true, false) as Node3D
+	assert_not_null(exported_mesh)
+	assert_not_null(exported_entity)
+	if exported_mesh and exported_entity:
+		assert_true(exported_mesh.global_transform.is_equal_approx(expected_mesh_transform))
+		assert_true(exported_entity.global_transform.is_equal_approx(expected_entity_transform))
+	DirAccess.remove_absolute(path)
+
+
 func test_export_playtest_scene_wires_nested_brush_io():
 	var baked := Node3D.new()
 	baked.name = "BakedGeometry"


### PR DESCRIPTION
- Preserve baked geometry, entity, and sun transforms in exported playtest scenes.
- Store MultiMesh instances in baked container space and set the 3D format before allocation.
- Cover translated, rotated, and scaled parents in focused tests.

Fixes #49
Fixes #50
