### PR TITLE
Fix Polygon and Path placement snapping

### DIFF
--- a/addons/hammerforge/hf_measure_tool.gd
+++ b/addons/hammerforge/hf_measure_tool.gd
@@ -434,8 +434,6 @@ func _raycast_world(camera: Camera3D, mouse_pos: Vector2) -> Variant:
 func _snap_hit(hit_pos: Vector3) -> Vector3:
 	if root.has_method("_snap_point"):
 		return root._snap_point(hit_pos)
-	if root.get("snap_system"):
-		return root.snap_system.snap_point(hit_pos)
 	return hit_pos
 
 

--- a/addons/hammerforge/hf_path_tool.gd
+++ b/addons/hammerforge/hf_path_tool.gd
@@ -874,8 +874,8 @@ func _reset() -> void:
 
 
 func _snap(pos: Vector3) -> Vector3:
-	if root and root.get("snap_system"):
-		return root.snap_system.snap_point(pos)
+	if root and root.has_method("_snap_point"):
+		return root._snap_point(pos)
 	if root and root.get("grid_snap") and root.grid_snap > 0.0:
 		var g: float = root.grid_snap
 		return Vector3(snappedf(pos.x, g), snappedf(pos.y, g), snappedf(pos.z, g))
@@ -883,18 +883,10 @@ func _snap(pos: Vector3) -> Vector3:
 
 
 func _raycast_ground(camera: Camera3D, mouse_pos: Vector2) -> Variant:
-	var ray_origin := camera.project_ray_origin(mouse_pos)
-	var ray_dir := camera.project_ray_normal(mouse_pos)
-	if root:
-		var space_state = root.get_world_3d().direct_space_state if root.get_world_3d() else null
-		if space_state:
-			var query := PhysicsRayQueryParameters3D.new()
-			query.from = ray_origin
-			query.to = ray_origin + ray_dir * 10000.0
-			var result := space_state.intersect_ray(query)
-			if not result.is_empty():
-				return result.position
-	return _raycast_to_y_plane(camera, mouse_pos, 0.0)
+	if not root or not root.has_method("_raycast"):
+		return null
+	var hit: Dictionary = root._raycast(camera, mouse_pos)
+	return hit.get("position")
 
 
 func _raycast_to_y_plane(camera: Camera3D, mouse_pos: Vector2, y: float) -> Vector3:
@@ -902,9 +894,7 @@ func _raycast_to_y_plane(camera: Camera3D, mouse_pos: Vector2, y: float) -> Vect
 	var dir := camera.project_ray_normal(mouse_pos)
 	if absf(dir.y) < 0.0001:
 		return Vector3(origin.x, y, origin.z)
-	var t := (y - origin.y) / dir.y
-	if t < 0.0:
-		t = 0.0
+	var t := maxf((y - origin.y) / dir.y, 0.0)
 	return origin + dir * t
 
 

--- a/addons/hammerforge/hf_polygon_tool.gd
+++ b/addons/hammerforge/hf_polygon_tool.gd
@@ -483,8 +483,8 @@ func _reset() -> void:
 
 
 func _snap(pos: Vector3) -> Vector3:
-	if root and root.get("snap_system"):
-		return root.snap_system.snap_point(pos)
+	if root and root.has_method("_snap_point"):
+		return root._snap_point(pos)
 	if root and root.get("grid_snap") and root.grid_snap > 0.0:
 		var g: float = root.grid_snap
 		return Vector3(snappedf(pos.x, g), snappedf(pos.y, g), snappedf(pos.z, g))
@@ -492,20 +492,10 @@ func _snap(pos: Vector3) -> Vector3:
 
 
 func _raycast_ground(camera: Camera3D, mouse_pos: Vector2) -> Variant:
-	var ray_origin := camera.project_ray_origin(mouse_pos)
-	var ray_dir := camera.project_ray_normal(mouse_pos)
-	# Try physics raycast
-	if root:
-		var space_state = root.get_world_3d().direct_space_state if root.get_world_3d() else null
-		if space_state:
-			var query := PhysicsRayQueryParameters3D.new()
-			query.from = ray_origin
-			query.to = ray_origin + ray_dir * 10000.0
-			var result := space_state.intersect_ray(query)
-			if not result.is_empty():
-				return result.position
-	# Fallback: Y=0 plane
-	return _raycast_to_y_plane(camera, mouse_pos, 0.0)
+	if not root or not root.has_method("_raycast"):
+		return null
+	var hit: Dictionary = root._raycast(camera, mouse_pos)
+	return hit.get("position")
 
 
 func _raycast_to_y_plane(camera: Camera3D, mouse_pos: Vector2, y: float) -> Vector3:
@@ -513,9 +503,7 @@ func _raycast_to_y_plane(camera: Camera3D, mouse_pos: Vector2, y: float) -> Vect
 	var dir := camera.project_ray_normal(mouse_pos)
 	if absf(dir.y) < 0.0001:
 		return Vector3(origin.x, y, origin.z)
