### PR TITLE
Add PR, issue, and Dependabot templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Something in the HammerForge editor plugin isn't working
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search existing issues first. Verify the behavior against the current
+        `main` branch where you can.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you observed, including any errors from the Godot Output panel.
+      placeholder: Baking a selection with a subtractive brush leaves the old mesh in place.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps starting from a fresh scene, if possible.
+      placeholder: |
+        1. Add a LevelRoot to an empty 3D scene.
+        2. Draw two overlapping brushes in the Build tab.
+        3. ...
+    validations:
+      required: true
+
+  - type: input
+    id: godot-version
+    attributes:
+      label: Godot version
+      description: CI currently runs 4.7-stable.
+      placeholder: "4.7-stable"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "Windows 11 / Ubuntu 24.04 / macOS 15"
+    validations:
+      required: true
+
+  - type: input
+    id: commit
+    attributes:
+      label: HammerForge commit or version
+      placeholder: "96036bc, or v0.x.y"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output
+      description: Paste errors from the Godot Output/Debugger panel. Redact any tokens.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contributing guide
+    url: https://github.com/saworbit/hammerforge/blob/main/CONTRIBUTING.md
+    about: Architecture conventions, local check commands, and PR expectations.
+  - name: Roadmap
+    url: https://github.com/saworbit/hammerforge/blob/main/ROADMAP.md
+    about: Check whether the change you want is already planned.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature request
+description: Propose a new capability or an improvement to an existing one
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Large changes should start here rather than as a PR. Keep proposals aligned
+        with the current MVP and the subsystem architecture (LevelRoot is the public API).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that is awkward or impossible today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What should the editor do instead? Name the dock tab or tool if it has one.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Build (brushes, drawing, vertex/edge editing)
+        - Paint (surfaces, terrain, materials)
+        - Objects (entities, prefabs, I/O wiring)
+        - Test (bake, validation, quick play)
+        - Architecture / code quality
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Including any existing workaround you're using now.
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional notes
+      description: Tradeoffs, affected subsystems, or related issues.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Godot and GDScript tooling are pinned in ci.yml itself, so only the
+  # Actions themselves are tracked here.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "enhancement"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- What changed and why. Keep the PR limited to one topic. -->
+
+## Before / After Behavior
+
+<!-- Describe the user-visible behavior change. Note known limitations plainly. -->
+
+- Before:
+- After:
+
+## Related Issue
+
+<!-- e.g. "Closes #41". Large changes should start from an issue or discussion. -->
+
+## Checks
+
+- [ ] `gdformat --check addons/hammerforge/` passes
+- [ ] `gdlint addons/hammerforge/` passes
+- [ ] `godot --headless -s res://addons/gut/gut_cmdln.gd --path .` passes
+- [ ] Docs updated together where behavior changed (README, guide/spec, ROADMAP status, `[Unreleased]` in CHANGELOG)
+- [ ] `git diff --check` is clean and relative Markdown links resolve
+- [ ] No MCP tokens, `user://` settings, verification logs, editor screenshots, or local client overrides committed
+- [ ] `addons/godot_mcp` left untouched, or the vendor snapshot was updated deliberately


### PR DESCRIPTION
## Summary

Repo/GitHub hygiene pass. The repo had no `.github` templates, so bug reports arrived without Godot version or repro steps, feature requests without an affected subsystem, and PRs without the local check results `CONTRIBUTING.md` already asks for.

## Before / After Behavior

- **Before:** blank issue box for everything; no PR checklist; GitHub Actions versions in `ci.yml` drift with nothing watching them.
- **After:** structured bug/feature issue forms, a PR template mirroring the CONTRIBUTING checklist, and weekly Dependabot updates for Actions only.

## What's included

- `.github/pull_request_template.md` — gdformat/gdlint/GUT checks, the paired doc-update rule (README + guide/spec + ROADMAP + `[Unreleased]` changelog), `git diff --check`, and the no-secrets / don't-sweep-`addons/godot_mcp` rules.
- `.github/ISSUE_TEMPLATE/bug_report.yml` — labelled `bug`; requires what happened, expected, repro, Godot version, and OS.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — labelled `enhancement`; Area dropdown keyed to the dock tabs (Build/Paint/Objects/Test/Architecture/Docs).
- `.github/ISSUE_TEMPLATE/config.yml` — blank issues stay enabled; links to CONTRIBUTING and ROADMAP.
- `.github/dependabot.yml` — `github-actions` only, weekly, grouped. Godot and GDScript tooling versions are pinned inside `ci.yml` and deliberately left out of Dependabot's scope.

Labels used (`bug`, `enhancement`) already exist on the repo. No GDScript touched, so the lint/format/test jobs are unaffected.

## Related

Part of the same pass that merged #58, deleted its branch, and enabled **Automatically delete head branches** on the repo.

## Checks

- [x] No GDScript changed — `gdformat`/`gdlint`/GUT scope untouched
- [x] All four YAML files parse
- [x] `git diff --check` clean
- [x] No tokens, MCP settings, logs, or screenshots committed
- [x] `addons/godot_mcp` untouched