### PR TITLE
Refresh project documentation and roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 - **Snap-to-perpendicular** (dock **P**): drop the cursor onto the closest point on a brush AABB edge, so offsets stay 90° to that edge.
 
 ### Fixed
+- **Playtest exports are complete and playable:** exported scenes include `PlaytestPlayer` at the active spawn pose, keep nested baked mesh/collision and brush I/O nodes through recursive ownership, and preserve source transforms when moving baked trees, entities, and `DefaultSun` under the packed scene root.
+- **MultiMesh bake keeps instance placement:** source transforms are converted into baked-container space, and `TRANSFORM_3D` is selected before instance allocation.
+- **Brush entity I/O participates everywhere:** bake dispatcher detection, exported-scene detection, connection listing, dangling cleanup, and target rename reconciliation all include tied brush entities.
+- **Entity container validation uses the real LevelRoot property:** `HFValidation.has_entity_container()` now checks `entities_node`.
+- **Polygon height and path trim edge cases:** downward polygon height input stays positive, and auto-trim can assign material palette slot 0.
 - **Tied `func_detail` / trigger brushes bake again:** they stay out of world CSG, then a post-pass emits detail meshes + collision and trigger `Area3D` volumes (including copied I/O metadata).
 - **`.map` brush entities round-trip:** `func_detail` / `func_wall` / triggers export as their own entity blocks and import with `brush_entity_class` set.
 - **`.map` point entities keep their keys:** export writes `entity_data` (angle, targetname, etc.) alongside classname/origin.
@@ -22,6 +27,7 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 - **History thumbnails skip GPU readback** when the History section is hidden, and new rows append instead of rebuilding the list.
 
 ### Changed
+- **Project documentation matches current `main`:** user-facing tab names, snap modes, playtest export behavior, architecture notes, roadmap priorities, and verified CI totals now agree across the README, guides, spec, and checklists.
 - **Merged-mesh bake uses `WorkerThreadPool`** when `bake_use_thread_pool` is on. Surface grouping/transforms run on a worker; `ArrayMesh` assembly stays on the main thread.
 - **`.hflevel` stringify/hash/compress run on the write thread.** Capture stays on the main thread; unchanged captures skip the disk rewrite once the hash settles.
 - **Test-tab bake/play handlers live in `dock_manage_handler.gd`:** bake, validate, Test Level, spawn, and playtest dock methods are thin wrappers around `HFDockManageHandler`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,14 @@ Thanks for helping improve HammerForge.
 3. Update docs and tests when behavior changes.
 4. Run formatting, lint, and test checks before submitting (see below).
 
+## Documentation Expectations
+- Use the displayed UI names—**Build**, **Paint**, **Objects**, and **Test**—in user-facing instructions. Legacy `entity_*` and `manage_*` filenames may be named when explaining internals.
+- Verify behavior claims against current code and tests. Do not copy test totals or source line counts from an older document.
+- Update the README, relevant guide/spec, roadmap status, and `[Unreleased]` changelog together when a change affects users or contributors.
+- Only publish aggregate test totals from a successful full CI run; include the verification date so readers can distinguish a measured snapshot from a permanent guarantee.
+- Check relative Markdown links and `git diff --check` before submitting documentation-only changes.
+- Describe known limitations plainly and link the tracking issue instead of implying unfinished safety or fidelity work is complete.
+
 ## Code Expectations
 - Follow the subsystem architecture (LevelRoot is the public API).
 - Prefer undo actions that use stable IDs and state snapshots. Use `collation_tag` for rapid operations.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development Guide
 
-Last updated: July 21, 2026
+Last updated: September 2, 2026
 
 This document covers local setup, codebase structure, and how to test features.
 
@@ -30,7 +30,7 @@ addons/hammerforge/
   plugin_input_router.gd Viewport keymap dispatch (delete/nudge/tools/paint/axis lock)
   plugin_vertex_input.gd Vertex/edge pick, drag, merge, and split dispatch
   plugin_hud.gd          HUD context, mode banner, and context-toolbar state
-  level_root.gd          Coordinator (~2,200 lines), delegates to subsystems
+  level_root.gd          Coordinator (2,844 lines), delegates to subsystems
   input_state.gd         Drag/paint state machine (HFInputState)
   hf_selection_gesture.gd Select-mode LMB arbiter (native object selection, face marquee, gizmos)
   dock.gd + dock.tscn    UI dock (displayed as Build, Paint, Objects, Test), collapsible sections with persisted state