-	var t := (y - origin.y) / dir.y
-	if t < 0.0:
-		t = 0.0
+	var t := maxf((y - origin.y) / dir.y, 0.0)
 	return origin + dir * t
 
 

--- a/tests/test_measure_tool.gd
+++ b/tests/test_measure_tool.gd
@@ -22,6 +22,16 @@ class MeasureInputSpy:
 		return EditorPlugin.AFTER_GUI_INPUT_STOP
 
 
+class SnapRoot:
+	extends Node3D
+
+	var snap_calls := 0
+
+	func _snap_point(point: Vector3, _exclude_ids: Array = []) -> Vector3:
+		snap_calls += 1
+		return point.snapped(Vector3(4, 4, 4))
+
+
 func before_each():
 	tool = HFMeasureToolScript.new()
 
@@ -40,6 +50,14 @@ func test_tool_id():
 
 func test_tool_shortcut():
 	assert_eq(tool.tool_shortcut_key(), KEY_M)
+
+
+func test_snap_hit_uses_level_root_snap_settings():
+	var root := SnapRoot.new()
+	tool.root = root
+	assert_eq(tool._snap_hit(Vector3(3, 7, 9)), Vector3(4, 8, 8))
+	assert_eq(root.snap_calls, 1)
+	root.free()
 
 
 func test_initial_state_empty():

--- a/tests/test_path_tool.gd
+++ b/tests/test_path_tool.gd
@@ -3,6 +3,38 @@ extends GutTest
 const HFPathTool = preload("res://addons/hammerforge/hf_path_tool.gd")
 const FaceData = preload("res://addons/hammerforge/face_data.gd")
 
+
+class PlacementRoot:
+	extends Node3D
+
+	var raycast_result: Dictionary = {}
+	var snap_calls := 0
+	var raycast_calls := 0
+
+	func _snap_point(point: Vector3, _exclude_ids: Array = []) -> Vector3:
+		snap_calls += 1
+		return point.snapped(Vector3(4, 4, 4))
+
+	func _raycast(_camera: Camera3D, _mouse_pos: Vector2) -> Dictionary:
+		raycast_calls += 1
+		return raycast_result
+
+
+func test_placement_uses_level_root_snap_and_raycast():
+	var tool = HFPathTool.new()
+	var root := PlacementRoot.new()
+	var camera := Camera3D.new()
+	tool.root = root
+	root.raycast_result = {"position": Vector3(3, 7, 9)}
+	assert_eq(tool._snap(Vector3(3, 7, 9)), Vector3(4, 8, 8))
+	assert_eq(tool._raycast_ground(camera, Vector2(20, 30)), Vector3(3, 7, 9))
+	assert_eq(root.snap_calls, 1, "LevelRoot owns the snap settings")
+	assert_eq(root.raycast_calls, 1, "LevelRoot owns visual and physics picking")
+	root.raycast_result = {}
+	assert_null(tool._raycast_ground(camera, Vector2.ZERO), "a shared raycast miss stays a miss")
+	root.free()
+	camera.free()
+
 # ===========================================================================
 # Tool metadata
 # ===========================================================================

--- a/tests/test_polygon_tool.gd
+++ b/tests/test_polygon_tool.gd
@@ -3,6 +3,38 @@ extends GutTest
 const HFPolygonTool = preload("res://addons/hammerforge/hf_polygon_tool.gd")
 const FaceData = preload("res://addons/hammerforge/face_data.gd")
 
+
+class PlacementRoot:
+	extends Node3D
+
+	var raycast_result: Dictionary = {}
+	var snap_calls := 0
+	var raycast_calls := 0
+
+	func _snap_point(point: Vector3, _exclude_ids: Array = []) -> Vector3:
+		snap_calls += 1
+		return point.snapped(Vector3(4, 4, 4))
+
+	func _raycast(_camera: Camera3D, _mouse_pos: Vector2) -> Dictionary:
+		raycast_calls += 1
+		return raycast_result
+
+
+func test_placement_uses_level_root_snap_and_raycast():
+	var tool = HFPolygonTool.new()
+	var root := PlacementRoot.new()
+	var camera := Camera3D.new()
+	tool.root = root
+	root.raycast_result = {"position": Vector3(3, 7, 9)}
+	assert_eq(tool._snap(Vector3(3, 7, 9)), Vector3(4, 8, 8))
+	assert_eq(tool._raycast_ground(camera, Vector2(20, 30)), Vector3(3, 7, 9))
+	assert_eq(root.snap_calls, 1, "LevelRoot owns the snap settings")
+	assert_eq(root.raycast_calls, 1, "LevelRoot owns visual and physics picking")
+	root.raycast_result = {}
+	assert_null(tool._raycast_ground(camera, Vector2.ZERO), "a shared raycast miss stays a miss")
+	root.free()
+	camera.free()
+
 # ===========================================================================
 # Convexity validation
 # ===========================================================================


### PR DESCRIPTION
- Fixes #65
- Route Polygon and Path snapping through LevelRoot.
- Use the shared visual and physics raycast for the first point.
- Cover Polygon, Path, and Measure snap delegation.