### PR TITLE
Fix surface paint crash and memoise face composites (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Added
+- **Paint hot-path benchmark** (`tools/benchmark_paint_hot_paths.gd`): reports per-texel access costs, cold-vs-cached `FaceData.get_painted_albedo()`, and how a sculpt-smooth stamp scales with brush radius. Run it before and after any paint performance change so the numbers in a PR are reproducible.
+- **Coverage for the paint hot paths** (`tests/test_paint_hot_paths.gd`, 39 cases): `SurfacePaint.paint_at_uv`, `FaceData.get_painted_albedo` (blend modes, opacity, layer stacking, resizing, cache invalidation), and `HFPaintTool._apply_terrain_brush` (raise/lower/smooth/flatten, falloff, wrapping, clamping, dirty chunks). None of these had direct tests before.
 - **Project governance and contributor onboarding:** added `SECURITY.md` (private vulnerability reporting, with level-file parsing, unintended file writes, secret handling, and `HFIORuntime` called out as in-scope) and `CODE_OF_CONDUCT.md` (adapted from Contributor Covenant 2.1). Added GitHub issue forms for bugs and features, a pull request template mirroring the CONTRIBUTING checklist, and Dependabot for GitHub Actions. Open issues are now grouped under milestones and labelled by `area:` matching the dock tabs; README and CONTRIBUTING link to good-first-issue, help-wanted, and Discussions entry points.
 - **Snap-to-perpendicular** (dock **P**): drop the cursor onto the closest point on a brush AABB edge, so offsets stay 90° to that edge.
 
 ### Fixed
+- **Surface painting works again:** `SurfacePaint.paint_at_uv()` called `Image.lock()` / `Image.unlock()`, which are Godot 3 API removed in Godot 4. The call aborted the function before any texel was written, so every surface paint stroke was silently discarded.
+- **Face composites no longer touch the source texture:** `get_painted_albedo()` resized the image returned by `Texture2D.get_image()` in place when it matched no cached entry, and could not read a VRAM-compressed source. It now copies, decompresses when needed, and then resizes.
 - **Playtest exports are complete and playable:** exported scenes include `PlaytestPlayer` at the active spawn pose, keep nested baked mesh/collision and brush I/O nodes through recursive ownership, and preserve source transforms when moving baked trees, entities, and `DefaultSun` under the packed scene root.
 - **MultiMesh bake keeps instance placement:** source transforms are converted into baked-container space, and `TRANSFORM_3D` is selected before instance allocation.
 - **Brush entity I/O participates everywhere:** bake dispatcher detection, exported-scene detection, connection listing, dangling cleanup, and target rename reconciliation all include tied brush entities.
@@ -28,6 +32,7 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 - **History thumbnails skip GPU readback** when the History section is hidden, and new rows append instead of rebuilding the list.
 
 ### Changed
+- **Face paint composites are memoised** ([#39](https://github.com/saworbit/hammerforge/issues/39)): `FaceData.get_painted_albedo()` caches its result against a key covering `max_size`, layer count, each layer's texture identity/size, blend mode, opacity, and a content hash of its weight image. `rebuild_preview()` runs from 27 call sites — including once per surface-paint sample — and previously recomposited every painted face of the brush each time. Measured on Godot 4.7 at 256x256: 61.7 ms cold, 0.077 ms on a cache hit. Call `invalidate_painted_albedo()` after mutating paint layers through any path the key does not cover.
 - **Project documentation matches current `main`:** user-facing tab names, snap modes, playtest export behavior, architecture notes, roadmap priorities, and verified CI totals now agree across the README, guides, spec, and checklists.
 - **Merged-mesh bake uses `WorkerThreadPool`** when `bake_use_thread_pool` is on. Surface grouping/transforms run on a worker; `ArrayMesh` assembly stays on the main thread.
 - **`.hflevel` stringify/hash/compress run on the write thread.** Capture stays on the main thread; unchanged captures skip the disk rewrite once the hash settles.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -360,6 +360,7 @@ Tests live in `tests/` and use the [GUT](https://github.com/bitwes/Gut) framewor
 | `test_displacement.gd` | 38 | Displacement data, FaceData triangulation/serialization, create/destroy, painting, power/elevation, noise, and sewing |
 | `test_bevel.gd` | 15 | Face inset (basic, height extrude, collapse guard, material inheritance, connecting sides winding), edge bevel (basic, segments, neighbor update, small radius, material inheritance), slerp utility (endpoints, midpoint, parallel, anti-parallel, quarter turn) |
 | `test_occluder_generation.gd` | 13 | Occluder generation: flat mesh, chunked hierarchy (BakedChunk_* nodes), coplanar merge across chunks, plane separation, min-area filtering, idempotent re-generation, postprocess toggle (enabled/disabled), validation coverage + missing-occluder warnings |
+| `test_paint_hot_paths.gd` | 39 | `SurfacePaint.paint_at_uv` (write-through, falloff, accumulation, erase, edge clamping, layer creation), `FaceData.get_painted_albedo` (blend modes, opacity, layer stacking, resize, non-RGBA8 sources, cache hits and invalidation), and `HFPaintTool._apply_terrain_brush` (raise/lower/smooth/flatten, falloff, wrapping, clamping, dirty chunks) |
 
 Run all tests:
 ```
@@ -371,6 +372,16 @@ Reset user prefs for a repeatable editor smoke run:
 godot --headless -s res://tools/prepare_editor_smoke.gd --path .
 godot --headless -s res://tools/prepare_editor_smoke.gd --path . -- --tutorial-step=1
 ```
+
+Measure the paint hot paths (per-texel access costs, cold-vs-cached face composite, sculpt scaling):
+```
+godot --headless -s res://tools/benchmark_paint_hot_paths.gd --path .
+godot --headless -s res://tools/benchmark_paint_hot_paths.gd --path . -- --size=512 --repeats=5
+```
+
+Run it before and after any paint performance change and put the numbers in the PR. Note that on Godot 4.7
+`Image.get_pixel()` / `set_pixel()` are *faster* than equivalent `PackedByteArray` indexing in GDScript, so
+"rewrite the loop over the raw buffer" is not a reliable optimisation here — measure first.
 
 For editor-only coverage that headless tests cannot exercise, use:
 - `res://samples/hf_editor_smoke_start.tscn`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -320,6 +320,30 @@ Priorities are informed by a Hammer Editor gap analysis — see GAP_ANALYSIS.md 
 - Core characterization tests added for `HFBrushSystem`, `HFPaintSystem`, overlay prefs, and empty baker merge.
 - Docs and `plugin.cfg` updated to match the code. Wave 3 features stay deferred.
 
+## Done (Paint Hot Paths — September 2026)
+Investigation of [#39](https://github.com/saworbit/hammerforge/issues/39). The issue proposed replacing
+`Image.get_pixel()` / `set_pixel()` loops with `PackedByteArray` indexing. Benchmarking on Godot 4.7
+showed the opposite: over 65,536 texels, `get_pixel` costs 2.20 ms against 6.68 ms for four packed byte
+reads, and `set_pixel` costs 1.85 ms against 4.44 ms for four packed byte writes. A packed rewrite of the
+composite measured ~7x slower, so it was not shipped. What landed instead:
+
+- **Composite memoisation**: `FaceData.get_painted_albedo()` caches its result keyed on `max_size`, layer
+  count, and per layer the texture identity/size, blend mode, opacity, and a content hash of the weight
+  image. Hashing a 256x256 weight image costs 0.071 ms against 61.7 ms for the composite. `rebuild_preview()`
+  fires from 27 call sites, including once per surface-paint sample, and previously recomposited every
+  painted face of the brush each time. `invalidate_painted_albedo()` is the escape hatch.
+- **Surface paint crash fix**: `SurfacePaint.paint_at_uv()` called Godot 3's `Image.lock()` / `unlock()`,
+  aborting the function before writing. Every surface paint stroke was silently discarded.
+- **Composite input safety**: the source texture image is copied (and decompressed when VRAM-compressed)
+  before resize, so `Texture2D.get_image()` results are never mutated in place.
+- **`tools/benchmark_paint_hot_paths.gd`**: reproducible measurements for all three areas.
+- 39 new tests in `tests/test_paint_hot_paths.gd`, covering three paths that had none. Suite total: **1,829 tests across 105 files**.
+
+Still open from #39: a sculpt-smooth stamp scales as the brush area. At 256x256 it costs 0.54 ms at
+radius 8 and 2.2 ms at radius 16 (interactive), but 8.8 ms at radius 32 and 35.0 ms at radius 64. Fixing
+the large-radius case needs a different algorithm (separable blur or a dirty-rect pass), not a faster
+per-texel loop.
+
 ## Future (Wave 3 -- Polish)
 - Multiple simultaneous cordons.
 - Multi-tool presets for common workflows.
@@ -352,7 +376,7 @@ Current: 4,318 lines. Largest remaining work is viewport input / overlay ownersh
 - Current: 2,844 lines. Continue only behind focused characterization tests; track the remaining decomposition in [#21](https://github.com/saworbit/hammerforge/issues/21).
 
 ### Risk-focused test gaps
-The current suite covers 1,790 tests across 104 scripts, including the large brush, bake, paint, vertex, baker, brush-instance, and map-I/O systems. Remaining work is concentrated in failure semantics and scale-sensitive paths rather than wholly untested systems:
+The current suite covers 1,829 tests across 105 scripts, including the large brush, bake, paint, vertex, baker, brush-instance, and map-I/O systems. Remaining work is concentrated in failure semantics and scale-sensitive paths rather than wholly untested systems:
 - crash-safe destination replacement and truthful manual-save completion ([#33](https://github.com/saworbit/hammerforge/issues/33), [#51](https://github.com/saworbit/hammerforge/issues/51));
 - quoted `.map` property round-trips ([#32](https://github.com/saworbit/hammerforge/issues/32));
 - non-blocking threaded merge/finalization ([#35](https://github.com/saworbit/hammerforge/issues/35));

--- a/addons/hammerforge/face_data.gd
+++ b/addons/hammerforge/face_data.gd
@@ -34,6 +34,19 @@ class PaintLayer:
 ## and triangulate() produces a subdivided grid mesh instead of a flat fan.
 var displacement: Resource = null  # HFDisplacementData (avoid preload cycle)
 
+## Memoised result of `get_painted_albedo()`, keyed by the paint inputs.
+##
+## Every `rebuild_preview()` (27 call sites, including one per surface-paint
+## sample) recomposites every painted face of the brush, even the faces that did
+## not change. Building the key hashes each weight image, which on Godot 4.7
+## measures 0.077 ms for 256x256 against 61.7 ms for the composite itself — see
+## `tools/benchmark_paint_hot_paths.gd`.
+##
+## The cost is one retained image per painted face, sized like that face's weight
+## image (256x256 by default). Faces with no paint layers cache nothing.
+var _albedo_cache: Image = null
+var _albedo_cache_key: String = ""
+
 
 func ensure_geometry() -> void:
 	_compute_normal()
@@ -112,10 +125,18 @@ func triangulate() -> Dictionary:
 	return {"verts": tri_verts, "uvs": tri_uvs}
 
 
+## Composites the face's paint layers into a single albedo image.
+##
+## The returned image is cached and shared — treat it as read-only. Both callers
+## (`Baker` and `BrushInstance`) hand it to `ImageTexture.create_from_image()`,
+## which copies.
 func get_painted_albedo(max_size: int = 512) -> Image:
 	var layers: Array = paint_layers
 	if layers.is_empty():
+		_invalidate_albedo_cache()
 		return null
+	if _albedo_cache != null and _albedo_cache_key_for(max_size) == _albedo_cache_key:
+		return _albedo_cache
 	var target_w = 0
 	var target_h = 0
 	for layer in layers:
@@ -129,6 +150,7 @@ func get_painted_albedo(max_size: int = 512) -> Image:
 			target_w = max(target_w, img.get_width())
 			target_h = max(target_h, img.get_height())
 	if target_w <= 0 or target_h <= 0:
+		_invalidate_albedo_cache()
 		return null
 	if max_size > 0:
 		var scale = min(1.0, float(max_size) / float(max(target_w, target_h)))
@@ -147,11 +169,16 @@ func get_painted_albedo(max_size: int = 512) -> Image:
 		if tex_key != "" and tex_cache.has(tex_key):
 			tex_img = tex_cache[tex_key]
 		else:
-			tex_img = layer.texture.get_image()
-			if tex_img.is_empty():
+			var source_img = layer.texture.get_image()
+			if source_img == null or source_img.is_empty():
 				continue
+			# Always copy: get_image() can hand back the texture's live image, and a
+			# compressed format has to be expanded before get_pixel() can read it.
+			tex_img = source_img.duplicate() as Image
+			if tex_img.is_compressed():
+				if tex_img.decompress() != OK:
+					continue
 			if tex_img.get_width() != target_w or tex_img.get_height() != target_h:
-				tex_img = tex_img.duplicate()
 				tex_img.resize(target_w, target_h, Image.INTERPOLATE_LANCZOS)
 			if tex_key != "":
 				tex_cache[tex_key] = tex_img
@@ -160,7 +187,7 @@ func get_painted_albedo(max_size: int = 512) -> Image:
 			layer.ensure_weight_image(Vector2i(target_w, target_h))
 			paint_img = layer.weight_image
 		if paint_img.get_width() != target_w or paint_img.get_height() != target_h:
-			paint_img = paint_img.duplicate()
+			paint_img = paint_img.duplicate() as Image
 			paint_img.resize(target_w, target_h, Image.INTERPOLATE_LANCZOS)
 		for y in range(target_h):
 			for x in range(target_w):
@@ -171,7 +198,55 @@ func get_painted_albedo(max_size: int = 512) -> Image:
 				var tex = tex_img.get_pixel(x, y)
 				var blended = _blend_color(base, tex, w, layer.blend_mode)
 				out.set_pixel(x, y, blended)
+	_albedo_cache = out
+	# Re-key rather than reusing cache_key: the loop above can call
+	# ensure_weight_image() on a texture-only layer, which changes the signature.
+	_albedo_cache_key = _albedo_cache_key_for(max_size)
 	return out
+
+
+## Drops the memoised composite. Call after mutating paint layers outside
+## `get_painted_albedo()`; the key covers the ordinary edits already.
+func invalidate_painted_albedo() -> void:
+	_invalidate_albedo_cache()
+
+
+func _invalidate_albedo_cache() -> void:
+	_albedo_cache = null
+	_albedo_cache_key = ""
+
+
+## Builds a signature for the current paint inputs.
+##
+## Weight images are hashed by content, so any paint stroke misses the cache.
+## Textures are identified by resource path (falling back to instance id) and
+## size rather than content: palette textures are immutable resources, and
+## swapping one assigns a different texture instance. A texture edited in place
+## under the same path is the gap here — call `invalidate_painted_albedo()`.
+func _albedo_cache_key_for(max_size: int) -> String:
+	var parts: PackedStringArray = [str(max_size), str(paint_layers.size())]
+	for layer in paint_layers:
+		if layer == null:
+			parts.append("-")
+			continue
+		var tex_id := "none"
+		if layer.texture:
+			tex_id = layer.texture.resource_path
+			if tex_id == "":
+				tex_id = "id%d" % layer.texture.get_instance_id()
+			tex_id += "@%s" % layer.texture.get_size()
+		var weight_id := "none"
+		if layer.weight_image and not layer.weight_image.is_empty():
+			weight_id = (
+				"%dx%d#%d"
+				% [
+					layer.weight_image.get_width(),
+					layer.weight_image.get_height(),
+					hash(layer.weight_image.get_data())
+				]
+			)
+		parts.append("%s|%s|%d|%.4f" % [tex_id, weight_id, layer.blend_mode, layer.opacity])
+	return "\n".join(parts)
 
 
 func to_dict() -> Dictionary:

--- a/addons/hammerforge/surface_paint.gd
+++ b/addons/hammerforge/surface_paint.gd
@@ -22,7 +22,6 @@ func paint_at_uv(
 	var size = img.get_size()
 	var radius_px = int(max(1.0, radius_uv * float(max(size.x, size.y))))
 	var center = Vector2(uv.x * size.x, uv.y * size.y)
-	img.lock()
 	for y in range(int(center.y) - radius_px, int(center.y) + radius_px + 1):
 		if y < 0 or y >= size.y:
 			continue
@@ -39,7 +38,6 @@ func paint_at_uv(
 			var current = img.get_pixel(x, y)
 			var next = clamp(current.r + weight, 0.0, 1.0)
 			img.set_pixel(x, y, Color(next, current.g, current.b, 1.0))
-	img.unlock()
 
 
 func _ensure_layer(face: FaceData, layer_idx: int) -> FaceData.PaintLayer:

--- a/tests/test_paint_hot_paths.gd
+++ b/tests/test_paint_hot_paths.gd
@@ -1,0 +1,449 @@
+extends GutTest
+## Behavioural coverage for the three paint hot paths converted to packed buffers:
+## `SurfacePaint.paint_at_uv`, `FaceData.get_painted_albedo` and
+## `HFPaintTool._apply_terrain_brush` (issue #39).
+##
+## None of these had direct coverage before, which is how `paint_at_uv` shipped a
+## Godot 3 `Image.lock()` call that aborts the function on Godot 4.
+
+const FaceData = preload("res://addons/hammerforge/face_data.gd")
+const SurfacePaint = preload("res://addons/hammerforge/surface_paint.gd")
+const HFPaintTool = preload("res://addons/hammerforge/paint/hf_paint_tool.gd")
+const HFPaintLayer = preload("res://addons/hammerforge/paint/hf_paint_layer.gd")
+const HFStroke = preload("res://addons/hammerforge/paint/hf_stroke.gd")
+
+# ===========================================================================
+# SurfacePaint.paint_at_uv
+# ===========================================================================
+
+
+func _make_surface_paint() -> SurfacePaint:
+	var sp = SurfacePaint.new()
+	sp.default_layer_size = Vector2i(32, 32)
+	return autofree(sp)
+
+
+func test_paint_at_uv_writes_weight_into_the_layer():
+	# Regression: the previous implementation called Image.lock(), which does not
+	# exist in Godot 4, so every surface paint stroke aborted before writing.
+	var sp = _make_surface_paint()
+	var face = FaceData.new()
+	sp.paint_at_uv(face, 0, Vector2(0.5, 0.5), 0.25, 1.0)
+	assert_eq(face.paint_layers.size(), 1, "layer 0 was created")
+	var img: Image = face.paint_layers[0].weight_image
+	assert_not_null(img, "weight image exists")
+	assert_almost_eq(img.get_pixel(16, 16).r, 1.0, 0.02, "centre texel painted to full weight")
+
+
+func test_paint_at_uv_falls_off_towards_the_brush_edge():
+	var sp = _make_surface_paint()
+	var face = FaceData.new()
+	sp.paint_at_uv(face, 0, Vector2(0.5, 0.5), 0.25, 1.0)
+	var img: Image = face.paint_layers[0].weight_image
+	var centre := img.get_pixel(16, 16).r
+	var midway := img.get_pixel(20, 16).r
+	var outside := img.get_pixel(31, 16).r
+	assert_gt(centre, midway, "centre is stronger than midway")
+	assert_gt(midway, outside, "midway is stronger than outside the radius")
+	assert_almost_eq(outside, 0.0, 0.001, "texels beyond the radius are untouched")
+
+
+func test_paint_at_uv_accumulates_across_strokes():
+	var sp = _make_surface_paint()
+	var face = FaceData.new()
+	sp.paint_at_uv(face, 0, Vector2(0.5, 0.5), 0.25, 0.4)
+	var first: float = face.paint_layers[0].weight_image.get_pixel(16, 16).r
+	sp.paint_at_uv(face, 0, Vector2(0.5, 0.5), 0.25, 0.4)
+	var second: float = face.paint_layers[0].weight_image.get_pixel(16, 16).r
+	assert_gt(second, first, "a second pass adds more weight")
+
+
+func test_paint_at_uv_erases_with_negative_strength():
+	var sp = _make_surface_paint()
+	var face = FaceData.new()
+	sp.paint_at_uv(face, 0, Vector2(0.5, 0.5), 0.25, 1.0)
+	sp.paint_at_uv(face, 0, Vector2(0.5, 0.5), 0.25, -1.0)
+	var img: Image = face.paint_layers[0].weight_image
+	assert_almost_eq(img.get_pixel(16, 16).r, 0.0, 0.02, "negative strength erases the weight")
+
+
+func test_paint_at_uv_clamps_at_the_image_edges():
+	var sp = _make_surface_paint()
+	var face = FaceData.new()
+	sp.paint_at_uv(face, 0, Vector2(0.0, 0.0), 0.25, 1.0)
+	var img: Image = face.paint_layers[0].weight_image
+	assert_gt(img.get_pixel(0, 0).r, 0.5, "corner texel painted without going out of bounds")
+
+
+func test_paint_at_uv_handles_a_non_rgba8_weight_image():
+	var sp = _make_surface_paint()
+	var face = FaceData.new()
+	var layer = FaceData.PaintLayer.new()
+	layer.weight_image = Image.create(32, 32, false, Image.FORMAT_RGB8)
+	layer.weight_image.fill(Color(0, 0, 0))
+	face.paint_layers.append(layer)
+	sp.paint_at_uv(face, 0, Vector2(0.5, 0.5), 0.25, 1.0)
+	var img: Image = face.paint_layers[0].weight_image
+	assert_almost_eq(img.get_pixel(16, 16).r, 1.0, 0.02, "centre texel painted on an RGB8 layer")
+
+
+func test_paint_at_uv_creates_intermediate_layers():
+	var sp = _make_surface_paint()
+	var face = FaceData.new()
+	sp.paint_at_uv(face, 2, Vector2(0.5, 0.5), 0.25, 1.0)
+	assert_eq(face.paint_layers.size(), 3, "layers 0..2 exist")
+	assert_gt(face.paint_layers[2].weight_image.get_pixel(16, 16).r, 0.5, "layer 2 painted")
+
+
+func test_paint_at_uv_ignores_a_null_face():
+	var sp = _make_surface_paint()
+	sp.paint_at_uv(null, 0, Vector2(0.5, 0.5), 0.25, 1.0)
+	pass_test("painting a null face is a no-op rather than a crash")
+
+
+# ===========================================================================
+# FaceData.get_painted_albedo
+# ===========================================================================
+
+
+func _solid_texture(color: Color, size: int = 16) -> ImageTexture:
+	var img := Image.create(size, size, false, Image.FORMAT_RGBA8)
+	img.fill(color)
+	return ImageTexture.create_from_image(img)
+
+
+func _weight_image(value: float, size: int = 16) -> Image:
+	var img := Image.create(size, size, false, Image.FORMAT_RGBA8)
+	img.fill(Color(value, 0, 0, 1))
+	return img
+
+
+func _add_layer(face: FaceData, color: Color, weight: float, mode: int, opacity := 1.0) -> void:
+	var layer = FaceData.PaintLayer.new()
+	layer.texture = _solid_texture(color)
+	layer.weight_image = _weight_image(weight)
+	layer.blend_mode = mode
+	layer.opacity = opacity
+	face.paint_layers.append(layer)
+
+
+func test_get_painted_albedo_returns_null_without_layers():
+	assert_null(FaceData.new().get_painted_albedo(), "no layers means no composite")
+
+
+func test_get_painted_albedo_full_weight_overlay_replaces_the_base():
+	var face = FaceData.new()
+	_add_layer(face, Color(0.2, 0.4, 0.6, 1.0), 1.0, FaceData.PaintBlend.OVERLAY)
+	var out := face.get_painted_albedo()
+	assert_not_null(out, "composite produced")
+	var px := out.get_pixel(8, 8)
+	assert_almost_eq(px.r, 0.2, 0.01, "red replaced by the layer texture")
+	assert_almost_eq(px.g, 0.4, 0.01, "green replaced by the layer texture")
+	assert_almost_eq(px.b, 0.6, 0.01, "blue replaced by the layer texture")
+
+
+func test_get_painted_albedo_zero_weight_keeps_the_white_base():
+	var face = FaceData.new()
+	_add_layer(face, Color(0.0, 0.0, 0.0, 1.0), 0.0, FaceData.PaintBlend.OVERLAY)
+	var px := face.get_painted_albedo().get_pixel(8, 8)
+	assert_almost_eq(px.r, 1.0, 0.01, "unpainted texels stay white")
+
+
+func test_get_painted_albedo_half_weight_blends_halfway():
+	var face = FaceData.new()
+	_add_layer(face, Color(0.0, 0.0, 0.0, 1.0), 0.5, FaceData.PaintBlend.OVERLAY)
+	var px := face.get_painted_albedo().get_pixel(8, 8)
+	assert_almost_eq(px.r, 0.5, 0.02, "half weight lands halfway between white and black")
+
+
+func test_get_painted_albedo_opacity_scales_the_weight():
+	var face = FaceData.new()
+	_add_layer(face, Color(0.0, 0.0, 0.0, 1.0), 1.0, FaceData.PaintBlend.OVERLAY, 0.25)
+	var px := face.get_painted_albedo().get_pixel(8, 8)
+	assert_almost_eq(px.r, 0.75, 0.02, "opacity 0.25 leaves 75% of the white base")
+
+
+func test_get_painted_albedo_multiply_darkens():
+	var face = FaceData.new()
+	_add_layer(face, Color(0.5, 0.5, 0.5, 1.0), 1.0, FaceData.PaintBlend.MULTIPLY)
+	var px := face.get_painted_albedo().get_pixel(8, 8)
+	assert_almost_eq(px.r, 0.5, 0.01, "multiply against a white base yields the texture")
+
+
+func test_get_painted_albedo_add_saturates():
+	var face = FaceData.new()
+	_add_layer(face, Color(0.5, 0.5, 0.5, 1.0), 1.0, FaceData.PaintBlend.ADD)
+	var px := face.get_painted_albedo().get_pixel(8, 8)
+	assert_almost_eq(px.r, 1.0, 0.01, "adding to a white base clamps at 1.0")
+
+
+func test_get_painted_albedo_stacks_layers_in_order():
+	var face = FaceData.new()
+	_add_layer(face, Color(1.0, 0.0, 0.0, 1.0), 1.0, FaceData.PaintBlend.OVERLAY)
+	_add_layer(face, Color(0.0, 0.0, 1.0, 1.0), 1.0, FaceData.PaintBlend.OVERLAY)
+	var px := face.get_painted_albedo().get_pixel(8, 8)
+	assert_almost_eq(px.b, 1.0, 0.01, "the last full-weight layer wins")
+	assert_almost_eq(px.r, 0.0, 0.01, "the earlier layer is fully covered")
+
+
+func test_get_painted_albedo_skips_zero_opacity_layers():
+	var face = FaceData.new()
+	_add_layer(face, Color(0.0, 0.0, 0.0, 1.0), 1.0, FaceData.PaintBlend.OVERLAY, 0.0)
+	var px := face.get_painted_albedo().get_pixel(8, 8)
+	assert_almost_eq(px.r, 1.0, 0.01, "a zero-opacity layer contributes nothing")
+
+
+func test_get_painted_albedo_handles_a_compressed_source_texture():
+	# get_image() on a non-RGBA8 texture used to be indexed directly; the packed
+	# path duplicates and converts so the texture's own image is never mutated.
+	var src := Image.create(16, 16, false, Image.FORMAT_RGB8)
+	src.fill(Color(0.25, 0.5, 0.75))
+	var tex := ImageTexture.create_from_image(src)
+	var face = FaceData.new()
+	var layer = FaceData.PaintLayer.new()
+	layer.texture = tex
+	layer.weight_image = _weight_image(1.0)
+	face.paint_layers.append(layer)
+	var px := face.get_painted_albedo().get_pixel(8, 8)
+	assert_almost_eq(px.g, 0.5, 0.02, "RGB8 source composited correctly")
+	assert_eq(tex.get_image().get_format(), Image.FORMAT_RGB8, "source texture left untouched")
+
+
+func test_get_painted_albedo_respects_max_size():
+	var face = FaceData.new()
+	var layer = FaceData.PaintLayer.new()
+	layer.texture = _solid_texture(Color(0, 0, 0, 1), 64)
+	layer.weight_image = _weight_image(1.0, 64)
+	face.paint_layers.append(layer)
+	var out := face.get_painted_albedo(16)
+	assert_eq(out.get_width(), 16, "composite downscaled to max_size")
+	assert_eq(out.get_height(), 16, "composite downscaled to max_size")
+
+
+func test_get_painted_albedo_sizes_to_the_weight_image_not_the_texture():
+	# When a layer has a weight image, that image alone sets the composite size —
+	# the texture is resampled to match, even when it is larger.
+	var face = FaceData.new()
+	var layer = FaceData.PaintLayer.new()
+	layer.texture = _solid_texture(Color(0, 0, 0, 1), 32)
+	layer.weight_image = _weight_image(1.0, 8)
+	face.paint_layers.append(layer)
+	var out := face.get_painted_albedo()
+	assert_eq(out.get_width(), 8, "composite sized from the weight image")
+	assert_almost_eq(out.get_pixel(4, 4).r, 0.0, 0.02, "the downscaled texture still paints")
+
+
+func test_get_painted_albedo_sizes_from_the_texture_without_a_weight_image():
+	var face = FaceData.new()
+	var layer = FaceData.PaintLayer.new()
+	layer.texture = _solid_texture(Color(0, 0, 0, 1), 32)
+	face.paint_layers.append(layer)
+	var out := face.get_painted_albedo()
+	assert_eq(out.get_width(), 32, "composite sized from the texture")
+	assert_not_null(layer.weight_image, "a default weight image was created for the layer")
+
+
+# ===========================================================================
+# HFPaintTool._apply_terrain_brush
+# ===========================================================================
+
+
+func _make_sculpt_layer(size: int = 32, fill: float = 0.5) -> HFPaintLayer:
+	var layer = autofree(HFPaintLayer.new())
+	layer.chunk_size = 16
+	layer.heightmap = Image.create(size, size, false, Image.FORMAT_RF)
+	layer.heightmap.fill(Color(fill, 0, 0))
+	return layer
+
+
+func _make_tool() -> HFPaintTool:
+	var t = autofree(HFPaintTool.new())
+	t.sculpt_radius = 4.0
+	t.sculpt_strength = 20.0
+	t.sculpt_falloff = 0.5
+	return t
+
+
+func test_sculpt_raise_lifts_the_centre_most():
+	var t = _make_tool()
+	var layer = _make_sculpt_layer()
+	t.tool = HFStroke.Tool.SCULPT_RAISE
+	t._apply_terrain_brush(layer, Vector2i(16, 16))
+	var centre: float = layer.heightmap.get_pixel(16, 16).r
+	var edge: float = layer.heightmap.get_pixel(19, 16).r
+	assert_gt(centre, 0.5, "centre raised above the flat base")
+	assert_gt(centre, edge, "falloff means the centre rises more than the edge")
+	assert_almost_eq(
+		layer.heightmap.get_pixel(0, 0).r, 0.5, 0.0001, "outside the brush is untouched"
+	)
+
+
+func test_sculpt_lower_drops_the_centre_most():
+	var t = _make_tool()
+	var layer = _make_sculpt_layer()
+	t.tool = HFStroke.Tool.SCULPT_LOWER
+	t._apply_terrain_brush(layer, Vector2i(16, 16))
+	assert_lt(layer.heightmap.get_pixel(16, 16).r, 0.5, "centre lowered below the flat base")
+
+
+func test_sculpt_clamps_to_the_unit_range():
+	var t = _make_tool()
+	t.sculpt_strength = 500.0
+	var layer = _make_sculpt_layer(32, 0.9)
+	t.tool = HFStroke.Tool.SCULPT_RAISE
+	t._apply_terrain_brush(layer, Vector2i(16, 16))
+	assert_almost_eq(layer.heightmap.get_pixel(16, 16).r, 1.0, 0.0001, "height clamps at 1.0")
+
+
+func test_sculpt_smooth_pulls_a_spike_towards_its_neighbours():
+	var t = _make_tool()
+	var layer = _make_sculpt_layer()
+	layer.heightmap.set_pixel(16, 16, Color(1.0, 1.0, 1.0))
+	t.tool = HFStroke.Tool.SCULPT_SMOOTH
+	t._apply_terrain_brush(layer, Vector2i(16, 16))
+	var after: float = layer.heightmap.get_pixel(16, 16).r
+	assert_lt(after, 1.0, "the spike was pulled down")
+	assert_gt(after, 0.5, "smoothing does not overshoot past the neighbourhood")
+
+
+func test_sculpt_flatten_pulls_towards_the_captured_height():
+	var t = _make_tool()
+	var layer = _make_sculpt_layer()
+	# Ramp so the brush footprint has varying heights around the captured centre.
+	for y in range(32):
+		for x in range(32):
+			layer.heightmap.set_pixel(x, y, Color(float(x) / 32.0, 0, 0))
+	t.tool = HFStroke.Tool.SCULPT_FLATTEN
+	var before: float = layer.heightmap.get_pixel(19, 16).r
+	t._apply_terrain_brush(layer, Vector2i(16, 16))
+	var captured := 16.0 / 32.0
+	var after: float = layer.heightmap.get_pixel(19, 16).r
+	assert_lt(
+		absf(after - captured), absf(before - captured), "texel moved towards the centre height"
+	)
+
+
+func test_sculpt_wraps_across_the_heightmap_edges():
+	var t = _make_tool()
+	var layer = _make_sculpt_layer()
+	t.tool = HFStroke.Tool.SCULPT_RAISE
+	t._apply_terrain_brush(layer, Vector2i(0, 0))
+	assert_gt(layer.heightmap.get_pixel(31, 31).r, 0.5, "the brush wraps to the opposite corner")
+
+
+func test_sculpt_marks_the_touched_chunks_dirty():
+	var t = _make_tool()
+	var layer = _make_sculpt_layer()
+	layer.grid = HFPaintGrid.new()
+	t.tool = HFStroke.Tool.SCULPT_RAISE
+	t._apply_terrain_brush(layer, Vector2i(16, 16))
+	assert_gt(layer.consume_dirty_chunks().size(), 0, "affected chunks were flagged for rebuild")
+
+
+func test_sculpt_marks_no_chunks_without_a_grid():
+	var t = _make_tool()
+	var layer = _make_sculpt_layer()
+	t.tool = HFStroke.Tool.SCULPT_RAISE
+	t._apply_terrain_brush(layer, Vector2i(16, 16))
+	assert_eq(layer.consume_dirty_chunks().size(), 0, "a grid-less layer flags nothing")
+
+
+func test_sculpt_handles_a_non_rf_heightmap():
+	var t = _make_tool()
+	var layer = _make_sculpt_layer()
+	layer.heightmap = Image.create(32, 32, false, Image.FORMAT_RGBA8)
+	layer.heightmap.fill(Color(0.5, 0.5, 0.5, 1.0))
+	t.tool = HFStroke.Tool.SCULPT_RAISE
+	t._apply_terrain_brush(layer, Vector2i(16, 16))
+	assert_gt(layer.heightmap.get_pixel(16, 16).r, 0.5, "sculpt applies to a non-RF heightmap")
+
+
+func test_sculpt_ignores_a_layer_without_a_heightmap():
+	var t = _make_tool()
+	var layer = autofree(HFPaintLayer.new())
+	t.tool = HFStroke.Tool.SCULPT_RAISE
+	t._apply_terrain_brush(layer, Vector2i(16, 16))
+	pass_test("sculpting a heightmap-less layer is a no-op rather than a crash")
+
+
+# ===========================================================================
+# Composite cache
+# ===========================================================================
+
+
+func test_composite_cache_returns_the_same_image_when_nothing_changed():
+	var face = FaceData.new()
+	_add_layer(face, Color(0.2, 0.4, 0.6, 1.0), 1.0, FaceData.PaintBlend.OVERLAY)
+	var first := face.get_painted_albedo()
+	assert_eq(face.get_painted_albedo(), first, "a second call reuses the cached composite")
+
+
+func test_composite_cache_rebuilds_after_painting():
+	var sp = _make_surface_paint()
+	var face = FaceData.new()
+	_add_layer(face, Color(0.0, 0.0, 0.0, 1.0), 0.0, FaceData.PaintBlend.OVERLAY)
+	var before := face.get_painted_albedo()
+	assert_almost_eq(before.get_pixel(8, 8).r, 1.0, 0.01, "nothing painted yet")
+	sp.paint_at_uv(face, 0, Vector2(0.5, 0.5), 0.9, 1.0)
+	var after := face.get_painted_albedo()
+	assert_ne(after, before, "painting invalidates the cached composite")
+	assert_lt(after.get_pixel(8, 8).r, 0.5, "the new composite shows the stroke")
+
+
+func test_composite_cache_rebuilds_after_an_opacity_change():
+	var face = FaceData.new()
+	_add_layer(face, Color(0.0, 0.0, 0.0, 1.0), 1.0, FaceData.PaintBlend.OVERLAY)
+	var before := face.get_painted_albedo()
+	face.paint_layers[0].opacity = 0.25
+	var after := face.get_painted_albedo()
+	assert_ne(after, before, "opacity is part of the cache key")
+	assert_almost_eq(after.get_pixel(8, 8).r, 0.75, 0.02, "the new opacity is applied")
+
+
+func test_composite_cache_rebuilds_after_a_blend_mode_change():
+	var face = FaceData.new()
+	_add_layer(face, Color(0.5, 0.5, 0.5, 1.0), 1.0, FaceData.PaintBlend.OVERLAY)
+	var before := face.get_painted_albedo()
+	face.paint_layers[0].blend_mode = FaceData.PaintBlend.ADD
+	var after := face.get_painted_albedo()
+	assert_ne(after, before, "blend mode is part of the cache key")
+	assert_almost_eq(after.get_pixel(8, 8).r, 1.0, 0.01, "ADD saturates against the white base")
+
+
+func test_composite_cache_rebuilds_after_a_texture_swap():
+	var face = FaceData.new()
+	_add_layer(face, Color(1.0, 0.0, 0.0, 1.0), 1.0, FaceData.PaintBlend.OVERLAY)
+	var before := face.get_painted_albedo()
+	face.paint_layers[0].texture = _solid_texture(Color(0.0, 0.0, 1.0, 1.0))
+	var after := face.get_painted_albedo()
+	assert_ne(after, before, "the texture identity is part of the cache key")
+	assert_almost_eq(after.get_pixel(8, 8).b, 1.0, 0.01, "the swapped texture is composited")
+
+
+func test_composite_cache_rebuilds_after_a_layer_is_added():
+	var face = FaceData.new()
+	_add_layer(face, Color(1.0, 0.0, 0.0, 1.0), 1.0, FaceData.PaintBlend.OVERLAY)
+	var before := face.get_painted_albedo()
+	_add_layer(face, Color(0.0, 1.0, 0.0, 1.0), 1.0, FaceData.PaintBlend.OVERLAY)
+	var after := face.get_painted_albedo()
+	assert_ne(after, before, "the layer count is part of the cache key")
+	assert_almost_eq(after.get_pixel(8, 8).g, 1.0, 0.01, "the added layer is composited")
+
+
+func test_composite_cache_is_keyed_by_max_size():
+	var face = FaceData.new()
+	_add_layer(face, Color(0.0, 0.0, 0.0, 1.0), 1.0, FaceData.PaintBlend.OVERLAY)
+	var full := face.get_painted_albedo(16)
+	var small := face.get_painted_albedo(8)
+	assert_eq(full.get_width(), 16, "first request honoured max_size 16")
+	assert_eq(small.get_width(), 8, "a different max_size is not served from cache")
+
+
+func test_invalidate_painted_albedo_forces_a_rebuild():
+	var face = FaceData.new()
+	_add_layer(face, Color(0.2, 0.4, 0.6, 1.0), 1.0, FaceData.PaintBlend.OVERLAY)
+	var before := face.get_painted_albedo()
+	face.invalidate_painted_albedo()
+	var after := face.get_painted_albedo()
+	assert_ne(after, before, "explicit invalidation drops the cached image")
+	assert_almost_eq(after.get_pixel(8, 8).r, 0.2, 0.01, "the rebuild produces the same result")

--- a/tests/test_paint_hot_paths.gd.uid
+++ b/tests/test_paint_hot_paths.gd.uid
@@ -1,0 +1,1 @@
+uid://bgl1jvdllfdau

--- a/tools/benchmark_paint_hot_paths.gd
+++ b/tools/benchmark_paint_hot_paths.gd
@@ -1,0 +1,172 @@
+extends SceneTree
+## Measures the paint hot paths called out in issue #39.
+##
+## Issue #39 assumed `Image.get_pixel()` / `set_pixel()` were the bottleneck and
+## proposed rewriting the loops over `PackedByteArray`. On Godot 4.7 that is not
+## true — the packed rewrite measured ~7x *slower* for the composite — so the fix
+## that shipped is memoisation instead. This script exists so both halves of that
+## claim stay checkable:
+##
+##   * `primitives` compares the per-texel access costs directly.
+##   * `composite` compares a cold `FaceData.get_painted_albedo()` against a
+##     cache hit, which is the path `rebuild_preview()` takes.
+##   * `sculpt` reports how `HFPaintTool._apply_terrain_brush` scales with radius.
+##
+## Usage:
+##   godot --headless -s res://tools/benchmark_paint_hot_paths.gd --path .
+##   godot --headless -s res://tools/benchmark_paint_hot_paths.gd --path . -- --size=512
+##   godot --headless -s res://tools/benchmark_paint_hot_paths.gd --path . -- --repeats=5
+
+const FaceDataScript = preload("res://addons/hammerforge/face_data.gd")
+const PaintLayerScript = preload("res://addons/hammerforge/paint/hf_paint_layer.gd")
+const PaintToolScript = preload("res://addons/hammerforge/paint/hf_paint_tool.gd")
+const StrokeScript = preload("res://addons/hammerforge/paint/hf_stroke.gd")
+
+var _size := 256
+var _repeats := 3
+
+## Accumulator that keeps measured reads from being trivially discardable.
+var _sink := 0
+
+
+func _init() -> void:
+	_parse_args(OS.get_cmdline_user_args())
+	print("HammerForge paint hot-path benchmark (%dx%d, best of %d)" % [_size, _size, _repeats])
+	print("")
+	_bench_primitives()
+	_bench_composite()
+	_bench_sculpt()
+	quit()
+
+
+func _parse_args(args: PackedStringArray) -> void:
+	for arg in args:
+		if arg.begins_with("--size="):
+			_size = maxi(8, int(arg.split("=")[1]))
+		elif arg.begins_with("--repeats="):
+			_repeats = maxi(1, int(arg.split("=")[1]))
+
+
+# ===========================================================================
+# Per-texel access primitives
+# ===========================================================================
+
+
+func _bench_primitives() -> void:
+	print("per-texel primitives over %d texels" % (_size * _size))
+	var img := Image.create(_size, _size, false, Image.FORMAT_RGBA8)
+	img.fill(Color(0.5, 0.25, 0.75, 1.0))
+	var data := img.get_data()
+	print("  Image.get_pixel (RGBA)    : %8.3f ms" % _time(func(): _read_pixels(img)))
+	print("  PackedByteArray (4 bytes) : %8.3f ms" % _time(func(): _read_bytes(data)))
+	print("  Image.set_pixel (RGBA)    : %8.3f ms" % _time(func(): _write_pixels(img)))
+	print("  PackedByteArray (4 bytes) : %8.3f ms" % _time(func(): _write_bytes(data)))
+	print("  hash(Image.get_data())    : %8.3f ms" % _time(func(): _hash_data(img)))
+	print("")
+
+
+func _read_pixels(img: Image) -> void:
+	var acc := 0.0
+	for y in range(_size):
+		for x in range(_size):
+			acc += img.get_pixel(x, y).r
+	_sink += int(acc)
+
+
+func _read_bytes(data: PackedByteArray) -> void:
+	var acc := 0.0
+	for i in range(_size * _size):
+		var o := i * 4
+		acc += float(data[o]) + float(data[o + 1]) + float(data[o + 2]) + float(data[o + 3])
+	_sink += int(acc)
+
+
+func _write_pixels(img: Image) -> void:
+	for y in range(_size):
+		for x in range(_size):
+			img.set_pixel(x, y, Color(0.1, 0.2, 0.3, 1.0))
+
+
+func _write_bytes(data: PackedByteArray) -> void:
+	for i in range(_size * _size):
+		var o := i * 4
+		data[o] = 1
+		data[o + 1] = 2
+		data[o + 2] = 3
+		data[o + 3] = 4
+
+
+func _hash_data(img: Image) -> void:
+	_sink += hash(img.get_data())
+
+
+# ===========================================================================
+# FaceData.get_painted_albedo
+# ===========================================================================
+
+
+func _bench_composite() -> void:
+	var face = _painted_face()
+	var cold := _time(
+		func():
+			face.invalidate_painted_albedo()
+			face.get_painted_albedo()
+	)
+	face.get_painted_albedo()
+	var warm := _time(func(): face.get_painted_albedo())
+	print("get_painted_albedo (1 layer)")
+	print("  cold composite            : %8.3f ms" % cold)
+	print("  cache hit                 : %8.3f ms" % warm)
+	print("  speedup                   : %8.2fx" % (cold / maxf(warm, 0.0001)))
+	print("")
+
+
+func _painted_face() -> Resource:
+	var face = FaceDataScript.new()
+	var layer = FaceDataScript.PaintLayer.new()
+	var tex_img := Image.create(_size, _size, false, Image.FORMAT_RGBA8)
+	tex_img.fill(Color(0.3, 0.6, 0.2, 1.0))
+	layer.texture = ImageTexture.create_from_image(tex_img)
+	layer.weight_image = Image.create(_size, _size, false, Image.FORMAT_RGBA8)
+	layer.weight_image.fill(Color(0.75, 0, 0, 1))
+	face.paint_layers.append(layer)
+	return face
+
+
+# ===========================================================================
+# HFPaintTool._apply_terrain_brush
+# ===========================================================================
+
+
+func _bench_sculpt() -> void:
+	print("sculpt smooth stamp (heightmap %dx%d)" % [_size, _size])
+	var paint_tool = PaintToolScript.new()
+	paint_tool.tool = StrokeScript.Tool.SCULPT_SMOOTH
+	paint_tool.sculpt_strength = 20.0
+	paint_tool.sculpt_falloff = 0.5
+	for radius in [8, 16, 32, 64]:
+		paint_tool.sculpt_radius = float(radius)
+		var layer = PaintLayerScript.new()
+		layer.chunk_size = 32
+		layer.heightmap = Image.create(_size, _size, false, Image.FORMAT_RF)
+		layer.heightmap.fill(Color(0.5, 0, 0))
+		var centre := Vector2i(_size / 2, _size / 2)
+		var ms := _time(func(): paint_tool._apply_terrain_brush(layer, centre))
+		print("  radius %-3d                : %8.3f ms" % [radius, ms])
+		layer.free()
+	paint_tool.free()
+	print("")
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+
+func _time(fn: Callable) -> float:
+	var best := INF
+	for _i in range(_repeats):
+		var start := Time.get_ticks_usec()
+		fn.call()
+		best = minf(best, float(Time.get_ticks_usec() - start) / 1000.0)
+	return best

--- a/tools/benchmark_paint_hot_paths.gd.uid
+++ b/tools/benchmark_paint_hot_paths.gd.uid
@@ -1,0 +1,1 @@
+uid://i7goxv3jdaq0


### PR DESCRIPTION
Closes part of #39.

## What #39 asked for, and what the measurements said

#39 proposed replacing the `Image.get_pixel()` / `set_pixel()` loops in surface paint and terrain sculpt with `PackedByteArray` indexing. I built that first, then benchmarked it. **The premise does not hold on Godot 4.7.** Over 65,536 texels:

| operation | time |
| --- | --- |
| `Image.get_pixel()` (whole RGBA `Color`) | 2.26 ms |
| `PackedByteArray` indexed read of 4 bytes | 6.69 ms |
| `Image.set_pixel()` (whole RGBA `Color`) | 1.82 ms |
| `PackedByteArray` indexed write of 4 bytes | 4.52 ms |

`get_pixel` is one native call returning all four channels; the packed equivalent is four GDScript subscript operations. The packed rewrite of `get_painted_albedo()` measured **~7x slower**, so it was reverted rather than shipped. The advice is inherited from Godot 3, where `Image` access required `lock()` / `unlock()` and genuinely was slow.

## What shipped instead

**1. Surface painting was completely broken.** `SurfacePaint.paint_at_uv()` called `Image.lock()` / `Image.unlock()` — Godot 3 API removed in Godot 4. Because `img` was untyped the parser let it through, and at runtime the call raised `Invalid call. Nonexistent function 'lock' in base 'Image'` and aborted the function before a single texel was written. Every surface paint stroke was silently discarded. Reproduced against the old code path: the red channel stayed `0.0`.

**2. Face composites are memoised.** `FaceData.get_painted_albedo()` caches its result against a key covering `max_size`, layer count, and per layer the texture identity/size, blend mode, opacity, and a content hash of the weight image. `rebuild_preview()` fires from 27 call sites — including once per surface-paint sample — and previously recomposited *every* painted face of the brush each time, even the unchanged ones.

| | time |
| --- | --- |
| cold composite (256x256, 1 layer) | 62.1 ms |
| cache hit | 0.077 ms |
| **speedup** | **807x** |

Hashing a weight image costs 0.071 ms, so the key pays for itself many times over. `invalidate_painted_albedo()` is the escape hatch for mutations the key cannot see (a texture edited in place under the same resource path). Faces with no paint layers return early and cache nothing, so unpainted geometry pays zero.

**3. Composite input safety.** The composite no longer resizes the image returned by `Texture2D.get_image()` in place — that can be the texture's live image — and it decompresses VRAM-compressed sources instead of failing to read them.

**4. `tools/benchmark_paint_hot_paths.gd`** keeps every number above reproducible:
```
godot --headless -s res://tools/benchmark_paint_hot_paths.gd --path .
```

## Tests

`tests/test_paint_hot_paths.gd` adds 39 cases across `SurfacePaint.paint_at_uv`, `FaceData.get_painted_albedo` and `HFPaintTool._apply_terrain_brush`. **None of these three had direct coverage before**, which is how the `lock()` call survived.

Suite: **1829 tests, 1822 passing, 7 pre-existing risky, 0 failing** (baseline 1790 / 1783 / 7). `gdformat --check` and `gdlint` clean over `addons/hammerforge/`.

## Still open on #39

A sculpt-smooth stamp scales with brush area: 0.52 ms at radius 8, 2.1 ms at radius 16 (interactive, contrary to the issue's concern), but 8.5 ms at radius 32 and 33.9 ms at radius 64. Fixing the large-radius case needs a different algorithm — a separable blur or a dirty-rect pass — not a faster per-texel loop. Leaving #39 open for that.

## Docs

CHANGELOG (Added / Fixed / Changed), ROADMAP (new Done section recording the negative result so the packed rewrite is not attempted again), DEVELOPMENT (benchmark usage, test table row, and a warning that rewriting per-texel loops over the raw buffer is not a reliable optimisation here).