### PR TITLE
Add security policy, code of conduct, and contributor entry points

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,17 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Questions and discussion
+    url: https://github.com/saworbit/hammerforge/discussions
+    about: Not sure it's a bug? Ask here — workflow questions are welcome.
   - name: Contributing guide
     url: https://github.com/saworbit/hammerforge/blob/main/CONTRIBUTING.md
     about: Architecture conventions, local check commands, and PR expectations.
   - name: Roadmap
     url: https://github.com/saworbit/hammerforge/blob/main/ROADMAP.md
     about: Check whether the change you want is already planned.
+  - name: Code of Conduct
+    url: https://github.com/saworbit/hammerforge/blob/main/CODE_OF_CONDUCT.md
+    about: Expected behavior, and how to report a problem privately.
+  - name: Report a security vulnerability
+    url: https://github.com/saworbit/hammerforge/security/advisories/new
+    about: Please do not file security issues publicly. Use private reporting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Added
+- **Project governance and contributor onboarding:** added `SECURITY.md` (private vulnerability reporting, with level-file parsing, unintended file writes, secret handling, and `HFIORuntime` called out as in-scope) and `CODE_OF_CONDUCT.md` (adapted from Contributor Covenant 2.1). Added GitHub issue forms for bugs and features, a pull request template mirroring the CONTRIBUTING checklist, and Dependabot for GitHub Actions. Open issues are now grouped under milestones and labelled by `area:` matching the dock tabs; README and CONTRIBUTING link to good-first-issue, help-wanted, and Discussions entry points.
 - **Snap-to-perpendicular** (dock **P**): drop the cursor onto the closest point on a brush AABB edge, so offsets stay 90° to that edge.
 
 ### Fixed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,93 @@