@@ -59,7 +59,7 @@ addons/hammerforge/
   hf_path_tool.gd        Path tool (waypoints → corridor brushes with miter joints, stairs, railings, trim, tool_id=103)
   hf_keymap.gd           Customizable keyboard shortcuts (JSON load/save, action matching, 5 categories: Tools/Editing/Selection/Paint/Axis Lock)
   hf_user_prefs.gd       Cross-session user preferences (user://hammerforge_prefs.json)
-  hf_snap_system.gd      Centralized snap (Grid/Vertex/Center modes + custom snap lines, threshold-based candidates)
+  hf_snap_system.gd      Centralized snap (Grid/Vertex/Center/Edge/Perpendicular + custom snap lines, threshold-based candidates)
   hf_prefab.gd           Reusable brush+entity groups (variants, tags, save/load .hfprefab)
   hf_op_result.gd        Lightweight operation result (ok, message, fix_hint)
   undo_helper.gd         HFUndoHelper: state-capture undo with collation (merges rapid edits into one step)
@@ -238,8 +238,8 @@ addons/hammerforge/
 - **Theme-aware UI.** All custom panels (context toolbar, coach marks, hotkey palette, operation replay, toasts, selection filter) use `HFThemeUtils` static methods (`panel_bg()`, `muted_text()`, `accent()`, etc.) instead of hardcoded colors. Each component provides a `refresh_theme_colors()` method called from `plugin.gd:_on_editor_theme_changed()`. `HFThemeUtils.is_dark_theme()` reads `interface/theme/base_color` luminance from `EditorInterface.get_editor_settings()`.
 - **History browser.** `ui/hf_history_browser.gd` replaces the plain ItemList in the displayed Test tab History section. Records entries via `record_entry(name, version, undo_redo)` with viewport thumbnail capture. Double-click emits `navigate_requested(version)` which `dock._on_history_navigate()` handles by looping undo/redo to the target version. Undo/redo buttons are exposed via `get_undo_button()`/`get_redo_button()`. `dock._refresh_history_list()` wraps ItemList code in `if history_list:` and always calls `_update_history_buttons()`.
 - **Multi-ruler measure tool.** `hf_measure_tool.gd` stores up to 20 rulers in `_measurements: Array[Dictionary]`. Shift+Click chains from the last endpoint; Ctrl+Click sets a snap reference through `HFSnapSystem.set_custom_snap_line()`. Plain RMB is reserved for native camera navigation. Angles are computed at shared vertices via `dir_a.angle_to(dir_b)`. `_finish_ruler()` adjusts `_snap_ref_index` on rollover (decrement if after evicted, clear if evicted).
-- **Export playtest.** `dock._on_export_playtest()` validates spawn, auto-creates if missing (with full undo via state capture before `create_default_spawn()`), bakes, calls `level_root.export_playtest_scene()` to pack baked + entities + default lighting into a `.tscn`, then launches via `play_custom_scene()`.
-- **Geometry-aware snapping.** `_snap_point()` delegates to `HFSnapSystem`. Three modes (Grid=1, Vertex=2, Center=4) as a bitmask. Custom snap lines (set via `set_custom_snap_line()`) are checked alongside grid/geometry candidates. Vertex mode collects 8 box corners from all brushes; Center mode collects brush centers. Closest candidate within `snap_threshold` beats grid snap. Pass `exclude_ids` to skip the brush being dragged.
+- **Export playtest.** `dock._on_export_playtest()` validates spawn, auto-creates if missing (with full undo via state capture before `create_default_spawn()`), bakes, calls `level_root.export_playtest_scene()`, then launches via `play_custom_scene()`. The packed scene contains a player controller at the active spawn, baked output, point and brush entities, default lighting/environment, and an I/O dispatcher when needed. Recursive owner assignment preserves nested geometry/collision in the `.tscn`; reparented content preserves its global transform.
+- **Geometry-aware snapping.** `_snap_point()` delegates to `HFSnapSystem`. Five modes (Grid=1, Vertex=2, Center=4, Edge=8, Perpendicular=16) form a bitmask. Custom snap lines (set via `set_custom_snap_line()`) are checked alongside grid/geometry candidates. Vertex mode collects transformed brush-AABB corners, Center collects brush centers, Edge collects AABB-edge midpoints, and Perpendicular projects the current point to the closest point on each AABB edge. The closest eligible geometry candidate within `snap_threshold` beats grid snap. Pass `exclude_ids` to skip the brush being dragged.
 - **Reference cleanup.** `delete_brush()` calls `_cleanup_brush_references()` which strips group_id meta (+ cleans empty groups via `visgroup_system._cleanup_empty_group()`), clears visgroup membership, and calls `entity_system.cleanup_dangling_connections()` to remove I/O connections targeting the deleted node. Always fires before the node is removed from the tree.
 - **Managed brush/entity edits.** `LevelRoot.delete_managed_nodes()`, `create_managed_duplicates()`, and `nudge_managed_nodes()` split canonical brush and `DraftEntity` paths between their owning systems while presenting one undoable editor action. Entity duplication uses captured entity info, preserves entity data plus group/visgroup membership, and assigns a unique copy name. Entity deletion removes group/visgroup membership and dangling I/O references before detaching the node. Do not route a selected `DraftEntity` through a brushes-only shortcut guard.
 - **Live dimensions.** `input_state.get_drag_dimensions()` returns `Vector3(W, H, D)` during DRAG_BASE/DRAG_HEIGHT; `Vector3.ZERO` otherwise. `format_dimensions()` renders as `"64 x 32 x 48"` (whole numbers omit decimals). The mode indicator banner appends dimensions to the stage hint during drag gestures.
@@ -254,7 +254,7 @@ addons/hammerforge/
 The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs on push and PR to `main`:
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
-- **GUT unit + integration tests** -- 1,687 tests across 90 test scripts (1,680 passing plus seven intentional no-assert safety tests; 7,502 assertions; runs Godot headless)
+- **GUT unit + integration tests** -- 1,783 tests across 104 test scripts (1,776 passing plus seven intentional no-assert safety tests; 7,825 assertions; verified in CI September 2, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```
@@ -297,42 +297,42 @@ Tests live in `tests/` and use the [GUT](https://github.com/bitwes/Gut) framewor
 | `test_hollow_tool.gd` | 10 | Hollow creation (6 walls), thickness validation, material/operation preservation |
 | `test_clip_tool.gd` | 16 | Axis splitting (X/Y/Z), size correctness, property preservation (material, visgroups, group_id, brush_entity_class), edge rejection |
 | `test_brush_entity.gd` | 19 | Tie/untie entity classes, structural brush filtering, bake collection exclusion, brush info round-trip, and exact Commit Cuts preparation/finalization |
-| `test_entity_io.gd` | 24 | Entity I/O CRUD (add/remove/get outputs), find by name, get_all_connections, serialization, default values |
+| `test_entity_io.gd` | 27 | Entity I/O CRUD (add/remove/get outputs), find by name, get_all_connections, serialization, default values |
 | `test_justify_uv.gd` | 10 | UV justify modes (fit/center/left/right/top/bottom/stretch/tile), zero-range safety, offset accumulation |
 | `test_brush_info_roundtrip.gd` | 19 | Brush info capture/restore with visgroups, group_id, brush_entity_class, material, move floor/ceiling argument safety |
 | `test_face_data.gd` | 15 | FaceData to_dict/from_dict round-trip, ensure_geometry, triangulate, box_projection_axis |
 | `test_paint_layer.gd` | 32 | Cell bit storage, chunk management, material IDs, blend weights, dirty tracking, heightmap, memory |
 | `test_heightmap_io.gd` | 12 | Base64 encode/decode round-trip, noise generation (FastNoiseLite), determinism |
-| `test_hflevel_io.gd` | 32 | Variant encode/decode (Vector2/3, Transform3D, Basis, Color), payload build/parse, full pipeline |
+| `test_hflevel_io.gd` | 38 | Variant encode/decode (Vector2/3, Transform3D, Basis, Color), payload build/parse, full pipeline |
 | `test_brush_shapes.gd` | 37 | Box face generation, normals, vertex bounds, triangulation, serialization, centered odd-sided pyramid/prism preview+bake bounds, winding migration, sparse overlay lifecycle, material refresh, and truthful custom-face previews |
 | `test_viewport_outlines.gd` | 39 | Semantic primitive/custom/subtract outlines, combined nested entity targets, top-level/hidden visibility, hover suppression, shape-aware handle sizing, odd-polygon agreement, world-snapped resize, and bounded recovery/cancel/undo behavior |
 | `test_selection_gesture.gd` | 38 | Native Object Select/widget ownership, modal Face Select, scope/focus guards, runtime repair, modifiers, recovery, native duplicate/reparent handling, prefab unlinking, bake-setting invalidation, native overlay drawing, and stable-ID transform/Inspector/FaceData/undo Bake Changed reconciliation |
 | `test_picking_correctness.gd` | 15 | Exact non-box face hits and placement, construction-plane fallback, internal entity preview traversal, nearest brush/entity ordering, scaled world-ray distances, hidden-visgroup exclusion, and canonical visibility-aware picking across tools |
 | `test_entity_props.gd` | 12 | Entity property form defaults (all types), roundtrip capture/restore, empty properties safety |
 | `test_duplicator.gd` | 7 | Instance count, progressive offset, clear cleanup, to_dict/from_dict roundtrip, edge cases |
-| `test_map_export.gd` | 19 | Quake/Valve220 face line format, auto-axes, entity property formatting, fractional coords, projections |
+| `test_map_export.gd` | 27 | Quake/Valve220 face formats, custom-face geometry, entity properties, brush entities, fractional coordinates, and projections |
 | `test_tool_registry.gd` | 27 | Tool registration, activate/deactivate, dispatch routing, shortcut/external ID guards, exclusivity, and pointer capture cancel/recovery |
 | `test_keymap.gd` | 20 | Default bindings loaded, key/modifier matching, display strings, rebinding, JSON roundtrip, and current action coverage |
-| `test_user_prefs.gd` | 13 | Defaults, get/set prefs, section state, recent files, JSON roundtrip, and dismissed hints |
-| `test_dirty_tags.gd` | 17 | Exact transform/material/UV/paint/vertex dirty tags, no-op suppression, floor routing, paint/full tags, consume, and batch queue/flush/discard/nesting |
+| `test_user_prefs.gd` | 15 | Defaults, get/set prefs, section state, recent files, JSON roundtrip, and dismissed hints |
+| `test_dirty_tags.gd` | 19 | Exact transform/material/UV/paint/vertex dirty tags, no-op suppression, floor routing, paint/full tags, consume, and batch queue/flush/discard/nesting |
 | `test_prototype_textures.gd` | 27 | Catalog constants, path generation, texture existence, material persistence (resource_path), batch loading into MaterialManager |
 | `test_op_result.gd` | 30 | HFOpResult constructors and operation result/failure/fix-hint contracts |
-| `test_snap_system.gd` | 14 | Grid/Vertex/Center snap modes, threshold, preview exclusion, priority, and empty-scene fallback |
+| `test_snap_system.gd` | 17 | Grid/Vertex/Center/Edge/Perpendicular snap modes, threshold, preview exclusion, priority, and empty-scene fallback |
 | `test_drag_dimensions.gd` | 16 | Drag dimensions/formatting plus normalized sphere/cylinder/cone/capsule placement bounds |
 | `test_bugfix_regressions.gd` | 32 | Vertex undo/projection/axis constraints, cancelled-release restoration, viewport owner routing, RMB session and lost-release recovery, narrow native-object handling, paint capture, and scene-creation safety |
 | `test_vertex_system.gd` | 35 | Vertex movement/convexity/undo snapshots, exact convex-clip dirty tags, and perspective/orthographic/axis-locked drag projection |
 | `test_reference_cleanup.gd` | 8 | Delete cleans group/visgroup membership and entity I/O while preserving unrelated references |
-| `test_bake_system.gd` | 117 | Baked-container adoption/replacement/clear and exact snapshot restore, conservative legacy migration (chunk, face-material, heightmap), structural-cut fallback, one-pass visual/collision CSG equivalence, transformed cordon/chunk interactions, build options, dry runs, preview modes, dirty-tag concurrency, connectors/navmesh, and mode 2 integration |
+| `test_bake_system.gd` | 127 | Baked-container adoption/replacement/clear and exact snapshot restore, conservative legacy migration (chunk, face-material, heightmap), structural-cut fallback, one-pass visual/collision CSG equivalence, transformed cordon/chunk interactions, build options, dry runs, preview modes, dirty-tag concurrency, connectors/navmesh, brush entities, and mode 2 integration |
 | `test_bake_issues.gd` | 10 | check_bake_issues: degenerate, oversized, floating subtract, overlapping subtracts, non-manifold/open-edge, clean level, entity skip |
 | `test_weld_and_planarity.gd` | 21 | Non-planar face detection (5), vertex welding + ensure_geometry refresh (3), planarity auto-fix (3), micro-gap detection (2), edge-key independence (1), boundary-straddling weld/gap/parse (3), MapIO integration (2), MapIO snap unit (2) |
 | `test_quick_play_modes.gd` | 13 | Severity blocking, cordon save/restore, dirty retention, camera yaw, and spawn restore across play/error paths |
 | `test_integration.gd` | 22 | End-to-end: brush lifecycle, paint + heightmap, entity workflow, visgroup cross-system, snap, bake cross-system, entity I/O cleanup, brush info round-trip |
 | `test_shortcut_dialog.gd` | 8 | Category assignment (tools, paint, axis lock, editing), action labels (known/unknown), get_all_bindings copy safety |
 | `test_tutorial_wizard.gd` | 18 | Step advancement, persistence, deferred start/resume, bake validation, completion, and no-root safety |
-| `test_subtract_preview.gd` | 13 | AABB math, overlapping cut groups, enable/disable, debounce, and safe destroy |
-| `test_prefab.gd` | 10 | Empty prefab, to_dict/from_dict roundtrip, transform preservation, file save/load, invalid data handling, multiple brushes, entity I/O preservation, instantiate empty |
+| `test_subtract_preview.gd` | 14 | AABB math, overlapping live-CSG cut groups, enable/disable, debounce, and safe destroy |
+| `test_prefab.gd` | 11 | Empty prefab, to_dict/from_dict roundtrip, transform preservation, file save/load, invalid data handling, multiple brushes, entity I/O preservation, instantiate empty |
 | `test_vertex_edges.gd` | 19 | Edge extraction (12 edges for box), dedup, edge selection (additive, toggle, clear), edge world positions, edge split (vertex count, face vert count), vertex merge, sub-mode toggle, get_single_selected_edge, point-to-segment-dist-2d |
-| `test_polygon_tool.gd` | 19 | Convexity/face construction, height state, missed-release and focus recovery, tool metadata, and settings schema |
+| `test_polygon_tool.gd` | 20 | Convexity/face construction, bidirectional positive height, missed-release and focus recovery, tool metadata, and settings schema |
 | `test_path_tool.gd` | 16 | Segment/miter construction, face data, reconstruction, pointer lifecycle, and tool metadata |
 | `test_material_browser.gd` | 24 | Thumbnail grid, palette view, null material skip, selection signals, double-click, drag data, search, pattern/color filters, favorites, hover preview, context popup |
 | `test_material_integration.gd` | 28 | Brush search (_iter_pick_nodes), hover overlay mesh (normals, mutation, lifecycle), whole-brush/per-face assignment via root, face selection counting via dock, resolve_material_assign_action fallback (face→brush→error), selection-clear signaling, and the invariant that empty `EditorSelection` is never hidden by a stale plugin cache |
@@ -343,21 +343,21 @@ Tests live in `tests/` and use the [GUT](https://github.com/bitwes/Gut) framewor
 | `test_io_presets.gd` | 21 | Builtin preset structure, user preset CRUD, apply with target mapping/self/delay/fire_once, save entity as preset, get target tags |
 | `test_io_visualizer_enhanced.gd` | 22 | Color logic (selected/fire_once/type/default/delay), Bézier math (endpoints/midpoint/tangent), connection summary, live weak selection/rename tracking, highlight connected toggle/clear |
 | `test_io_highlight_sync.gd` | 16 | Panel/toolbar sync from visualizer, set_pressed_no_signal contracts, signal emission, signal-driven integration (toolbar↔panel propagation, alternating sources) |
-| `test_io_runtime.gd` | 36 | I/O-to-Signal dispatcher: wiring, method dispatch (direct/snake-case/generic/signal fallback), parameters, fire-once, user signals, multi-target fan-out, chain reactions, debug signal accuracy, rewire idempotency, duplicate source isolation, extra scan roots (transient/NodePath/overlap/descendant pruning), fire_on() static helper, HFEntitySystem.fire_output() fallback |
+| `test_io_runtime.gd` | 38 | I/O-to-Signal dispatcher: wiring, method dispatch (direct/snake-case/generic/signal fallback), parameters, fire-once, user signals, multi-target fan-out, chain reactions, debug signal accuracy, rewire idempotency, duplicate source isolation, extra scan roots (transient/NodePath/overlap/descendant pruning), fire_on() static helper, HFEntitySystem.fire_output() fallback |
 | `test_brush_to_heightmap.gd` | 14 | Default settings, empty input, single/multi conversion, skip subtract brushes, mesh/displacement bounds, height scale, cell bounds, target layer reuse, grid properties, display name, height roundtrip |
 | `test_scatter_brush.gd` | 15 | Defaults, circle/spline scatter, filters, deterministic transforms, preview, commit, and scale variation |
-| `test_path_tool_extras.gd` | 23 | Extended schema/options, stairs, railings, trim, HUD, placement, and edge cases |
+| `test_path_tool_extras.gd` | 24 | Extended schema/options, stairs, railings, trim including material slot zero, HUD, placement, and edge cases |
 | `test_dock_terrain_integration.gd` | 30 | Dock heightmap convert (selection→convert→grid inheritance→chunk_size→signal→active layer→regenerate→height data), scatter settings (defaults, spline points, circle, null controls), scatter preview (circle, no layer, spline too few/stale/valid), scatter commit (empty, no mesh early return, preserves result), scatter clear (removes preview, safe when null, already-freed) |
 | `test_theme_utils.gd` | 15 | Dark/light detection, panel_bg, panel_border, muted_text, primary_text, accent, success/warning/error colors, toast bg variants, make_panel_stylebox, consistency across dark/light |
 | `test_perf_monitor.gd` | 6 | Entity count, vertex estimate, chunk recommendation, health, AABB, and empty state |
 | `test_measure_tool.gd` | 22 | Tool metadata/state, rulers/distances/chaining, cap/removal, snap references, input ownership, and HUD |
 | `test_snap_system_custom.gd` | 6 | Custom snap line set/clear, projection onto line, snap_point with custom line, threshold, clear restores default |
-| `test_history_browser.gd` | 12 | Record/cap/clear, undo/redo controls, icon/color mapping, navigation, and history refresh |
-| `test_export_playtest.gd` | 3 | Export empty level, includes DirectionalLight3D, includes WorldEnvironment |
+| `test_history_browser.gd` | 14 | Record/cap/clear, undo/redo controls, icon/color mapping, navigation, and history refresh |
+| `test_export_playtest.gd` | 8 | Empty export, lighting/environment, player spawn/controller, nested ownership, and transform preservation |
 | `test_dock_history_and_playtest.gd` | 8 | Null-safe history refresh/buttons, selection typing, version updates, spawn creation, and state capture |
-| `test_baker.gd` | 24 | Material-preserving merge/face bake, indexed/non-indexed concatenation, convex collision generation, snapshots, and simplification |
+| `test_baker.gd` | 26 | Material-preserving merge/face bake, indexed/non-indexed concatenation, convex collision generation, snapshots, and simplification |
 | `test_undo_helper.gd` | 10 | History callbacks, collation tags/windows/scopes, dynamic method arities, and null safety |
-| `test_displacement.gd` | 37 | Displacement data, FaceData triangulation/serialization, create/destroy, painting, power/elevation, noise, and sewing |
+| `test_displacement.gd` | 38 | Displacement data, FaceData triangulation/serialization, create/destroy, painting, power/elevation, noise, and sewing |
 | `test_bevel.gd` | 15 | Face inset (basic, height extrude, collapse guard, material inheritance, connecting sides winding), edge bevel (basic, segments, neighbor update, small radius, material inheritance), slerp utility (endpoints, midpoint, parallel, anti-parallel, quarter turn) |
 | `test_occluder_generation.gd` | 13 | Occluder generation: flat mesh, chunked hierarchy (BakedChunk_* nodes), coplanar merge across chunks, plane separation, min-area filtering, idempotent re-generation, postprocess toggle (enabled/disabled), validation coverage + missing-occluder warnings |
 

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -1,6 +1,6 @@
 # HammerForge Spec
 
-Last updated: July 21, 2026
+Last updated: September 2, 2026
 
 This document describes HammerForge's architecture and data flow.
 
@@ -12,7 +12,7 @@ This document describes HammerForge's architecture and data flow.
 
 ## Architecture
 
-HammerForge uses a coordinator + subsystems pattern. `LevelRoot` is a coordinator (~2,200 lines) that owns all container nodes, exported properties, and signals, and delegates work to subsystem classes. Each subsystem receives a reference to `LevelRoot` in its constructor. Default editor UX is the core loop (Draw → material → entity → bake → Test Level); radial menu, coach marks, and operation replay install only when `power_user_overlays` is enabled.
+HammerForge uses a coordinator + subsystems pattern. `LevelRoot` is a 2,844-line coordinator that owns container nodes, exported properties, and signals, and delegates work to subsystem classes. Each subsystem receives a reference to `LevelRoot` in its constructor. Default editor UX is the core loop (Draw → material → entity → bake → Test Level); radial menu, coach marks, and operation replay install only when `power_user_overlays` is enabled.
 
 ### Signals (Central Registry)
 All signals are defined on `LevelRoot`. Subsystems emit them via `root.<signal>.emit(...)`. UI and other consumers subscribe instead of polling.
@@ -44,7 +44,7 @@ All signals are defined on `LevelRoot`. Subsystems emit them via `root.<signal>.
 |--------|------|
 | `plugin.gd` | EditorPlugin entry point, input routing, undo/redo, sticky LevelRoot discovery |
 | `level_root.gd` | Thin coordinator: containers, exports, signals, delegates to subsystems |
-| `dock.gd` + `dock.tscn` | UI dock (4 tabs: Brush, Paint, Entities, Manage), collapsible sections, tool state |
+| `dock.gd` + `dock.tscn` | UI dock (4 tabs: Build, Paint, Objects, Test), collapsible sections, tool state |
 | `ui/collapsible_section.gd` | Reusable `HFCollapsibleSection` toggle-header VBoxContainer |
 | `input_state.gd` | Drag/paint/extrude state machine (`Mode` enum: IDLE, DRAG_BASE, DRAG_HEIGHT, SURFACE_PAINT, EXTRUDE) |
 | `hf_selection_gesture.gd` | Native Object Select / modal Face Select gesture ownership and recovery state |
@@ -63,7 +63,7 @@ All signals are defined on `LevelRoot`. Subsystems emit them via `root.<signal>.
 | `uv_editor.gd` + `uv_editor.tscn` | UV editing dock control |
 | `hf_keymap.gd` | Customizable keyboard shortcuts (JSON load/save, action → binding mapping) |
 | `hf_user_prefs.gd` | Cross-session user preferences (`user://hammerforge_prefs.json`) |
-| `hf_snap_system.gd` | Centralized snap system (Grid/Vertex/Center modes, threshold-based candidate selection) |
+| `hf_snap_system.gd` | Centralized snap system (Grid/Vertex/Center/Edge/Perpendicular modes, threshold-based candidate selection) |
 | `hf_op_result.gd` | Lightweight operation result (`ok`, `message`, `fix_hint`) returned by brush operations |
 | `hf_prefab.gd` | Reusable brush+entity group with variants, tags, live-linking (save/load `.hfprefab`, I/O remap) |
 | `hf_polygon_tool.gd` | Polygon tool: click convex verts → extrude to brush (tool_id=102, KEY_P) |
@@ -80,8 +80,8 @@ All signals are defined on `LevelRoot`. Subsystems emit them via `root.<signal>.
 | `hf_toast.gd` | Toast notification system (auto-fading stacked messages) |
 | `hf_material_browser.gd` | Visual material browser (thumbnail grid, search, filters, favorites, drag-drop) |
 | `paint_tab_builder.gd` | Builds Paint tab sections + signal connections |
-| `entity_tab_builder.gd` | Builds Entity Properties + Entity I/O + I/O Wiring sections (all context-hidden until entity selected) |
-| `manage_tab_builder.gd` | Builds Manage tab sections (Bake, File, Settings, Prefabs, etc.) |
+| `entity_tab_builder.gd` | Builds the displayed Objects tab's Entity Properties + Entity I/O + I/O Wiring sections (all context-hidden until entity selected) |
+| `manage_tab_builder.gd` | Builds the displayed Test tab's sections (Bake, File, Settings, Prefabs, etc.; legacy internal filename) |
 | `selection_tools_builder.gd` | Builds Selection Tools section (hollow, clip, merge, move, tie, duplicator) |
 
 ### Subsystems (`addons/hammerforge/systems/`)
@@ -100,7 +100,7 @@ All signals are defined on `LevelRoot`. Subsystems emit them via `root.<signal>.
 | `hf_visgroup_system.gd` | `HFVisgroupSystem` | Visgroups (visibility groups), brush/entity grouping |
 | `hf_carve_system.gd` | `HFCarveSystem` | Boolean-subtract carve (progressive-remainder box slicing) |
 | `hf_io_visualizer.gd` | `HFIOVisualizer` | Entity I/O connection lines in viewport (ImmediateMesh) |
-| `hf_subtract_preview.gd` | `HFSubtractPreview` | Wireframe AABB intersection overlay between subtract and additive brushes (debounced, pooled) |
+| `hf_subtract_preview.gd` | `HFSubtractPreview` | Live CSG cut overlay between subtract and additive brushes, with a wireframe AABB fallback (debounced, pooled) |
 | `hf_vertex_system.gd` | `HFVertexSystem` | Vertex/edge selection, move, split, merge with convexity validation. Edge sub-mode with wireframe overlay |
 | `hf_spawn_system.gd` | `HFSpawnSystem` | Player spawn lookup, validation (floor/collision/headroom), auto-fix, debug visualisation |
 | `hf_prefab_system.gd` | `HFPrefabSystem` | Prefab instance registry (stable entity UIDs), variant cycling, live-linked propagation, override tracking, push-to-source |
@@ -301,8 +301,8 @@ Foliage Populator
 - `find_entities_by_name()` searches both `entities_node` and `draft_brushes_node` for target resolution.
 - `fire_output(entity, output_name, parameter)` delegates to `HFIORuntime` dispatcher if present in the scene, falls back to direct multi-target resolution otherwise.
 - I/O connections are serialized with entity info in `.hflevel` saves and undo/redo state via `capture_entity_info()` / `restore_entity_from_info()`.
-- Dock UI: collapsible "Entity I/O" section in Entities tab with fields for Output, Target, Input, Parameter, Delay, Fire Once. Add/Remove buttons and connection ItemList. Context-hidden (only visible when an entity is selected); auto-refreshes on selection change.
-- **Viewport visualization**: `HFIOVisualizer` draws ImmediateMesh lines between connected entities. Color-coded: green=standard, orange=fire_once, yellow=selected entity connections. Throttled refresh (10 frames). "Show I/O Lines" checkbox in Entities tab.
+- Dock UI: collapsible "Entity I/O" section in the Objects tab with fields for Output, Target, Input, Parameter, Delay, Fire Once. Add/Remove buttons and connection ItemList. Context-hidden (only visible when an entity is selected); auto-refreshes on selection change.
+- **Viewport visualization**: `HFIOVisualizer` draws ImmediateMesh lines between connected entities. Color-coded: green=standard, orange=fire_once, yellow=selected entity connections. Throttled refresh (10 frames). "Show I/O Lines" checkbox in the Objects tab.
 - **Runtime signal translation**: `HFIORuntime` (`hf_io_runtime.gd`) auto-wires `entity_io_outputs` metadata into Godot signals on bake/export. Auto-injected by `export_playtest_scene()` and optionally by `postprocess_bake()` (`bake_wire_io` export). Connections keyed by node instance ID; targets resolved to all matching nodes. Delivery cascade: direct method → snake_case → `_on_io_input()` → user signal. Source entities receive `io_<OutputName>` user signals. Delay via `SceneTreeTimer`, fire-once tracked per-connection. `extra_scan_root_paths: Array[NodePath]` (@export) persists scan roots across scene save/reload. `_prune_overlapping_roots()` deduplicates by instance ID and ancestor/descendant relationship.
 
 ### Brush Entity Classes
@@ -336,6 +336,7 @@ Foliage Populator
 - **Bake time estimate** (`estimate_bake_time()`): ratio-based extrapolation from `_last_bake_duration_ms` and brush count.
 - **Bake issue detection** (`HFValidationSystem.check_bake_issues()`): returns Array of `{type, severity, message, node}` dicts. Checks: degenerate brush (sev=2), oversized (sev=1), floating subtract (sev=1), overlapping subtracts (sev=1), non-manifold edges (sev=2), open edges (sev=1), non-planar faces (sev=1), micro-gaps between brushes (sev=1), occlusion coverage (sev=0 info or sev=1 warning). Non-planar detection uses `planarity_tolerance` (default 0.01). Micro-gap detection uses `weld_tolerance` (default 0.001). Both use 27-cell spatial hash neighbor lookup for boundary-safe distance checks. `_edge_key()` for topology (non-manifold/open-edge) uses fixed 0.001 precision, intentionally decoupled from `weld_tolerance`.
 - **Auto-fix helpers**: `weld_brush_vertices(brush)` snaps near-coincident vertices within `weld_tolerance` via BFS grouping + `ensure_geometry()` refresh. `fix_non_planar_faces(brush)` projects drifting vertices onto the best-fit plane from each face's first 3 vertices.
+- **Playtest export** (`export_playtest_scene()`): packs baked output, brush entities, point entities, default lighting/environment, and a player controller positioned at the active spawn. Reparented content keeps its world transform, nested geometry/collision receives recursive scene ownership, and `HFIORuntime` is injected when connections exist.
 
 ## Face Materials + Surface Paint
 Face data is stored per DraftBrush face with material assignment, UV projection, and optional paint layers.
@@ -381,12 +382,12 @@ The dock uses 4 tabs with collapsible sections for visual hierarchy:
 
 | Tab | Contents |
 |-----|----------|
-| **Brush** | Shape, size, grid snap, quick snap presets, material picker, operation mode (Add/Sub), texture lock |
+| **Build** | Shape, size, five snap modes, quick snap presets, material picker, operation mode (Add/Sub), texture lock, contextual selection tools |
 | **Paint** | 7 collapsible sections: Floor Paint, Heightmap, Blend & Terrain, Regions, Materials (with Refresh Prototypes), UV Editor, Surface Paint |
-| **Entities** | Entity palette with drag-and-drop, Create DraftEntity, Entity Properties + Entity I/O + I/O Wiring (context-hidden collapsible sections, visible only when entity selected) |
-| **Manage** | Bake, Actions (floor/cuts/clear), File, Presets, History, Settings, Performance, plus Visgroups & Cordon (inserted programmatically) |
+| **Objects** | Entity palette with drag-and-drop, Create DraftEntity, Entity Properties + Entity I/O + I/O Wiring (context-hidden collapsible sections, visible only when entity selected) |
+| **Test** | Test Level, Bake, Actions (floor/cuts/clear), File, Presets, History, Settings, Performance, plus Visgroups & Cordon (inserted programmatically) |
 
-- **Brush tab** includes contextual **Selection Tools** section (hollow, clip, merge, move, tie, duplicator) visible when brushes are selected.
+- **Build tab** includes contextual **Selection Tools** section (hollow, clip, merge, move, tie, duplicator) visible when brushes are selected.
 - Tab contents built by dedicated builder classes: `PaintTabBuilder`, `EntityTabBuilder`, `ManageTabBuilder`, `SelectionToolsBuilder` (in `ui/`). Each is RefCounted with `build()` and `connect_signals()` methods. Dock delegates to builders, reducing `dock.gd` by ~35%.
 - Collapsible sections have HSeparator, 4px indented content, and persisted collapsed state. All 18 sections tracked in `_all_sections` dict.
 - "No LevelRoot" banner and autosave warning defined in dock.tscn.
@@ -487,25 +488,26 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_texture_lock.gd` | 10 | UV offset/scale compensation for PLANAR_X/Y/Z, BOX_UV, CYLINDRICAL |
 | `test_cordon_filter.gd` | 10 | AABB intersection, cordon-filtered collection, chunk_coord utility |
 | `test_keymap.gd` | 20 | Default bindings, modifier matching, display strings, rebinding, JSON roundtrip, current action coverage |
-| `test_user_prefs.gd` | 13 | Defaults, get/set prefs, section state, recent files, JSON roundtrip, dismissed hints |
-| `test_dirty_tags.gd` | 17 | Exact transform/material/UV/paint/vertex tags, no-op suppression, paint/full tags, and batching |
+| `test_user_prefs.gd` | 15 | Defaults, get/set prefs, section state, recent files, JSON roundtrip, dismissed hints |
+| `test_dirty_tags.gd` | 19 | Exact transform/material/UV/paint/vertex tags, no-op suppression, paint/full tags, and batching |
 | `test_prototype_textures.gd` | 27 | Catalog constants, path generation, texture existence, material persistence (resource_path), batch loading into MaterialManager |
 | `test_op_result.gd` | 30 | HFOpResult constructors and operation result/failure/fix-hint contracts |
-| `test_snap_system.gd` | 14 | Grid/Vertex/Center snap modes, preview exclusion, threshold, priority, fallback |
+| `test_snap_system.gd` | 17 | Grid/Vertex/Center/Edge/Perpendicular snap modes, preview exclusion, threshold, priority, fallback |
 | `test_drag_dimensions.gd` | 16 | Drag dimensions/formatting and normalized radial primitive placement |
 | `test_reference_cleanup.gd` | 8 | Delete cleans group/visgroup membership and dangling entity I/O safely |
-| `test_bake_system.gd` | 117 | Baked lifecycle/migration/snapshots, cut-safe face-material fallback, one-pass CSG visual/collision equivalence, options, collection, previews, dirty concurrency, connectors/navmesh, and mode integration |
+| `test_bake_system.gd` | 127 | Baked lifecycle/migration/snapshots, cut-safe face-material fallback, one-pass CSG visual/collision equivalence, options, collection, previews, dirty concurrency, connectors/navmesh, brush entities, and mode integration |
 | `test_bake_issues.gd` | 10 | check_bake_issues: degenerate, oversized, floating subtract, overlapping subtracts, clean level, entity skip |
 | `test_weld_and_planarity.gd` | 21 | Non-planar detection, vertex welding + ensure_geometry refresh, planarity auto-fix, micro-gap detection, edge-key independence, boundary-straddling coverage, MapIO integration + unit |
 | `test_quick_play_modes.gd` | 13 | Severity blocking, cordon save/restore, dirty retention, camera yaw, spawn restore |
 | `test_integration.gd` | 22 | End-to-end: brush lifecycle, paint + heightmap, entity workflow, visgroup cross-system, snap, bake, I/O cleanup, info round-trip |
 | `test_shortcut_dialog.gd` | 8 | Category assignment (tools, paint, axis lock, editing), action labels, get_all_bindings copy safety |
 | `test_tutorial_wizard.gd` | 18 | Step advancement, persistence/resume, completion, bake validation, no-root safety |
-| `test_subtract_preview.gd` | 10 | AABB intersection, enable/disable, debounce, safe destroy lifecycle |
-| `test_prefab.gd` | 10 | Empty prefab, roundtrip, transforms, file I/O, invalid data, entity I/O |
+| `test_subtract_preview.gd` | 14 | AABB broad-phase, live CSG groups, enable/disable, debounce, safe destroy lifecycle |
+| `test_prefab.gd` | 11 | Empty prefab, roundtrip, transforms, file I/O, invalid data, entity I/O |
+| `test_export_playtest.gd` | 8 | Empty export, lighting/environment, player spawn/controller, nested ownership, and transform preservation |
 | `test_selection_gesture.gd` | 38 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite: **1,687 tests** across **90 files** (**1,680 passing** plus seven intentional no-assert safety tests; **7,502 assertions**).
+Full suite (verified in CI on September 2, 2026): **1,783 tests** across **104 scripts** (**1,776 passing** plus seven intentional no-assert safety tests; **7,825 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-1680%20passing-brightgreen" alt="1680 tests passing">
-  <img src="https://img.shields.io/badge/GDScript-25k%2B%20lines-blueviolet" alt="25k+ lines">
+  <img src="https://img.shields.io/badge/Tests-1776%20passing-brightgreen" alt="1776 tests passing">
+  <img src="https://img.shields.io/badge/GDScript-44k%2B%20lines-blueviolet" alt="44k+ lines">
 </p>
 
 > **Fair warning:** This is a solo hobby project in early alpha. I built it to support another project and it grew from there. It's buggy, rough around the edges, and a bit directionless. If any of this looks useful to you, I'd genuinely appreciate help testing and filing issues. Contributions welcome -- just know you're signing up for an adventure, not a polished product.
@@ -28,7 +28,7 @@ The previous AI-generated logo has been retired. If you're a designer or artist 
 
 Level editors like Hammer and TrenchBroom proved that **brush-based workflows** are the fastest way to block out 3D spaces. HammerForge brings that paradigm into Godot so you never have to leave the editor:
 
-- **No live CSG** -- brushes are lightweight preview nodes; CSG runs only at bake time, keeping the editor snappy even with hundreds of brushes.
+- **No full-scene live CSG** -- brushes are lightweight preview nodes; full CSG runs only at bake time. An optional, capped subtract overlay computes only nearby cut previews.
 - **Two-click geometry** -- drag a base rectangle, click to set height. Extrude faces to extend rooms. Type exact numbers any time.
 - **Paint floors and terrain** -- grid-based floor paint with heightmaps, multi-material blending, auto-connectors (ramps/stairs), and foliage scatter.
 - **Bake when ready** -- one click produces merged meshes, collision shapes (trimesh, per-brush convex, or per-visgroup partitioned), lightmap UVs, navmeshes, and LODs.
@@ -41,7 +41,7 @@ HammerForge is a single `addons/` folder. No external tools, no custom builds, n
 
 | | |
 |---|---|
-| **21 subsystems** + coordinator architecture | **1,687 unit + integration tests** with CI on every push |
+| **Subsystem-based coordinator architecture** | **1,783 unit + integration tests** with CI on every push |
 | **15 brush shapes** (box through dodecahedron) | **150 built-in prototype textures** for instant greyboxing |
 | **Quake `.map`** + **glTF `.glb`** export | **.hflevel** native format with threaded I/O |
 | **Customizable keymaps** (JSON) | **Plugin API** for custom tools |
@@ -107,6 +107,8 @@ Geometry-aware snapping goes beyond a simple grid:
 | Grid | G | Regular grid intersections |
 | Vertex | V | Corners of existing brushes (8 per box) |
 | Center | C | Center points of existing brushes |
+| Edge | E | Midpoints of existing brush AABB edges |
+| Perpendicular | P | Closest point on an existing brush AABB edge |
 
 Closest candidate within threshold wins. Modes combine freely. The Measure tool can set a **custom snap reference line** with Ctrl+Click for alignment along arbitrary axes. **Texture Lock** preserves UV alignment for HammerForge move and resize actions, including nudge and Move to Floor/Ceiling. Godot's native Node3D transform widget keeps brush-local UV data unchanged. **Move to Floor/Ceiling** (Ctrl+Shift+F/C) raycasts to snap brushes vertically. **UV Justify** offers fit/center/left/right/top/bottom/stretch/tile alignment for selected faces.
 
@@ -191,7 +193,7 @@ Grid-based paint layers with chunked storage for large worlds:
 | **Test Level** | Check, bake, validate spawn, and run with the FPS controller |
 | **Play from Camera** | Test from the editor camera position and yaw |
 | **Play Selected Area** | Auto-cordon to selection, bake + play that region only |
-| **Export Playtest** | Bake + pack scene + launch as standalone playable scene (I/O auto-wired) |
+| **Export Playtest** | Bake + pack a playable scene with player, spawn pose, nested geometry/collision, lighting, and auto-wired I/O |
 | **Wire I/O** | Auto-translate entity I/O connections to Godot signals in baked output |
 
 ---
@@ -270,8 +272,8 @@ plugin.gd            EditorPlugin — input routing, toolbar, viewport overlay
        ├─ HFCarveSystem     Boolean-subtract carve (progressive-remainder slicing)
        ├─ HFIOVisualizer    Entity I/O connection lines in viewport (curved, color-coded, highlight pulse)
        ├─ HFIOPresets       Reusable I/O connection presets (built-in + user-saved)
-       ├─ HFSnapSystem      Grid / Vertex / Center snap + custom reference lines
-       ├─ HFSubtractPreview Wireframe AABB intersection overlay for subtract brushes
+       ├─ HFSnapSystem      Grid / Vertex / Center / Edge / Perpendicular snap + custom reference lines
+       ├─ HFSubtractPreview Live CSG cut overlay with wireframe AABB fallback
        ├─ HFVertexSystem    Vertex/edge selection, move, split, merge with convexity validation
        ├─ HFSpawnSystem     Player spawn lookup, validation, auto-fix, debug visualisation
        ├─ HFPrefabSystem    Instance registry, variant cycling, live-linked propagation
@@ -368,7 +370,7 @@ Shortcuts marked with **\*** are rebindable via `user://hammerforge_keymap.json`
 
 ## Testing
 
-1,687 tests across 90 scripts use the [GUT](https://github.com/bitwes/Gut) framework, including unit and integration coverage. The current suite has 1,680 passing tests plus seven intentional no-assert safety tests, with 7,502 assertions. All checks run on every push via GitHub Actions.
+The verified Godot 4.7 CI run on September 2, 2026 contains **1,783 tests across 104 scripts**: **1,776 passing tests**, seven intentional no-assert safety tests, and **7,825 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless
@@ -430,10 +432,15 @@ See [ROADMAP.md](ROADMAP.md) for the full plan.
 - Material atlas packing and merge-selected-brushes
 - Snap-to-edge (dock **E**) and snap-to-perpendicular (dock **P**)
 - Bake `func_detail` meshes and trigger `Area3D` volumes
+- Playtest exports with a spawned FPS player, recursive nested-node ownership, and preserved source transforms
+- MultiMesh consolidation that keeps instance transforms in baked-container space
 
-**Next up:**
-- PBR channels in the material atlas
-- Faster surface-paint / terrain sculpt (avoid per-pixel GDScript loops)
+**Current tracked work:**
+- Save completion and replacement safety ([#33](https://github.com/saworbit/hammerforge/issues/33), [#51](https://github.com/saworbit/hammerforge/issues/51))
+- `.map` entity string round-trip fidelity ([#32](https://github.com/saworbit/hammerforge/issues/32))
+- Non-blocking threaded mesh merge ([#35](https://github.com/saworbit/hammerforge/issues/35))
+- PBR atlas channels and paint hot paths ([#24](https://github.com/saworbit/hammerforge/issues/24), [#39](https://github.com/saworbit/hammerforge/issues/39))
+- Smaller coordinator and dock ownership boundaries ([#21](https://github.com/saworbit/hammerforge/issues/21), [#22](https://github.com/saworbit/hammerforge/issues/22), [#41](https://github.com/saworbit/hammerforge/issues/41))
 
 **Later:**
 - Bezier patch editing
@@ -490,5 +497,5 @@ Run `godot --headless --import --path .` first, then re-run the test command.
 
 <p align="center">
   <strong>MIT License</strong><br>
-  <sub>Built for Godot 4.7+ | Last updated July 21, 2026</sub>
+  <sub>Built for Godot 4.7+ | Last updated September 2, 2026</sub>
 </p>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last updated: August 28, 2026
+Last updated: September 2, 2026
 
 This roadmap is a directional plan. Items may change based on user feedback.
 
@@ -21,15 +21,15 @@ Priorities are informed by a Hammer Editor gap analysis — see GAP_ANALYSIS.md 
 - GUT unit test suite (47 tests) with CI integration.
 
 ## Done (Dock UX Overhaul)
-- Consolidated 8 tabs to 4 (Brush, Paint, Entities, Manage).
+- Consolidated 8 tabs to 4 (now displayed as Build, Paint, Objects, Test).
 - Collapsible sections with separators, indented content, persisted collapsed state.
-- Selection tools (hollow, clip, move, tie, duplicator) contextually shown in Brush tab.
+- Selection tools (hollow, clip, move, tie, duplicator) contextually shown in the Build tab.
 - Compact toolbar (single-char labels with tooltips, VSeparator before extrude).
 - Signal-driven paint/material/surface paint sync (replaced 10-frame polling).
 - UV Justify 3×2 grid layout. Standardized 70px label widths, 32px +/- buttons.
 - "No LevelRoot" banner and autosave warning defined in dock.tscn.
 - Sticky LevelRoot discovery (deep recursive search, no re-selection needed).
-- Manage tab trimmed: Actions has New Level/floor/cuts/clear.
+- Test tab trimmed: Actions has New Level/floor/cuts/clear.
 
 ## Done (Code Quality Audit)
 - Comprehensive duck-typing removal across baker, file system, plugin, and dock (~30 sites total).
@@ -52,7 +52,7 @@ Priorities are informed by a Hammer Editor gap analysis — see GAP_ANALYSIS.md 
 ## Done (Wave 2b -- Structural Tools)
 - Clipping tool (split brushes along axis-aligned plane). Shift+X.
 - Entity I/O system (Source-style input/output connections with parameter, delay, fire-once).
-- Entity I/O dock UI (collapsible section in Entities tab with connection list).
+- Entity I/O dock UI (collapsible section in the Objects tab with connection list).
 - Brush entity visual indicators (color-coded overlays: cyan = func_detail, orange = triggers).
 
 ## Done (TrenchBroom-Inspired Architecture Improvements)
@@ -102,7 +102,7 @@ Priorities are informed by a Hammer Editor gap analysis — see GAP_ANALYSIS.md 
 
 ## Done (FreeCAD-Inspired Improvements)
 - Operation result reporting: `HFOpResult` return values with actionable fix hints on hollow/clip/delete. Failures auto-toast via `user_message`.
-- Geometry-aware snap system: `HFSnapSystem` with Grid/Vertex/Center modes. Closest geometry candidate within threshold beats grid snap. G/V/C toggle buttons in dock.
+- Geometry-aware snap system: `HFSnapSystem` with Grid, Vertex, Center, Edge, and Perpendicular modes. Closest geometry candidate within threshold beats grid snap. G/V/C/E/P toggle buttons in the dock.
 - Live dimensions during drag: mode indicator banner shows real-time W x H x D during DRAG_BASE and DRAG_HEIGHT.
 - Reference cleanup on deletion: deleting brushes auto-strips group/visgroup membership and cleans dangling entity I/O connections with toast notification.
 - 44 new tests (op_result, snap_system, drag_dimensions, reference_cleanup). Total: 413 tests across 27 files.
@@ -155,8 +155,8 @@ Priorities are informed by a Hammer Editor gap analysis — see GAP_ANALYSIS.md 
 ## Done (Player Spawn System + Quick Play Overhaul)
 - **HFSpawnSystem** subsystem: spawn lookup with primary-flag priority, physics-based validation (floor raycast, capsule collision, headroom, below-map), auto-fix to suggested position, default spawn creation from brush centroid.
 - **Quick Play validation flow**: pre-flight spawn check before every bake+play. Critical issues show fix dialog. Warnings toast and proceed. Missing spawn auto-creates a safe default.
-- **Debug visualisation**: green/red capsule, floor/ceiling rays (ImmediateMesh), floor disc, collision sphere. Auto-cleanup timer or persistent toggle ("Preview Spawn Debug" in Manage tab).
-- **Manage tab → Spawn section**: Validate Spawn, Create Default Spawn, Preview Spawn Debug toggle.
+- **Debug visualisation**: green/red capsule, floor/ceiling rays (ImmediateMesh), floor disc, collision sphere. Auto-cleanup timer or persistent toggle ("Preview Spawn Debug" in the Test tab).
+- **Test tab → Spawn section**: Validate Spawn, Create Default Spawn, Preview Spawn Debug toggle.
 - **player_start entity** enhanced with `primary`, `angle`, `height_offset` properties. Color changed to cyan.
 - **Playtest FPS controller** updated with `player_start_position` / `player_start_rotation_y` exports.
 - 21 new tests. Total: **685 tests across 41 files**.
@@ -203,7 +203,7 @@ Priorities are informed by a Hammer Editor gap analysis — see GAP_ANALYSIS.md 
 
 ## Done (I/O Connections & Entity Polish — Make Wiring Delightful)
 - **Smart auto-routing**: Bézier curved connection lines with arrowheads, parallel route offset (0.3 units per route), color-coded by output type (cyan=OnTrigger, red=OnDamage, yellow=OnUse, green=OnOpen, magenta=OnBreak, orange=OnTimer). Fire-once pulses brighter; delayed connections dim proportionally.
-- **I/O wiring panel** (`HFIOWiringPanel`): embedded in Entities tab with connection summary, outputs list, quick-wire form (output/target dropdown/input/param/delay/fire-once), and preset picker with target tag mapping.
+- **I/O wiring panel** (`HFIOWiringPanel`): embedded in the Objects tab with connection summary, outputs list, quick-wire form (output/target dropdown/input/param/delay/fire-once), and preset picker with target tag mapping.
 - **Connection presets** (`HFIOPresets`): 6 built-in presets (Door+Light+Sound, Button→Toggle, Alarm Sequence, Pickup+Remove, Damage+Break, Timer Lights). Save entity connections as reusable user presets. Target tags map to actual names at apply time. User presets persist to editor config directory.
 - **Highlight Connected**: toggle to pulse-highlight all linked entities (SphereMesh overlays with animated alpha). Summary label in context toolbar. Cross-UI sync between context toolbar and wiring panel via `set_pressed_no_signal()`.
 - Context toolbar entity section gains HL toggle button and IOSummary label.
@@ -213,7 +213,7 @@ Priorities are informed by a Hammer Editor gap analysis — see GAP_ANALYSIS.md 
 - **Coach marks** (`HFCoachMarks`): first-use floating step-by-step guides for 10 advanced tools (Polygon, Path, Carve, Vertex Edit, Extrude, Clip, Hollow, Measure, Decal, Surface Paint). Auto-triggered when tools are activated via keyboard, command palette, or context toolbar. Per-tool "Don't show again" persisted via user prefs.
 - **Operation replay timeline** (`HFOperationReplay`): compact horizontal timeline of up to 20 recent operations with color-coded icons by action type. Hover for detail + elapsed time, click Replay to undo/redo to that history point. Toggle with Ctrl+Shift+T. Records undo versions and drives `UndoRedo.undo()`/`redo()`.
 - **Enhanced command palette** (Ctrl+K): fuzzy search with subsequence matching (word-boundary and consecutive-char bonuses). "Did you mean: ..." suggestion label when no exact match. Caps at 5 fuzzy results. Ctrl+K added as toggle shortcut alongside Shift+?/F1.
-- **Example library** (`HFExampleLibrary`): 5 built-in demo levels (Simple Room, Corridor with Doorway, Jump Puzzle Platforms, Hollowed Building, Simple Arena). Difficulty badges, tags, searchable browser, "Study This" annotations. Load clears current scene and instantiates from JSON definitions. Manage tab section (collapsed by default).
+- **Example library** (`HFExampleLibrary`): 5 built-in demo levels (Simple Room, Corridor with Doorway, Jump Puzzle Platforms, Hollowed Building, Simple Arena). Difficulty badges, tags, searchable browser, "Study This" annotations. Load clears current scene and instantiates from JSON definitions. Test tab section (collapsed by default).
 - 63 new tests across 4 files (coach_marks, operation_replay, fuzzy_search, example_library). Total: **944 tests across 54 files**.
 
 ## Done (Terrain & Organic Enhancements — Brush-to-Terrain Pipeline)
@@ -252,12 +252,12 @@ Priorities are informed by a Hammer Editor gap analysis — see GAP_ANALYSIS.md 
 ## Done (Better Terrain Integration — Auto-Connectors)
 - **Auto-connector system** (`hf_auto_connector.gd`): auto-detect cross-layer height boundaries during bake. 4-directional neighbor scan, 6-part canonical dedupe key (handles corners/T-junctions), flood-fill grouping, ramp/stairs/auto mode selection. Connectors include CollisionShape3D for navmesh parsing. Selection-only bakes skip connectors.
 - **Bake pipeline integration**: `postprocess_bake()` with `selection_only` flag. `_append_auto_connectors()` creates meshes + collision shapes. Version-safe `_set_parsed_geometry_type()` static helper for Godot 4.6 navmesh property rename.
-- **Dock UI**: Auto Connectors checkbox, Mode dropdown (Ramp/Stairs/Auto), Step H and Width spinboxes in Manage tab Bake section.
+- **Dock UI**: Auto Connectors checkbox, Mode dropdown (Ramp/Stairs/Auto), Step H and Width spinboxes in the Test tab Bake section.
 - 44 new tests (27 auto_connector + 17 bake_system integration). Total: **1270 tests across 73 files**.
 
 ## Done (Automated Culling — Runtime Occlusion from Brush Geometry)
 - **Occluder generation bake pass** (`hf_bake_system.gd`): scans baked `MeshInstance3D` nodes (including inside `BakedChunk_*` intermediary nodes), groups coplanar triangles by normal (5° threshold) and plane distance (0.1 unit threshold), emits `OccluderInstance3D` with `ArrayOccluder3D` per group exceeding minimum area. Idempotent — re-bake replaces previous occluders.
-- **Configurable thresholds**: `bake_generate_occluders` toggle and `bake_occluder_min_area` (default 4.0 world units²) on LevelRoot. Dock checkbox + SpinBox in Manage tab → Bake section. Settings persist in `.hflevel`.
+- **Configurable thresholds**: `bake_generate_occluders` toggle and `bake_occluder_min_area` (default 4.0 world units²) on LevelRoot. Dock checkbox + SpinBox in Test → Bake. Settings persist in `.hflevel`.
 - **Validation integration**: `check_occlusion_coverage()` runs inside `check_bake_issues()`. Reports missing-occluder warnings (enabled but empty) and coverage stats (occluder count + % of baked AABB surface).
 - 13 new tests (`test_occluder_generation.gd`): flat mesh, chunked hierarchy, coplanar merge, plane separation, min-area filter, idempotency, postprocess toggle, validation. Total: **1283 tests across 75 files**.
 
@@ -277,7 +277,7 @@ Priorities are informed by a Hammer Editor gap analysis — see GAP_ANALYSIS.md 
 - **Dialog lifecycle safety**: `_pending_dialogs` tracking in plugin.gd with auto-free on teardown. All confirmed callbacks guard `is_instance_valid(root)` against scene-change invalidation.
 
 ## Done (Onboarding & Test Quality)
-- **New HammerForge Level** template button in Manage tab → Actions. One-click creation of floor + DefaultSun (DirectionalLight3D) + player spawn. Fully undoable via `capture_sun_info()` / `restore_sun_info()` in state system. DefaultSun is duplicated into Quick Play / Export Playtest scenes; fallback PlaytestSun yaw corrected from -30 to +30.
+- **New HammerForge Level** template button in Test → Actions. One-click creation of floor + DefaultSun (DirectionalLight3D) + player spawn. Fully undoable via `capture_sun_info()` / `restore_sun_info()` in state system. DefaultSun is duplicated into Test Level / Export Playtest scenes; fallback PlaytestSun yaw corrected from -30 to +30.
 - **HFLog test-aware warning wrapper** (`hf_log.gd`): `HFLog.warn()` replaces `push_warning()` at 15 negative-path sites. Tests use `begin_test_capture()` / `end_test_capture()` / `get_captured_warnings()` to suppress expected warnings and assert they were emitted. Eliminates trailing WARNING noise from the test suite.
 - **README onboarding**: Godot version requirement line, Quick Start GIF placeholder, bolded upgrade link.
 
@@ -299,6 +299,13 @@ Priorities are informed by a Hammer Editor gap analysis — see GAP_ANALYSIS.md 
 - `res://hammerforge_entities.json` overlays plugin entity definitions.
 - `.map` import/export of non-axis-aligned brushes uses CUSTOM faces.
 
+## Done (Runtime export and entity reliability — September 2026)
+- Playtest export now creates a playable scene with a player at the selected spawn, recursively owned nested geometry/collision, default lighting, and auto-wired entity I/O.
+- Export preserves world transforms when content is reparented into the packed playtest scene.
+- Foliage and scatter MultiMeshes preserve container-local placement instead of shifting when their parent is transformed.
+- Brush-entity I/O survives bake/export and cleanup, including `func_detail` and trigger post-processing.
+- Validation accepts valid alternate `Entities` containers, and polygon/path tools retain height and trim material settings.
+
 ## Done (Registry collapse, signal batching, snap-to-edge — August 2026)
 - `BrushManager` no longer owns or frees brush nodes; the system cache is the live list.
 - `create_brushes_from_infos`, `delete_brushes_by_id`, `nudge_brushes_by_id`, and `delete_managed_nodes` wrap `begin_signal_batch()` / `end_signal_batch()`.
@@ -309,7 +316,7 @@ Priorities are informed by a Hammer Editor gap analysis — see GAP_ANALYSIS.md 
 - Power-user overlays (radial menu, coach marks, operation replay) are opt-in.
 - Brush cache is the brush-list authority; `BrushManager` writes are null-safe.
 - Dead code removed: welcome panel, unused `BrushPrefab`, `debug_heightmap`, archived quadrant view.
-- Subtract preview labeled as AABB approximation (superseded by live CSG cut overlay).
+- Subtract preview remained opt-in and now uses a live CSG cut overlay with an AABB wireframe fallback.
 - Core characterization tests added for `HFBrushSystem`, `HFPaintSystem`, overlay prefs, and empty baker merge.
 - Docs and `plugin.cfg` updated to match the code. Wave 3 features stay deferred.
 
@@ -317,7 +324,6 @@ Priorities are informed by a Hammer Editor gap analysis — see GAP_ANALYSIS.md 
 - Multiple simultaneous cordons.
 - Multi-tool presets for common workflows.
 - Additional bake pipelines (merge strategies, export helpers).
-- Snap-to-perpendicular mode for the snap system (shipped: dock **P**).
 - Preference packs (e.g. "Speedrunner", "Precision") for one-click workflow presets.
 - Formalized plugin API (`HFEditorPlugin` base class for custom tool scripts with menu/toolbar hooks).
 - Bezier patch editing (control-point-grid surfaces as first-class brush type).
@@ -326,14 +332,14 @@ Priorities are informed by a Hammer Editor gap analysis — see GAP_ANALYSIS.md 
 The May 2026 simplification phase 1 landed shared utilities and migrated low-risk call sites. The following items continue that initiative but each requires a dedicated session with interactive UI/bake validation, or a profiling pass, before landing safely.
 
 ### Continued dock.gd decomposition
-The remaining ~5,100 lines are dominated by `_on_*` signal handlers wired to dock-internal state.
+The current 6,051-line file is still dominated by `_on_*` signal handlers wired to dock-internal state.
 - Split into per-tab handler files: `dock_brush_handler.gd` (done), `dock_paint_handler.gd` (done), `dock_entity_handler.gd` (done), `dock_manage_handler.gd` (Test-tab bake/play done). Target dock.gd shell at ~1,500 lines. File I/O, visgroups, and cordon still live on dock.gd.
 - Extract signal-wiring into `dock_connections.gd`.
 - Consolidate the entity-properties UI builder and the external-tool-settings UI builder (both schema-driven; share ~100 lines of dispatch logic).
 - Migrate `paint_tab_builder.gd` (50 call sites) and `manage_tab_builder.gd` (58 call sites) from `dock._make_*` to direct `HFUIFactory` calls. Mechanical churn — wait until shared with another tab-builder change.
 
 ### plugin.gd decomposition (Phase 3b)
-Current ~3,900 lines. Largest remaining work is viewport input / overlay ownership, not command match blocks:
+Current: 4,318 lines. Largest remaining work is viewport input / overlay ownership, not command match blocks:
 - `_handle_keyboard_input` now delegates to `plugin_input_router.gd` (`HFPluginInputRouter.handle_keyboard`).
 - `_dispatch_viewport_action` is a thin wrapper around `HFPluginCommands.execute`.
 - `_on_context_toolbar_action` and `_on_hotkey_palette_action` now route through `plugin_commands.gd` (`HFPluginCommands.execute`).
@@ -343,26 +349,19 @@ Current ~3,900 lines. Largest remaining work is viewport input / overlay ownersh
 ### Lazy system loading in level_root.gd (Phase 3a)
 - Replace 54 upfront `const X = preload(...)` statements with on-demand `_get_system(name)` accessor.
 - Systems instantiate on first access — reduces startup cost for simple scenes; fixes circular-preload risks as new systems are added.
-- Estimated reduction: level_root.gd 2,578 → ~1,800 lines.
-- Blocked on baseline test coverage (see below) so regressions in untested systems would be caught.
+- Current: 2,844 lines. Continue only behind focused characterization tests; track the remaining decomposition in [#21](https://github.com/saworbit/hammerforge/issues/21).
 
-### Backfill core system tests (Phase 2)
-Seven systems are individually >800 lines and currently untested:
-- `HFBrushSystem` (1,612 lines) — brush CRUD, grouping, selection, pending/committed cuts.
-- `HFBakeSystem` (1,212) — incremental bake, chunking, preview modes, occluder generation.
-- `HFPaintSystem` (926) — multi-layer paint, blend modes, heightmap sync, region streaming.
-- `HFVertexSystem` (876) — vertex/edge sub-modes, merge, split, transitions.
-- `Baker` (828) — snapshot phases, atlas integration, collision output.
-- `BrushInstance` (889) — serialization roundtrip, face-winding migration.
-- `MapIO` (449) — Valve220/Quake export fidelity.
-
-Each needs a dedicated harness because the dependencies (`LevelRoot`, `EditorUndoRedoManager`, `EditorInterface`) require careful stubbing. Backfilling under time pressure produces brittle tests that mask real issues.
+### Risk-focused test gaps
+The current suite covers 1,783 tests across 104 scripts, including the large brush, bake, paint, vertex, baker, brush-instance, and map-I/O systems. Remaining work is concentrated in failure semantics and scale-sensitive paths rather than wholly untested systems:
+- crash-safe destination replacement and truthful manual-save completion ([#33](https://github.com/saworbit/hammerforge/issues/33), [#51](https://github.com/saworbit/hammerforge/issues/51));
+- quoted `.map` property round-trips ([#32](https://github.com/saworbit/hammerforge/issues/32));
+- non-blocking threaded merge/finalization ([#35](https://github.com/saworbit/hammerforge/issues/35));
+- PBR material fidelity and paint export coverage ([#24](https://github.com/saworbit/hammerforge/issues/24), [#39](https://github.com/saworbit/hammerforge/issues/39)).
 
 ### Apply HFValidation broadly
 Currently applied to two `HFBrushSystem` methods as demonstration. Roughly 300 inline `if not root.<container>:` patterns remain across `hf_brush_system`, `hf_paint_system`, `hf_bake_system`, `hf_entity_system`, `baker`. Single-property guards are 1-line either way; the win is centralization. Apply opportunistically when touching each system, not as a bulk sweep.
 
 ### Performance enhancements (Phase 4) — needs profiling first
-- **Signal batching**: `state_system` fires multiple signals per frame during bulk operations. Add `begin_batch()` / `end_batch()` to coalesce UI updates. Picking batch boundaries blindly may regress; needs telemetry on which signals actually fire in storms.
 - **Mesh pooling**: `SubtractPreview`, bake preview, extrude preview, and now Carve/Clip/Hollow previews all create/destroy `MeshInstance3D` nodes frequently. A shared pool with `acquire()`/`release()` could reduce GC pressure. Needs profiling to confirm allocation hotspots.
 - **Preload graph audit**: `level_root.gd` preloads 54 system types upfront. As new systems land, circular-preload risks grow. Move non-critical paths (UI panels, map adapters) to string-based `load()`.
 

--- a/docs/HammerForge_Data_Portability.md
+++ b/docs/HammerForge_Data_Portability.md
@@ -1,6 +1,6 @@
 ﻿# HammerForge Data Portability
 
-Last updated: July 21, 2026
+Last updated: September 2, 2026
 
 This document describes how to move data in and out of HammerForge safely.
 
@@ -25,10 +25,12 @@ This document describes how to move data in and out of HammerForge safely.
 
 ## `.map` Import / Export
 - Use `.map` to exchange basic brush layouts with other editors.
-- Import supports axis-aligned boxes and simple cylinders.
-- Export writes box and cylinder primitives only and does not preserve per-face materials or paint data.
+- Axis-aligned boxes use the optimized primitive path; tilted, clipped, and other non-axis-aligned convex brushes import and export as CUSTOM face geometry.
+- Point-entity key/value properties and brush entity classes round-trip through the supported Classic Quake and Valve 220 adapters.
+- Per-face materials and HammerForge surface-paint layers are not preserved, so `.hflevel` remains the editable source of truth.
 - Treat `.map` as a blockout exchange format, not a full fidelity export.
 - Multi-format export: **Classic Quake** and **Valve 220** format adapters are available via the format selector in the dock File section. Valve 220 includes UV texture axes from FaceData.
+- Known limitation: quoted entity property values containing escaped quotes or backslashes do not yet round-trip reliably; follow [#32](https://github.com/saworbit/hammerforge/issues/32) for that parser fix.
 
 ### Import Vertex Welding
 Legacy .map files from Hammer, TrenchBroom, and other editors often carry floating-point representation drift in vertex coordinates. Two vertices that should be coincident may differ by a fraction of a unit, producing micro-gaps or non-planar faces after import.
@@ -75,9 +77,11 @@ After import, run **Check Only** (Test tab) to detect any remaining non-planar f
 
 ## Autosave Safety
 - Autosave writes happen on a background thread.
+- Saves first write a `.writing` sidecar, then replace the destination.
 - If a write fails (e.g., disk full, permissions), the `autosave_failed` signal fires and the dock shows a red warning label.
 - The next autosave interval retries automatically.
 - Manual save is always available via Test tab → File section.
+- Current limitation: replacement removes an existing destination before renaming the sidecar, so interruption in that window is not fully crash-atomic ([#33](https://github.com/saworbit/hammerforge/issues/33)). Manual save can also report that work was queued before the background write completes ([#51](https://github.com/saworbit/hammerforge/issues/51)). Keep `.hflevel` files in version control and treat the warning state—not the initial queued message—as the authoritative failure signal.
 
 ## Recommended Pipeline
 1. Design and iterate in HammerForge.

--- a/docs/HammerForge_Editor_Smoke_Checklist.md
+++ b/docs/HammerForge_Editor_Smoke_Checklist.md
@@ -1,6 +1,6 @@
 # HammerForge Editor Smoke Checklist
 
-Last updated: July 21, 2026
+Last updated: September 2, 2026
 
 This checklist covers the editor-only flows that are hard to validate in headless tests:
 - viewport input ownership: native Object Select clicks/marquees and filled hit targets, modal HammerForge Face Select, native navigation/gizmos, shortcut scope, and lost-release recovery
@@ -23,6 +23,8 @@ This checklist covers the editor-only flows that are hard to validate in headles
 - example library: load examples, study annotations, search/filter
 - convert selection to heightmap: brush selection → heightmap layer with terrain
 - foliage & scatter: circle/spline preview, commit, clear, UI controls in Paint tab
+- snapping: Grid/Vertex/Center/Edge/Perpendicular candidates and dock toggle state
+- playtest export: player/spawn, nested ownership, world transforms, and entity I/O
 
 ## Prep
 
@@ -51,7 +53,7 @@ Enable the HammerForge plugin if it is not already enabled.
 - Confirm **Test → Settings → Power-user overlays** is unchecked on a fresh prefs file.
 - Press backtick and Ctrl+Shift+T. Confirm a toast tells you to enable Power-user overlays rather than opening the radial menu or replay timeline.
 - Enable the checkbox, then confirm the radial menu and replay timeline work. Disable it again and confirm they disappear.
-- Confirm **Subtract Preview (AABB approx)** is the subtract-preview checkbox label.
+- Confirm **Subtract Preview** is the subtract-preview checkbox label.
 
 ### 1. Fresh Tutorial Startup
 - Open `hf_editor_smoke_start.tscn`.
@@ -121,6 +123,11 @@ Enable the HammerForge plugin if it is not already enabled.
 - Place a wedge or cone above the construction plane and aim at both a real sloped/curved surface and empty space inside its bounds. Drop an entity/prefab or start a surface-based placement at each point. Confirm the first lands on the exact visible face, while the empty-bounds ray continues to real geometry behind or the forward construction plane rather than landing on an AABB wall.
 - Activate Polygon, Path, Measure, and Decal in turn. For each, click once where the tool intentionally misses or passes; confirm the same physical event does not also select, draw, paint, or move a vertex. Switch to a built-in tool and confirm the external tool deactivates and any unfinished preview is cancelled.
 - While an external tool is idle and deliberately passes RMB/MMB/wheel input, confirm native camera navigation remains available without another HammerForge tool receiving the event.
+
+### 2d. Geometry Snap Modes
+- Draw two offset brushes and toggle the **G**, **V**, **C**, **E**, and **P** buttons independently in **Build**. Confirm the viewport indicator and dock state agree after each toggle.
+- With Vertex enabled, drag near a brush AABB corner; with Center enabled, drag near its center; with Edge enabled, drag near an AABB-edge midpoint. Confirm each candidate wins only within the snap threshold.
+- With Perpendicular enabled, drag near an AABB edge and confirm the point lands at the closest projection on that edge. Combine modes and confirm the closest eligible geometry candidate wins over a farther grid point.
 
 ### 3. Guided Step Flow
 - Step 1: draw an additive room brush; confirm the tutorial advances.
@@ -403,6 +410,7 @@ Enable the HammerForge plugin if it is not already enabled.
 - Set density to 2.0, radius to 5.0. Click **Preview**. Confirm dot instances appear in the viewport around the center of your selection.
 - Change preview mode to Wireframe; click **Preview** again; confirm wireframe preview replaces dots.
 - Click **Scatter** to commit. Confirm a toast appears ("Scattered N instances") and the preview is replaced by a permanent MultiMeshInstance3D.
+- Move or rotate the committed scatter container (or its parent), rebuild/commit again, and confirm instances retain the intended container-local placement rather than receiving the parent transform twice.
 - Click **Clear**. Confirm the preview node is removed from the viewport.
 - Switch shape to Spline. Select 3+ nodes/brushes. Click **Preview**. Confirm scatter instances follow the path defined by the selected node positions.
 - With only 1 node selected in Spline mode, click **Preview**. Confirm a warning toast appears and no preview is created.
@@ -447,8 +455,11 @@ Enable the HammerForge plugin if it is not already enabled.
 ### 25. Export Playtest Build
 - Open **Test → Advanced Bake**. Click **Export Playtest Build**.
 - If no spawn exists, confirm a toast about auto-creating a default spawn, and confirm the spawn creation is undoable.
-- Confirm the level bakes and a playtest scene launches.
+- Confirm the level bakes and a playtest scene launches with a controllable player at the active spawn and the expected spawn yaw.
+- Put a mesh/collision child below an extra nested Node3D and export again. Confirm the nested geometry and collision are present in the packed scene.
+- Move or rotate the LevelRoot, an entity container, and representative exported content. Confirm the launched scene preserves their visible world transforms without double-applying a parent transform.
 - If entities have I/O connections, confirm the exported scene contains an `HFIODispatcher` child node.
+- Tie a brush as `func_detail` or a trigger, add an I/O connection, export, and confirm both the tied brush and its runtime connection survive.
 - Stop the playtest. Undo; confirm the auto-created spawn is removed.
 
 ### 26. Displacement Surfaces

--- a/docs/HammerForge_MVP_GUIDE.md
+++ b/docs/HammerForge_MVP_GUIDE.md
@@ -1,6 +1,6 @@
 # HammerForge MVP Guide
 
-Last updated: July 21, 2026
+Last updated: September 2, 2026
 
 This guide is for contributors implementing or extending the MVP.
 
@@ -15,7 +15,7 @@ This guide is for contributors implementing or extending the MVP.
 HammerForge uses a **coordinator + subsystems** pattern:
 
 - **`plugin.gd`** handles editor input and routes to `LevelRoot`. Uses sticky `active_root` with deep recursive tree search.
-- **`level_root.gd`** is a coordinator (~2,200 lines) that owns containers, exports, and signals. All public methods delegate to subsystem classes. Default UX is Draw → material → entity → bake → Test Level; power-user overlays are opt-in.
+- **`level_root.gd`** is a 2,844-line coordinator that owns containers, exports, and signals. Public methods delegate to subsystem classes; continued decomposition is tracked in the roadmap. Default UX is Draw → material → entity → bake → Test Level; power-user overlays are opt-in.
 - **Subsystems** (`systems/*.gd`) are `RefCounted` classes that do the real work. Each receives a `LevelRoot` reference in its constructor.
 - **`input_state.gd`** is a state machine managing drag/paint modes.
 - **`dock.gd`** presents 4 tabs (Build, Paint, Objects, Test) with programmatic, persisted collapsible sections. Selection tools appear contextually in Build when brushes are selected. The primary toolbar exposes Draw, Select, Paint, More, and Help.
@@ -29,7 +29,7 @@ See [DEVELOPMENT.md](../DEVELOPMENT.md) for the full file tree and architecture 
 - `HFDragSystem` manages the two-stage draw lifecycle (base drag -> height click) and owns the `HFInputState` instance.
 - `HFExtrudeTool` handles face extrusion: picks a face via `FaceSelector`, shows a preview, and commits a new DraftBrush on release. Supports Up (along face normal) and Down (opposite).
 - `HFBrushSystem` handles brush CRUD, pending/committed cuts, materials, picking, hollow, clip, tie/untie, move floor/ceiling, and UV justify. Failable operations (hollow, clip, delete) return `HFOpResult` with actionable fix hints.
-- `HFSnapSystem` provides centralized snapping with Grid, Vertex (brush corners), and Center modes. `_snap_point()` delegates to it.
+- `HFSnapSystem` provides centralized Grid, Vertex, Center, Edge-midpoint, and Perpendicular snapping. `_snap_point()` delegates to it.
 - `HFInputState` exposes `get_drag_dimensions()` for live W x H x D display during drag gestures.
 - PendingCuts allow staging subtract operations before applying.
 
@@ -42,7 +42,7 @@ See [DEVELOPMENT.md](../DEVELOPMENT.md) for the full file tree and architecture 
 - Per-chunk blend images drive a four-slot shader (`hf_blend.gdshader`).
 - Blend tool paints material blend weights (slots B/C/D) on already-filled cells.
 - Auto-connectors (`HFConnectorTool`) generate ramp/stair meshes between layers.
-- Foliage populator (`HFFoliagePopulator`) scatters MultiMeshInstance3D with height/slope filtering.
+- Foliage populator (`HFFoliagePopulator`) scatters `MultiMeshInstance3D` content with height/slope filtering and container-local transforms.
 - Stable IDs are used to reconcile generated nodes without churn.
 
 ### Face Materials + Surface Paint (`HFPaintSystem`)
@@ -72,16 +72,18 @@ See [DEVELOPMENT.md](../DEVELOPMENT.md) for the full file tree and architecture 
 - Heightmap floor meshes are duplicated directly into baked output (bypass CSG) with trimesh collision.
 - Supports single and chunked baking modes.
 - Optional: mesh merging, LODs, lightmap UV2, navmesh, collision.
+- Post-processing carries tied brush entities (`func_detail`, `func_wall`, and triggers) and their I/O metadata into runtime output without treating them as structural CSG.
+- Playtest export adds a player at the active spawn, preserves reparented world transforms, assigns recursive ownership to nested geometry/collision, and wires entity I/O when present.
 
 ### Entities (`HFEntitySystem`)
 - Entities live under LevelRoot/Entities or `is_entity` meta.
 - Entities are excluded from bake.
 - Definitions are loaded from `addons/hammerforge/entities.json`.
-- **Entity I/O**: Source-style input/output connections stored as `entity_io_outputs` meta. Fields: output_name, target_name, input_name, parameter, delay, fire_once. Managed via `add_entity_output()`, `remove_entity_output()`, `get_entity_outputs()`. Connections serialize with entity info in `.hflevel`.
+- **Entity I/O**: Source-style input/output connections stored as `entity_io_outputs` meta. Fields: output_name, target_name, input_name, parameter, delay, fire_once. Managed via `add_entity_output()`, `remove_entity_output()`, `get_entity_outputs()`. Connections serialize with point and tied-brush entity info in `.hflevel`, bake output, and playtest exports.
 
 ### Subtract Preview (`HFSubtractPreview`)
 - `RefCounted` subsystem showing the live CSG cut between overlapping additive and subtractive DraftBrushes.
-- Uses `ImmediateMesh` with `PRIMITIVE_LINES` (same 12-edge box pattern as cordon wireframe).
+- Uses live CSG intersection meshes when available, with an `ImmediateMesh` AABB wireframe as a fast fallback.
 - Debounced rebuild (0.15s), MeshInstance3D pool (max 50 entries).
 - Connects to `brush_added`, `brush_removed`, `brush_changed` signals for automatic updates.
 - Toggle via `show_subtract_preview` export on LevelRoot. Persisted in state settings.
@@ -112,6 +114,7 @@ See [DEVELOPMENT.md](../DEVELOPMENT.md) for the full file tree and architecture 
 ### Persistence (`HFFileSystem` + `HFStateSystem`)
 - `HFStateSystem` captures and restores brush/entity/paint/settings state for undo/redo.
 - `HFFileSystem` handles .hflevel save/load, .map import/export, and glTF export with threaded I/O.
+- See [Data Portability](HammerForge_Data_Portability.md) for fidelity boundaries and current save-safety limitations.
 
 ## High-Level Flow
 1. Input is handled by `plugin.gd` (EditorPlugin) with typed references to `LevelRoot` and the dock.

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -1,6 +1,6 @@
 # HammerForge User Guide
 
-Last updated: July 21, 2026
+Last updated: September 2, 2026
 
 This guide covers the current HammerForge workflow in Godot 4.7: brush-based greyboxing, bake, entities, floor paint, and per-face materials/UVs.
 
@@ -187,7 +187,7 @@ The primary toolbar keeps the everyday path visible: **Draw**, **Select**, **Pai
 - **Shape**: choose from 15 built-in shapes with recognizable icons (plus Custom). Sides appears only for compatible pyramid/prism shapes.
 - **Size** X/Y/Z: defaults for new brushes.
 - **Grid Snap**: snap increment with quick preset buttons (1, 2, 4, 8, 16, 32, 64).
-- **Snap Modes**: G (Grid), V (Vertex — snap to brush corners), C (Center — snap to brush centers). Toggle independently; closest geometry within threshold beats grid snap.
+- **Snap Modes**: G (Grid), V (Vertex), C (Center), E (Edge midpoint), and P (Perpendicular projection). Toggle independently; the closest eligible geometry candidate within the threshold beats grid snap.
 - **Material**: active material picker.
 - **Physics Layer**: collision layer for baked output.
 - **Texture Lock**: UV alignment preserved on move/resize (enabled by default).
@@ -289,7 +289,10 @@ Click **Export Playtest Build** in **Test → Advanced Bake** to create a standa
 - Validates spawn (severity ≥ 2 blocks the export).
 - If no spawn exists, auto-creates a default (fully undoable with state capture).
 - Bakes the level in Full mode.
-- Packs baked geometry, entities, DefaultSun (if present), and fallback lighting (DirectionalLight3D + WorldEnvironment if no light exists) into a temporary scene at `user://hammerforge_playtest.tscn`.
+- Packs baked geometry, brush entities, point entities, DefaultSun (if present), and fallback lighting (DirectionalLight3D + WorldEnvironment if no light exists) into a temporary scene at `user://hammerforge_playtest.tscn`.
+- Adds the playtest player controller at the active spawn and applies the spawn's yaw.
+- Preserves world transforms while reparenting export content and recursively owns nested geometry/collision so it survives scene packing.
+- Injects the entity I/O runtime automatically when the exported content contains connections.
 - Launches the scene via `EditorInterface.play_custom_scene()`.
 - A toast confirms "Playtest launched" on success.
 
@@ -541,17 +544,19 @@ Enable **Subtract Preview** in Test tab → Settings to see the live CSG cut bet
 - **Autosave warning**: a red "Autosave failed!" label appears if a threaded save fails. Auto-hides after 30 seconds.
 
 ## Snap Modes
-HammerForge supports three snap modes that can be combined:
+HammerForge supports five snap modes that can be combined:
 
 | Mode | Button | Behavior |
 |------|--------|----------|
 | **Grid** | G | Snap to grid increments (default, always-on) |
-| **Vertex** | V | Snap to the 8 corners of existing brushes |
+| **Vertex** | V | Snap to the 8 transformed AABB corners of existing brushes |
 | **Center** | C | Snap to the center point of existing brushes |
+| **Edge** | E | Snap to the midpoint of an existing brush AABB edge |
+| **Perpendicular** | P | Snap to the closest perpendicular projection on a brush AABB edge |
 
-Toggle modes independently using the G/V/C buttons below the Grid Snap row in the Build tab. When multiple modes are enabled, the closest candidate wins — a nearby brush corner will beat a farther grid point. The snap threshold (default 2.0 world units) determines how close you need to be to a geometry candidate for it to take effect.
+Toggle modes independently using the G/V/C/E/P buttons below the Grid Snap row in the Build tab. When multiple modes are enabled, the closest candidate wins — a nearby brush corner will beat a farther grid point. The snap threshold (default 2.0 world units) determines how close you need to be to a geometry candidate for it to take effect.
 
-**Tip:** Enable Vertex snap when aligning brushes edge-to-edge. Enable Center snap when centering a brush inside another.
+**Tip:** Use Vertex for corner alignment, Center for centered placement, Edge for exact midpoints, and Perpendicular for a right-angle projection onto an edge.
 
 ## Undo/Redo
 - All brush operations (draw, delete, nudge, resize, paint, hollow, clip) support undo/redo.


### PR DESCRIPTION
## Summary
- align the README, user guide, contributor guide, spec, roadmap, and smoke checklist with current main
- document five snap modes, complete playtest exports, brush entity I/O, and MultiMesh transform behavior
- replace stale test and source counts with verified current values
- document current map and save-safety limitations with tracking issues

## Verification
- Godot 4.7 GUT suite: 1,783 tests, 1,776 passing, 7 intentional risky/no-assert safety tests, 7,825 assertions
- relative Markdown link audit
- documented per-file test-count audit
- stale terminology scan
- git diff --check