### PR TITLE
Report saves after durable writes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -254,7 +254,7 @@ addons/hammerforge/
 The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs on push and PR to `main`:
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
-- **GUT unit + integration tests** -- 1,783 tests across 104 test scripts (1,776 passing plus seven intentional no-assert safety tests; 7,825 assertions; verified in CI September 2, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 1,790 tests across 104 test scripts (1,783 passing plus seven intentional no-assert safety tests; 7,855 assertions; verified in CI September 2, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -508,6 +508,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 38 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 2, 2026): **1,783 tests** across **104 scripts** (**1,776 passing** plus seven intentional no-assert safety tests; **7,825 assertions**).
+Full suite (verified in CI on September 2, 2026): **1,790 tests** across **104 scripts** (**1,783 passing** plus seven intentional no-assert safety tests; **7,855 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-1776%20passing-brightgreen" alt="1776 tests passing">
+  <img src="https://img.shields.io/badge/Tests-1783%20passing-brightgreen" alt="1783 tests passing">
   <img src="https://img.shields.io/badge/GDScript-44k%2B%20lines-blueviolet" alt="44k+ lines">
 </p>
 
@@ -41,7 +41,7 @@ HammerForge is a single `addons/` folder. No external tools, no custom builds, n
 
 | | |
 |---|---|
-| **Subsystem-based coordinator architecture** | **1,783 unit + integration tests** with CI on every push |
+| **Subsystem-based coordinator architecture** | **1,790 unit + integration tests** with CI on every push |
 | **15 brush shapes** (box through dodecahedron) | **150 built-in prototype textures** for instant greyboxing |
 | **Quake `.map`** + **glTF `.glb`** export | **.hflevel** native format with threaded I/O |
 | **Customizable keymaps** (JSON) | **Plugin API** for custom tools |
@@ -370,7 +370,7 @@ Shortcuts marked with **\*** are rebindable via `user://hammerforge_keymap.json`
 
 ## Testing
 
-The verified Godot 4.7 CI run on September 2, 2026 contains **1,783 tests across 104 scripts**: **1,776 passing tests**, seven intentional no-assert safety tests, and **7,825 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 CI run on September 2, 2026 contains **1,790 tests across 104 scripts**: **1,783 passing tests**, seven intentional no-assert safety tests, and **7,855 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -352,7 +352,7 @@ Current: 4,318 lines. Largest remaining work is viewport input / overlay ownersh
 - Current: 2,844 lines. Continue only behind focused characterization tests; track the remaining decomposition in [#21](https://github.com/saworbit/hammerforge/issues/21).
 
 ### Risk-focused test gaps
-The current suite covers 1,783 tests across 104 scripts, including the large brush, bake, paint, vertex, baker, brush-instance, and map-I/O systems. Remaining work is concentrated in failure semantics and scale-sensitive paths rather than wholly untested systems:
+The current suite covers 1,790 tests across 104 scripts, including the large brush, bake, paint, vertex, baker, brush-instance, and map-I/O systems. Remaining work is concentrated in failure semantics and scale-sensitive paths rather than wholly untested systems:
 - crash-safe destination replacement and truthful manual-save completion ([#33](https://github.com/saworbit/hammerforge/issues/33), [#51](https://github.com/saworbit/hammerforge/issues/51));
 - quoted `.map` property round-trips ([#32](https://github.com/saworbit/hammerforge/issues/32));
 - non-blocking threaded merge/finalization ([#35](https://github.com/saworbit/hammerforge/issues/35));

--- a/addons/hammerforge/dock.gd
+++ b/addons/hammerforge/dock.gd
@@ -3157,6 +3157,18 @@ func _connect_root_signals() -> void:
 			"autosave_failed", Callable(self, "_on_autosave_failed")
 		):
 			connected_root.connect("autosave_failed", Callable(self, "_on_autosave_failed"))
+	if connected_root.has_signal("hflevel_save_completed"):
+		if not connected_root.is_connected(
+			"hflevel_save_completed", Callable(self, "_on_hflevel_save_completed")
+		):
+			connected_root.connect(
+				"hflevel_save_completed", Callable(self, "_on_hflevel_save_completed")
+			)
+	if connected_root.has_signal("hflevel_save_failed"):
+		if not connected_root.is_connected(
+			"hflevel_save_failed", Callable(self, "_on_hflevel_save_failed")
+		):
+			connected_root.connect("hflevel_save_failed", Callable(self, "_on_hflevel_save_failed"))
 	if connected_root.has_signal("paint_layer_changed"):
 		if not connected_root.is_connected(
 			"paint_layer_changed", Callable(self, "_on_root_paint_layer_changed")
@@ -3222,6 +3234,20 @@ func _disconnect_root_signals() -> void:
 	if connected_root.has_signal("autosave_failed"):
 		if connected_root.is_connected("autosave_failed", Callable(self, "_on_autosave_failed")):
 			connected_root.disconnect("autosave_failed", Callable(self, "_on_autosave_failed"))
+	if connected_root.has_signal("hflevel_save_completed"):
+		if connected_root.is_connected(
+			"hflevel_save_completed", Callable(self, "_on_hflevel_save_completed")
+		):
+			connected_root.disconnect(
+				"hflevel_save_completed", Callable(self, "_on_hflevel_save_completed")
+			)
+	if connected_root.has_signal("hflevel_save_failed"):
+		if connected_root.is_connected(
+			"hflevel_save_failed", Callable(self, "_on_hflevel_save_failed")
+		):
+			connected_root.disconnect(
+				"hflevel_save_failed", Callable(self, "_on_hflevel_save_failed")
+			)
 	if connected_root.has_signal("paint_layer_changed"):
 		if connected_root.is_connected(
 			"paint_layer_changed", Callable(self, "_on_root_paint_layer_changed")
@@ -3398,6 +3424,20 @@ func _on_autosave_failed(error_message: String) -> void:
 					if is_instance_valid(_autosave_warning):
 						_autosave_warning.visible = false
 			)
+
+
+func _on_hflevel_save_completed(path: String) -> void:
+	_set_status("Saved .hflevel", false, 3.0)
+	show_toast("Saved: %s" % path.get_file(), 0)
+	if _user_prefs:
+		_user_prefs.add_recent_file(path)
+		_user_prefs.save()
+
+
+func _on_hflevel_save_failed(path: String, error_message: String) -> void:
+	push_warning("HammerForge save failed for %s: %s" % [path, error_message])
+	_set_status("Failed to save .hflevel: %s" % path, true, 5.0)
+	show_toast("Save failed: %s" % path, 2)
 
 
 func _on_root_user_message(text: String, level: int) -> void:
@@ -4845,14 +4885,11 @@ func _on_hflevel_save_selected(path: String) -> void:
 		_set_status("No LevelRoot for .hflevel save", true)
 		return
 	var err = int(level_root.save_hflevel(path, true))
-	_set_status("Saved .hflevel" if err == OK else "Failed to save .hflevel", err != OK, 3.0)
 	if err != OK:
+		_set_status("Failed to save .hflevel", true, 3.0)
 		show_toast("Failed to save .hflevel: %s" % path.get_file(), 2)
 	else:
-		show_toast("Saved: %s" % path.get_file(), 0)
-	if err == OK and _user_prefs:
-		_user_prefs.add_recent_file(path)
-		_user_prefs.save()
+		_set_status("Saving .hflevel...", false)
 
 
 func _on_hflevel_load_selected(path: String) -> void:

--- a/addons/hammerforge/hflevel_io.gd
+++ b/addons/hammerforge/hflevel_io.gd
@@ -222,13 +222,50 @@ static func write_bytes_atomic(path: String, payload: PackedByteArray) -> int:
 		push_error("HFLevelIO: store_buffer failed for %s (error: %d)" % [tmp_path, err])
 		DirAccess.remove_absolute(tmp_path)
 		return err
-	if FileAccess.file_exists(path):
-		DirAccess.remove_absolute(path)
+	return _replace_file_atomic(path, tmp_path)
+
+
+static func _replace_file_atomic(path: String, tmp_path: String) -> int:
+	var backup_path := path + ".previous"
+	if not FileAccess.file_exists(path):
+		if FileAccess.file_exists(backup_path):
+			var recover_err := DirAccess.rename_absolute(backup_path, path)
+			if recover_err != OK:
+				return recover_err
+		else:
+			var first_rename := DirAccess.rename_absolute(tmp_path, path)
+			if first_rename != OK:
+				push_error("HFLevelIO: rename failed for %s (error: %d)" % [path, first_rename])
+				DirAccess.remove_absolute(tmp_path)
+			return first_rename
+	if FileAccess.file_exists(backup_path):
+		var stale_err := DirAccess.remove_absolute(backup_path)
+		if stale_err != OK:
+			return stale_err
+	var backup_err := DirAccess.copy_absolute(path, backup_path)
+	if backup_err != OK:
+		push_error("HFLevelIO: backup failed for %s (error: %d)" % [path, backup_err])
+		DirAccess.remove_absolute(tmp_path)
+		return backup_err
+	var remove_err := DirAccess.remove_absolute(path)
+	if remove_err != OK:
+		DirAccess.remove_absolute(backup_path)
+		DirAccess.remove_absolute(tmp_path)
+		return remove_err
 	var renamed := DirAccess.rename_absolute(tmp_path, path)
 	if renamed != OK:
 		push_error("HFLevelIO: rename failed for %s (error: %d)" % [path, renamed])
+		var restore_err := DirAccess.rename_absolute(backup_path, path)
+		if restore_err != OK:
+			push_error(
+				(
+					"HFLevelIO: restore failed for %s; previous file remains at %s (error: %d)"
+					% [path, backup_path, restore_err]
+				)
+			)
 		DirAccess.remove_absolute(tmp_path)
 		return renamed
+	DirAccess.remove_absolute(backup_path)
 	return OK
 
 
@@ -241,6 +278,11 @@ static func save_to_path(path: String, data: Dictionary, compress: bool = true) 
 static func load_from_path(path: String) -> Dictionary:
 	if path == "":
 		return {}
+	if not FileAccess.file_exists(path) and FileAccess.file_exists(path + ".previous"):
+		var recover_err := DirAccess.rename_absolute(path + ".previous", path)
+		if recover_err != OK:
+			push_error("HFLevelIO: recovery failed for %s (error: %d)" % [path, recover_err])
+			return {}
 	if not FileAccess.file_exists(path):
 		return {}
 	var file = FileAccess.open(path, FileAccess.READ)

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -197,6 +197,8 @@ signal face_selection_changed
 signal state_saved
 signal state_loaded
 signal autosave_failed(error_message: String)
+signal hflevel_save_completed(path: String)
+signal hflevel_save_failed(path: String, error_message: String)
 signal user_message(text: String, level: int)
 
 # ---------------------------------------------------------------------------
@@ -606,13 +608,28 @@ func _exit_tree() -> void:
 func _process(_delta: float) -> void:
 	if not Engine.is_editor_hint():
 		return
-	var write_error := file_system.process_thread_queue()
-	if write_error != "":
-		autosave_failed.emit(write_error)
+	_process_hflevel_saves()
 	if io_visualizer:
 		io_visualizer.process()
 	if subtract_preview and subtract_preview.is_enabled():
 		subtract_preview.process(_delta)
+
+
+func _process_hflevel_saves() -> void:
+	file_system.process_thread_queue()
+	for result in file_system.take_completed_saves():
+		var write_error := str(result.get("error", ""))
+		var save_path := str(result.get("path", ""))
+		var is_autosave := bool(result.get("autosave", false))
+		if write_error != "":
+			if is_autosave:
+				autosave_failed.emit(write_error)
+			else:
+				hflevel_save_failed.emit(save_path, write_error)
+			continue
+		state_saved.emit()
+		if not is_autosave:
+			hflevel_save_completed.emit(save_path)
 
 
 # ===========================================================================
@@ -1847,11 +1864,8 @@ func _apply_hflevel_settings(settings: Dictionary) -> void:
 # ===========================================================================
 
 
-func save_hflevel(path: String = "", force: bool = false) -> int:
-	var err = file_system.save_hflevel(path, force)
-	if err == OK:
-		state_saved.emit()
-	return err
+func save_hflevel(path: String = "", force: bool = false, autosave: bool = false) -> int:
+	return file_system.save_hflevel(path, force, autosave)
 
 
 func load_hflevel(path: String = "") -> bool:
@@ -2466,7 +2480,7 @@ func _setup_autosave() -> void:
 func _on_autosave_timeout() -> void:
 	if not hflevel_autosave_enabled:
 		return
-	save_hflevel(hflevel_autosave_path, true)
+	save_hflevel(hflevel_autosave_path, true, true)
 
 
 func _set_hflevel_autosave_enabled(value: bool) -> void:

--- a/addons/hammerforge/systems/hf_file_system.gd
+++ b/addons/hammerforge/systems/hf_file_system.gd
@@ -9,8 +9,9 @@ const HFMapValve220Type = preload("../map_adapters/hf_map_valve220.gd")
 
 var root: Node3D
 var _hflevel_thread: Thread = null
-var _hflevel_pending: Dictionary = {}
+var _hflevel_pending: Array[Dictionary] = []
 var _hflevel_last_hash: int = 0
+var _completed_saves: Array[Dictionary] = []
 ## Last write error observed on the main thread (thread result is returned from wait_to_finish).
 var _last_write_error := ""
 ## Set by process_thread_queue() from the worker result (true when hash matched).
@@ -21,7 +22,7 @@ func _init(level_root: Node3D) -> void:
 	root = level_root
 
 
-func save_hflevel(path: String = "", force: bool = false) -> int:
+func save_hflevel(path: String = "", force: bool = false, autosave: bool = false) -> int:
 	var target = path if path != "" else root.hflevel_autosave_path
 	if target == "":
 		return ERR_INVALID_PARAMETER
@@ -36,7 +37,7 @@ func save_hflevel(path: String = "", force: bool = false) -> int:
 	var compress := true
 	if root:
 		compress = bool(root.hflevel_compress)
-	start_hflevel_thread(target, encoded, compress, force)
+	start_hflevel_thread(target, encoded, compress, force, autosave)
 	return OK
 
 
@@ -125,7 +126,9 @@ func ensure_dir_for_path(path: String) -> void:
 		DirAccess.make_dir_recursive_absolute(dir_path)
 
 
-func start_hflevel_thread(path: String, encoded: Dictionary, compress: bool, force: bool) -> void:
+func start_hflevel_thread(
+	path: String, encoded: Dictionary, compress: bool, force: bool, autosave: bool = false
+) -> void:
 	if path == "":
 		return
 	var abs_path = ProjectSettings.globalize_path(path)
@@ -136,43 +139,74 @@ func start_hflevel_thread(path: String, encoded: Dictionary, compress: bool, for
 		autosave_abs = ProjectSettings.globalize_path(str(root.hflevel_autosave_path))
 	var job := {
 		"path": abs_path,
+		"display_path": path,
 		"encoded": encoded,
 		"compress": compress,
 		"force": force,
 		"keep": keep,
 		"autosave_abs": autosave_abs,
+		"autosave": autosave,
 		"last_hash": _hflevel_last_hash,
 	}
-	if _hflevel_thread and _hflevel_thread.is_alive():
-		job["force"] = true
-		_hflevel_pending = job
-		return
+	if _hflevel_thread:
+		if _hflevel_thread.is_alive():
+			job["force"] = true
+			_hflevel_pending.append(job)
+			return
+		_apply_thread_result(_hflevel_thread.wait_to_finish())
+		_hflevel_thread = null
 	_hflevel_thread = Thread.new()
 	_hflevel_thread.start(Callable(self, "_hflevel_thread_encode_and_write").bind(job))
 
 
 func _hflevel_thread_encode_and_write(job: Dictionary) -> Dictionary:
 	var path: String = str(job.get("path", ""))
+	var display_path: String = str(job.get("display_path", path))
 	var encoded: Dictionary = job.get("encoded", {})
 	var compress: bool = bool(job.get("compress", true))
 	var force: bool = bool(job.get("force", false))
 	var last_hash: int = int(job.get("last_hash", 0))
 	var keep: int = int(job.get("keep", 0))
 	var autosave_abs: String = str(job.get("autosave_abs", ""))
+	var autosave: bool = bool(job.get("autosave", false))
 	var packed: Dictionary = HFLevelIO.encode_payload_job(encoded, compress)
 	var hash_value: int = int(packed.get("hash", 0))
 	if not force and hash_value != 0 and hash_value == last_hash:
-		return {"error": "", "hash": hash_value, "skipped": true}
+		return {
+			"error": "",
+			"hash": hash_value,
+			"skipped": true,
+			"path": display_path,
+			"autosave": autosave,
+		}
 	var payload: PackedByteArray = packed.get("payload", PackedByteArray())
 	if payload.is_empty():
-		return {"error": "HFLevel: empty payload", "hash": hash_value, "skipped": true}
+		return {
+			"error": "HFLevel: empty payload",
+			"hash": hash_value,
+			"skipped": true,
+			"path": display_path,
+			"autosave": autosave,
+		}
 	var err := HFLevelIO.write_bytes_atomic(path, payload)
 	if err != OK:
 		var msg := "HFLevel: Failed to write file: %s (error: %d)" % [path, err]
 		push_error(msg)
-		return {"error": msg, "hash": hash_value, "skipped": false}
+		return {
+			"error": msg,
+			"hash": hash_value,
+			"skipped": false,
+			"path": display_path,
+			"autosave": autosave,
+		}
 	_write_autosave_rotation(path, payload, keep, autosave_abs)
-	return {"error": "", "hash": hash_value, "skipped": false}
+	return {
+		"error": "",
+		"hash": hash_value,
+		"skipped": false,
+		"path": display_path,
+		"autosave": autosave,
+	}
 
 
 func _write_autosave_rotation(
@@ -226,20 +260,24 @@ func process_thread_queue() -> String:
 		_hflevel_thread = null
 		var error := _apply_thread_result(result)
 		if not _hflevel_pending.is_empty():
-			var next = _hflevel_pending.duplicate(true)
-			_hflevel_pending.clear()
+			var next: Dictionary = _hflevel_pending.pop_front()
 			_start_pending_job(next)
 		return error
 	return ""
+
+
+func take_completed_saves() -> Array[Dictionary]:
+	var completed := _completed_saves.duplicate(true)
+	_completed_saves.clear()
+	return completed
 
 
 func shutdown() -> void:
 	if _hflevel_thread:
 		_apply_thread_result(_hflevel_thread.wait_to_finish())
 		_hflevel_thread = null
-	if not _hflevel_pending.is_empty():
-		var next = _hflevel_pending.duplicate(true)
-		_hflevel_pending.clear()
+	while not _hflevel_pending.is_empty():
+		var next: Dictionary = _hflevel_pending.pop_front()
 		_flush_job_sync(next)
 	_last_write_error = ""
 
@@ -252,6 +290,7 @@ func _apply_thread_result(result: Variant) -> String:
 			_hflevel_last_hash = int(result.get("hash", 0))
 		last_encode_skipped = bool(result.get("skipped", false))
 		_last_write_error = error
+		_completed_saves.append((result as Dictionary).duplicate(true))
 		return error
 	if result is String:
 		_last_write_error = result

--- a/tests/test_dock_usability.gd
+++ b/tests/test_dock_usability.gd
@@ -85,6 +85,49 @@ func test_async_bake_and_commit_cuts_never_enter_undo_as_coroutines() -> void:
 	assert_false(helper_body.contains("await "))
 
 
+func test_manual_save_reports_completion_after_worker_finishes() -> void:
+	var root := LevelRoot.new()
+	root.auto_spawn_player = false
+	root.commit_freeze = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	dock.level_root = root
+	dock.connected_root = root
+	dock._user_prefs = null
+	dock._connect_root_signals()
+	var path := "user://dock_manual_save_completion_test.hflevel"
+	DirAccess.remove_absolute(path)
+	dock._on_hflevel_save_selected(path)
+	assert_eq(dock.status_label.text, "Saving .hflevel...")
+	var guard := 0
+	while (
+		root.file_system._hflevel_thread
+		and root.file_system._hflevel_thread.is_alive()
+		and guard < 200
+	):
+		await get_tree().process_frame
+		guard += 1
+	root._process_hflevel_saves()
+	assert_eq(dock.status_label.text, "Saved .hflevel")
+	assert_true(FileAccess.file_exists(path))
+	DirAccess.remove_absolute(path)
+
+
+func test_manual_save_failure_names_destination() -> void:
+	var root := LevelRoot.new()
+	root.auto_spawn_player = false
+	root.commit_freeze = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	dock.level_root = root
+	dock.connected_root = root
+	dock._connect_root_signals()
+	var path := "user://blocked/manual.hflevel"
+	root.hflevel_save_failed.emit(path, "permission denied")
+	assert_true(dock.status_label.text.contains(path))
+	assert_true(dock.status_label.text.begins_with("Failed to save"))
+
+
 func _is_descendant_of(node: Node, ancestor: Node) -> bool:
 	var current := node
 	while current:

--- a/tests/test_hf_file_system.gd
+++ b/tests/test_hf_file_system.gd
@@ -20,6 +20,8 @@ func after_each():
 		files.shutdown()
 	if FileAccess.file_exists(_save_path):
 		DirAccess.remove_absolute(_save_path)
+	if FileAccess.file_exists(_second_save_path()):
+		DirAccess.remove_absolute(_second_save_path())
 	files = null
 	root = null
 
@@ -42,10 +44,20 @@ func _capture_hflevel_state() -> Dictionary:
 
 func _drain_write() -> String:
 	var guard := 0
-	while files._hflevel_thread and files._hflevel_thread.is_alive() and guard < 200:
-		await get_tree().process_frame
-		guard += 1
-	return files.process_thread_queue()
+	var last_error := ""
+	while guard < 400:
+		if files._hflevel_thread and files._hflevel_thread.is_alive():
+			await get_tree().process_frame
+			guard += 1
+			continue
+		last_error = files.process_thread_queue()
+		if not files._hflevel_thread and files._hflevel_pending.is_empty():
+			return last_error
+	return last_error
+
+
+func _second_save_path() -> String:
+	return "user://hf_encode_thread_test_second.hflevel"
 
 
 func test_save_encodes_on_write_thread_and_round_trips():
@@ -55,6 +67,31 @@ func test_save_encodes_on_write_thread_and_round_trips():
 	assert_true(FileAccess.file_exists(_save_path))
 	var loaded: Dictionary = HFLevelIO.load_from_path(_save_path)
 	assert_eq(loaded.get("name"), "level")
+	var completed := files.take_completed_saves()
+	assert_eq(completed.size(), 1)
+	assert_eq(completed[0].get("path"), _save_path)
+	assert_false(bool(completed[0].get("autosave", true)))
+
+
+func test_autosave_completion_keeps_its_kind():
+	assert_eq(files.save_hflevel(_save_path, true, true), OK)
+	await _drain_write()
+	var completed := files.take_completed_saves()
+	assert_eq(completed.size(), 1)
+	assert_true(bool(completed[0].get("autosave", false)))
+
+
+func test_queued_manual_saves_each_report_their_destination():
+	assert_eq(files.save_hflevel(_save_path, true), OK)
+	root.captured = {"name": "second"}
+	assert_eq(files.save_hflevel(_second_save_path(), true), OK)
+	await _drain_write()
+	var completed := files.take_completed_saves()
+	assert_eq(completed.size(), 2)
+	assert_eq(completed[0].get("path"), _save_path)
+	assert_eq(completed[1].get("path"), _second_save_path())
+	assert_true(FileAccess.file_exists(_save_path))
+	assert_true(FileAccess.file_exists(_second_save_path()))
 
 
 func test_unchanged_save_skips_rewrite_after_hash_settles():

--- a/tests/test_hflevel_io.gd
+++ b/tests/test_hflevel_io.gd
@@ -374,11 +374,55 @@ func test_uncompressed_payload_keeps_legacy_header():
 func test_save_to_path_is_atomic_and_leaves_no_writing_sidecar():
 	var path := "user://hflevel_atomic_test.hflevel"
 	var writing := path + ".writing"
+	var previous := path + ".previous"
 	HFLevelIO.save_to_path(path, {"v": 1}, false)
 	HFLevelIO.save_to_path(path, {"v": 2}, false)
 	var loaded: Dictionary = HFLevelIO.load_from_path(path)
 	assert_eq(int(loaded.get("v", 0)), 2)
 	assert_false(FileAccess.file_exists(writing), "Sidecar .writing file should be gone after save")
+	assert_false(FileAccess.file_exists(previous), "Successful replacement should remove its backup")
+	DirAccess.remove_absolute(path)
+
+
+func test_failed_replacement_restores_valid_destination():
+	var path := "user://hflevel_atomic_restore_test.hflevel"
+	var missing_tmp := path + ".missing"
+	var backup := path + ".previous"
+	HFLevelIO.save_to_path(path, {"v": 1}, false)
+	var err := HFLevelIO._replace_file_atomic(path, missing_tmp)
+	assert_push_error("rename failed")
+	assert_ne(err, OK)
+	var loaded: Dictionary = HFLevelIO.load_from_path(path)
+	assert_eq(int(loaded.get("v", 0)), 1, "Failed replacement must restore the last good save")
+	assert_false(FileAccess.file_exists(backup), "Restored backup should return to the main path")
+	DirAccess.remove_absolute(path)
+
+
+func test_replacement_recovers_interrupted_backup_before_writing():
+	var path := "user://hflevel_atomic_recovery_test.hflevel"
+	var writing := path + ".writing"
+	var backup := path + ".previous"
+	HFLevelIO.save_to_path(backup, {"v": 1}, false)
+	var next_payload := HFLevelIO.build_payload({"v": 2}, false)
+	var file := FileAccess.open(writing, FileAccess.WRITE)
+	file.store_buffer(next_payload)
+	file.close()
+	assert_eq(HFLevelIO._replace_file_atomic(path, writing), OK)
+	var loaded: Dictionary = HFLevelIO.load_from_path(path)
+	assert_eq(int(loaded.get("v", 0)), 2)
+	assert_false(FileAccess.file_exists(backup))
+	DirAccess.remove_absolute(path)
+
+
+func test_load_recovers_previous_file_after_interrupted_replacement():
+	var path := "user://hflevel_atomic_load_recovery_test.hflevel"
+	var backup := path + ".previous"
+	HFLevelIO.save_to_path(path, {"v": 1}, false)
+	assert_eq(DirAccess.rename_absolute(path, backup), OK)
+	var loaded: Dictionary = HFLevelIO.load_from_path(path)
+	assert_eq(int(loaded.get("v", 0)), 1)
+	assert_true(FileAccess.file_exists(path))
+	assert_false(FileAccess.file_exists(backup))
 	DirAccess.remove_absolute(path)
 
 


### PR DESCRIPTION
- Fixes #33. Preserve the previous hflevel until replacement succeeds and recover interrupted backups.
- Fixes #51. Report manual success, failure, and recent files only after the matching worker finishes.
- Keep queued save completions in order.

Checks: gdformat, gdlint, and the full Godot 4.7 suite with 1,790 tests.