+# Code of Conduct
+
+HammerForge is a small, early-alpha hobby project. Most people who show up here
+are trying to build a level, hit something rough, and want to help fix it. This
+document exists so that stays true.
+
+## The Short Version
+
+Be kind, be specific, and assume the other person is doing their best with
+incomplete information — because in a project this young, everyone is.
+
+## Our Pledge
+
+We want participating in HammerForge to be a harassment-free experience for
+everyone, regardless of age, body size, visible or invisible disability,
+ethnicity, sex characteristics, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, caste, colour, religion, or sexual identity and orientation.
+
+## What Good Looks Like
+
+- **Assume good faith.** A blunt bug report usually means someone is frustrated
+  with the software, not with you.
+- **Be concrete.** "The bake drops subtractive brushes when the cordon is
+  active" helps. "Baking is broken" doesn't.
+- **Welcome beginners.** Godot plugin internals are not obvious. Neither is
+  brush-based level design. Nobody should feel stupid for asking.
+- **Accept that "no" is a complete answer.** The maintainer may decline a
+  feature because it doesn't fit the MVP or because there isn't time. That's
+  not a rejection of you.
+- **Give feedback on the work, not the person.** Review the code, the design,
+  the documentation.
+- **Own your mistakes.** Apologise, fix it, move on. Nobody is keeping score.
+
+## What Isn't Acceptable
+
+- Harassment of any kind, public or private
+- Sexualised language or imagery, or unwelcome sexual attention
+- Trolling, insults, derogatory comments, or personal and political attacks
+- Publishing others' private information without explicit permission
+- Sustained disruption of discussions, issues, or pull requests
+- Any conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Scope
+
+This applies in every space this project uses — issues, pull requests,
+discussions, commit messages, code review, and the wiki — and when someone is
+representing the project in public.
+
+## Reporting
+
+If you experience or witness unacceptable behaviour, report it privately to the
+maintainer:
+
+- **Preferred:** [open a private report](https://github.com/saworbit/hammerforge/security/advisories/new)
+  — GitHub's private reporting creates a thread visible only to you and the
+  maintainer. It's labelled for security, but it's the most reliable private
+  channel this repo has.
+- **Alternative:** contact [@saworbit](https://github.com/saworbit) on GitHub
+  and ask for a private channel. Don't put details in a public comment.
+
+Reports are handled confidentially. You will not be pressured to interact with
+the person you're reporting.
+
+Please include what happened, where, roughly when, and links if you have them.
+A rough account is fine — don't sit on a report because you're not sure it's
+"serious enough."
+
+## Enforcement
+
+HammerForge has one maintainer, so there is no committee and no appeals board.
+The maintainer will:
+
+1. Read the report and ask you any clarifying questions privately.
+2. Decide on a response, proportionate to what happened.
+3. Tell you what was decided.
+
+Responses range from a private word, through a public correction and a
+temporary ban from interacting, up to a permanent ban. Deliberate harassment
+of an individual goes straight to the top of that range.
+
+If your report concerns the maintainer, say so — you're entitled to a straight
+answer about a conflict of interest, and to take the matter to
+[GitHub Support](https://support.github.com/contact/report-abuse) instead.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, which is available under
+[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). The pledge and the
+list of unacceptable behaviour follow the Covenant closely; the remainder is
+written for this project and its size.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,26 @@
 
 Thanks for helping improve HammerForge.
 
+This project follows a [Code of Conduct](CODE_OF_CONDUCT.md) — the short version
+is: be kind, be specific, and assume good faith. Security problems go through
+the [Security Policy](SECURITY.md) privately, **not** into a public issue.
+
+## New here?
+
+- [Good first issues](https://github.com/saworbit/hammerforge/labels/good%20first%20issue)
+  are scoped so you don't need to understand the whole architecture first.
+- [Help wanted](https://github.com/saworbit/hammerforge/labels/help%20wanted)
+  is the work that most needs another pair of hands.
+- `area:` labels (`build`, `paint`, `objects`, `test`, `architecture`, `docs`)
+  map to the dock tabs, so you can find issues in a part of the editor you
+  already use.
+- [Discussions](https://github.com/saworbit/hammerforge/discussions) is the
+  right place for "am I holding this wrong?" questions that aren't bug reports.
+
+Bug reports and feature requests both have
+[issue forms](https://github.com/saworbit/hammerforge/issues/new/choose) that
+prompt for what's actually needed to act on them.
+
 ## Scope
 - Small, focused changes are preferred.
 - Large changes should start with an issue or discussion before a PR.
@@ -90,3 +110,12 @@ All checks (format, lint, unit tests) run automatically on push/PR to `main` via
 ## Communication
 - Be clear about tradeoffs and known limitations.
 - Include before/after behavior notes in PR descriptions.
+- The PR template lists the checks above; tick what you ran rather than
+  guessing. "I couldn't run GUT locally" is a fine thing to say — CI will.
+- Reviews are on the code, not the person. See the
+  [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Reporting Security Issues
+Do not open a public issue. See [SECURITY.md](SECURITY.md) — level-file
+parsing, unintended file writes, secret handling, and `HFIORuntime` are the
+areas most likely to matter.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@
 
 ## Looking for a Logo
 
-The previous AI-generated logo has been retired. If you're a designer or artist and want to contribute a logo for HammerForge, I'd love to use it (with credit). Requirements: free to use under MIT, ideally SVG so it scales. Open an issue or PR if interested.
+The previous AI-generated logo has been retired. If you're a designer or artist and want to contribute a logo for HammerForge, I'd love to use it (with credit). Requirements: free to use under MIT, ideally SVG so it scales.
+
+**[Issue #61](https://github.com/saworbit/hammerforge/issues/61) has the full brief** — comment there with a sketch, or open a PR. No Godot knowledge needed.
 
 ---
 
@@ -407,6 +409,8 @@ gdlint addons/hammerforge/
 | [Changelog](CHANGELOG.md) | Version history |
 | [Roadmap](ROADMAP.md) | Planned features and priorities |
 | [Contributing](CONTRIBUTING.md) | How to contribute |
+| [Code of Conduct](CODE_OF_CONDUCT.md) | Expected behavior and how to report a problem |
+| [Security Policy](SECURITY.md) | What counts as a vulnerability and how to report one privately |
 | [Demo Clips](docs/demos/README.md) | Clip list and naming scheme |
 | [Sample Levels](samples/) | Minimal and stress test scenes |
 
@@ -458,7 +462,16 @@ This is a one-person project and there's more here than one person can properly 
 - **Edge cases** -- large levels, unusual brush shapes, rapid undo/redo, plugin reload cycles
 - **Documentation** -- if something in the user guide doesn't match reality, flag it
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get started.
+### Where to start
+
+- **[Good first issues](https://github.com/saworbit/hammerforge/labels/good%20first%20issue)** — scoped small, no deep architecture knowledge needed
+- **[Help wanted](https://github.com/saworbit/hammerforge/labels/help%20wanted)** — things I can't get to alone
+- **[Browse by area](https://github.com/saworbit/hammerforge/labels)** — `area:` labels map to the dock tabs: Build, Paint, Objects, Test
+- **[Milestones](https://github.com/saworbit/hammerforge/milestones)** — what the open work is grouped under
+- **[Discussions](https://github.com/saworbit/hammerforge/discussions)** — for questions that aren't bug reports
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup and the check commands, and
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for how we treat each other here.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,77 @@
+# Security Policy
+
+HammerForge is a Godot editor plugin. Most of it runs inside the Godot editor
+with the same privileges as the editor itself, and a smaller runtime piece
+(`HFIORuntime`) ships inside exported games. That shapes what counts as a
+security issue here.
+
+## Supported Versions
+
+| Version | Supported |
+|---|---|
+| `main` | Yes |
+| Anything older | No |
+
+There are no tagged releases yet. Fixes land on `main`; please reproduce
+against the latest `main` before reporting.
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for a security problem.**
+
+Use GitHub's private vulnerability reporting:
+[**Report a vulnerability**](https://github.com/saworbit/hammerforge/security/advisories/new)
+
+That opens a private thread visible only to you and the maintainer. If you
+can't use it, contact [@saworbit](https://github.com/saworbit) on GitHub and
+ask for a private channel — don't include details in a public message.
+
+Helpful things to include, as far as you have them:
+
+- What an attacker gains, and what they need to start (a crafted level file? a
+  malicious addon? editor access?)
+- Steps to reproduce, ideally from a fresh scene
+- The Godot version and OS
+- A minimal proof-of-concept file, if the issue involves parsing
+
+## What Is In Scope
+
+- **Level file parsing** — `.hflevel`, Quake `.map` import, and glTF paths.
+  These read untrusted files. Anything that turns a crafted level file into
+  code execution, arbitrary file read, or arbitrary file write is in scope.
+- **File writes outside the intended destination** — save, autosave, bake
+  output, and playtest export writing anywhere the user didn't ask for.
+- **Secret handling** — MCP tokens, editor configuration, or anything under
+  `user://` leaking into the repository, logs, exported builds, or diagnostics.
+- **`HFIORuntime`** — the runtime component that ships in exported games, since
+  it evaluates entity I/O connections at runtime.
+- **Supply-chain issues in what this repo ships**, including the vendored
+  `addons/godot_mcp` snapshot.
+
+## What Is Not In Scope
+
+Please file these as **normal issues** instead — they're still worth reporting,
+just not privately:
+
+- Crashes, freezes, or geometry corruption with no path to code execution or
+  data disclosure
+- Data loss from ordinary bugs (use a bug report; these get triaged seriously)
+- Vulnerabilities in Godot itself — report those to
+  [godotengine/godot](https://github.com/godotengine/godot/security)
+- Upstream vulnerabilities in GUT (`addons/gut/`) — report those upstream,
+  though a heads-up here is welcome so the vendored copy can be bumped
+- Anything that requires the attacker to already have write access to your
+  project directory or your editor configuration
+
+## What to Expect
+
+This is a solo hobby project in early alpha, so please calibrate accordingly:
+
+- **Acknowledgement:** best effort within a week
+- **Assessment and fix:** depends entirely on severity and my available time —
+  I'll tell you honestly rather than let a report go quiet
+- **Disclosure:** coordinated. I'll agree a timeline with you and credit you in
+  the advisory and changelog unless you'd rather stay anonymous
+- **Bounty:** none — there's no money in this project
+
+Thanks for taking the time to report responsibly.


### PR DESCRIPTION
## Summary

Second half of the hygiene pass started in #59. That one added the templates; this one adds the governance documents the repo was missing and wires up the paths a new contributor actually walks.

## Before / After Behavior

- **Before:** a public repo that parses untrusted level files had no private channel for reporting a parser vulnerability — the only option was a public issue. No Code of Conduct. The README asked for testers and a logo but pointed at nothing specific.
- **After:** private vulnerability reporting is enabled and documented, behavior expectations are written down, and every "where do I start?" path resolves to a real link.

## What's included

- **`SECURITY.md`** — private reporting via GitHub advisories. Scope is drawn from what this plugin actually does rather than boilerplate: `.hflevel` / `.map` / glTF parsing, file writes outside the intended destination, MCP token and `user://` leakage, and `HFIORuntime` (which ships inside exported games). Out-of-scope items are routed to normal issues rather than dismissed, and response timelines are stated honestly for a solo hobby project.
- **`CODE_OF_CONDUCT.md`** — adapted from Contributor Covenant 2.1, with attribution and the CC BY 4.0 link. Enforcement describes a single maintainer rather than implying a committee, and names GitHub Support as the escape hatch if a report concerns the maintainer.
- **README** — the Documentation table gains Code of Conduct and Security Policy rows; the Help Wanted section gains a "Where to start" list (good first issues, help wanted, area labels, milestones, Discussions); the logo paragraph now points at #61.
- **CONTRIBUTING** — opens with the Code of Conduct and the don't-file-security-publicly rule, adds a "New here?" section, and closes with a security-reporting pointer.
- **`.github/ISSUE_TEMPLATE/config.yml`** — adds Discussions, Code of Conduct, and private security reporting to the contact links.
- **CHANGELOG** — `[Unreleased] / Added` entry covering this and the templates from #59.

## Repo settings changed alongside this

Not in the diff, but part of the same pass:

- Private vulnerability reporting **enabled** (makes the `SECURITY.md` link work)
- Empty Wiki **disabled** — it was never initialized, so the tab led nowhere
- Discussions **enabled**
- Description corrected from "Godot 4.6+" to **4.7+**, matching the README and `ci.yml`
- `homepageUrl` cleared (it pointed back at this repo)
- Two milestones created from ROADMAP.md; all 5 open issues assigned and given `area:` labels matching the Area dropdown in the new feature form
- New labels: `area: build/paint/objects/test/architecture/docs`, `performance`
- #61 opened for the logo, labelled `help wanted` + `good first issue`

## Checks

- [x] No GDScript changed — `gdformat`/`gdlint`/GUT scope untouched
- [x] All four `.github` YAML files parse
- [x] Relative Markdown links resolve (`SECURITY.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `CHANGELOG.md`)
- [x] `git diff --check` clean
- [x] `[Unreleased]` changelog updated alongside the README change, per CONTRIBUTING
- [x] No tokens, MCP settings, logs, or screenshots committed
- [x] `addons/godot_mcp` untouched