### PR TITLE
Fix prefab member lookups

### DIFF
--- a/addons/hammerforge/systems/hf_brush_system.gd
+++ b/addons/hammerforge/systems/hf_brush_system.gd
@@ -223,7 +223,19 @@ func _find_brush_by_id(brush_id: String) -> Node:
 		if is_instance_valid(cached) and cached.is_inside_tree():
 			return cached
 		_brush_cache.erase(brush_id)
-	# Slow path: scan every managed brush container, including committed cutters.
+	# Slow path: scan editable brush containers and populate the live cache.
+	for node in root._iter_pick_nodes():
+		if node and node is DraftBrush:
+			if node.has_meta("brush_id") and str(node.get_meta("brush_id")) == brush_id:
+				_brush_cache[brush_id] = node
+				return node
+			if str((node as DraftBrush).brush_id) == brush_id:
+				_brush_cache[brush_id] = node
+				return node
+	return null
+
+
+func find_managed_brush_by_id(brush_id: String) -> Node:
 	var nodes: Array = (
 		root._iter_managed_brush_nodes()
 		if root.has_method("_iter_managed_brush_nodes")
@@ -232,10 +244,8 @@ func _find_brush_by_id(brush_id: String) -> Node:
 	for node in nodes:
 		if node and node is DraftBrush:
 			if node.has_meta("brush_id") and str(node.get_meta("brush_id")) == brush_id:
-				_brush_cache[brush_id] = node
 				return node
 			if str((node as DraftBrush).brush_id) == brush_id:
-				_brush_cache[brush_id] = node
 				return node
 	return null
 

--- a/addons/hammerforge/systems/hf_brush_system.gd
+++ b/addons/hammerforge/systems/hf_brush_system.gd
@@ -223,8 +223,13 @@ func _find_brush_by_id(brush_id: String) -> Node:
 		if is_instance_valid(cached) and cached.is_inside_tree():
 			return cached
 		_brush_cache.erase(brush_id)
-	# Slow path: scan and populate cache
-	for node in root._iter_pick_nodes():
+	# Slow path: scan every managed brush container, including committed cutters.
+	var nodes: Array = (
+		root._iter_managed_brush_nodes()
+		if root.has_method("_iter_managed_brush_nodes")
+		else root._iter_pick_nodes()
+	)
+	for node in nodes:
 		if node and node is DraftBrush:
 			if node.has_meta("brush_id") and str(node.get_meta("brush_id")) == brush_id:
 				_brush_cache[brush_id] = node

--- a/addons/hammerforge/systems/hf_entity_system.gd
+++ b/addons/hammerforge/systems/hf_entity_system.gd
@@ -32,6 +32,20 @@ func get_entity_definitions() -> Dictionary:
 	return root.entity_definitions
 
 
+func find_entity_by_prefab_uid(uid: String) -> Node3D:
+	if uid == "":
+		return null
+	if root.entities_node:
+		for child in root.entities_node.get_children():
+			if str(child.get_meta("hf_prefab_entity_id", "")) == uid:
+				return child as Node3D
+	if root.has_method("_iter_managed_brush_nodes"):
+		for child in root._iter_managed_brush_nodes():
+			if str(child.get_meta("hf_prefab_entity_id", "")) == uid:
+				return child as Node3D
+	return null
+
+
 func add_entity(entity: Node3D) -> void:
 	if not entity:
 		return

--- a/addons/hammerforge/systems/hf_prefab_system.gd
+++ b/addons/hammerforge/systems/hf_prefab_system.gd
@@ -47,15 +47,8 @@ func _assign_entity_uid() -> String:
 func _find_entity_by_uid(uid: String) -> Node3D:
 	if uid == "":
 		return null
-	if root.entities_node:
-		for child in root.entities_node.get_children():
-			if str(child.get_meta("hf_prefab_entity_id", "")) == uid:
-				return child
-	# Also check brush entities
-	if root.draft_brushes_node:
-		for child in root.draft_brushes_node.get_children():
-			if str(child.get_meta("hf_prefab_entity_id", "")) == uid:
-				return child
+	if root.entity_system and root.entity_system.has_method("find_entity_by_prefab_uid"):
+		return root.entity_system.find_entity_by_prefab_uid(uid)
 	return null
 
 
@@ -165,11 +158,8 @@ func _untag_nodes(rec: PrefabInstanceRecord) -> void:
 
 
 func _find_brush_by_id(brush_id: String) -> Node3D:
-	if not root.draft_brushes_node:
-		return null
-	for child in root.draft_brushes_node.get_children():
-		if str(child.get_meta("brush_id", "")) == brush_id:
-			return child
+	if root.brush_system and root.brush_system.has_method("find_brush_by_id"):
+		return root.brush_system.find_brush_by_id(brush_id) as Node3D
 	return null
 
 
@@ -300,6 +290,13 @@ func _remove_instance_nodes(rec: PrefabInstanceRecord) -> void:
 			if parent:
 				parent.remove_child(brush)
 			brush.queue_free()
+		else:
+			push_warning(
+				(
+					"Prefab instance '%s': brush '%s' was not found during removal."
+					% [rec.instance_id, bid]
+				)
+			)
 	for uid in rec.entity_uids:
 		var ent = _find_entity_by_uid(uid)
 		if ent:
@@ -307,6 +304,13 @@ func _remove_instance_nodes(rec: PrefabInstanceRecord) -> void:
 			if parent:
 				parent.remove_child(ent)
 			ent.queue_free()
+		else:
+			push_warning(
+				(
+					"Prefab instance '%s': entity '%s' was not found during removal."
+					% [rec.instance_id, uid]
+				)
+			)
 
 
 # ---------------------------------------------------------------------------
@@ -378,11 +382,25 @@ func push_instance_to_source(instance_id: String) -> bool:
 		var brush = _find_brush_by_id(bid)
 		if brush:
 			brush_nodes.append(brush)
+		else:
+			push_warning(
+				(
+					"Prefab instance '%s': brush '%s' was not found while saving the source."
+					% [instance_id, bid]
+				)
+			)
 	var entity_nodes: Array = []
 	for uid in rec.entity_uids:
 		var ent = _find_entity_by_uid(uid)
 		if ent:
 			entity_nodes.append(ent)
+		else:
+			push_warning(
+				(
+					"Prefab instance '%s': entity '%s' was not found while saving the source."
+					% [instance_id, uid]
+				)
+			)
 
 	# Re-capture as the current variant
 	var captured = HFPrefabType.capture_from_selection(

--- a/addons/hammerforge/systems/hf_prefab_system.gd
+++ b/addons/hammerforge/systems/hf_prefab_system.gd
@@ -158,8 +158,8 @@ func _untag_nodes(rec: PrefabInstanceRecord) -> void:
 
 
 func _find_brush_by_id(brush_id: String) -> Node3D:
-	if root.brush_system and root.brush_system.has_method("find_brush_by_id"):
-		return root.brush_system.find_brush_by_id(brush_id) as Node3D
+	if root.brush_system and root.brush_system.has_method("find_managed_brush_by_id"):
+		return root.brush_system.find_managed_brush_by_id(brush_id) as Node3D
 	return null
 
 

--- a/tests/test_prefab_enhancements.gd
+++ b/tests/test_prefab_enhancements.gd
@@ -3,6 +3,93 @@ extends GutTest
 const HFPrefabType = preload("res://addons/hammerforge/hf_prefab.gd")
 const HFLevelIO = preload("res://addons/hammerforge/hflevel_io.gd")
 const HFPrefabSystemType = preload("res://addons/hammerforge/systems/hf_prefab_system.gd")
+const HFBrushSystemType = preload("res://addons/hammerforge/systems/hf_brush_system.gd")
+const HFEntitySystemType = preload("res://addons/hammerforge/systems/hf_entity_system.gd")
+const DraftBrushType = preload("res://addons/hammerforge/brush_instance.gd")
+
+
+class PrefabLookupRoot:
+	extends Node3D
+
+	var draft_brushes_node := Node3D.new()
+	var pending_node := Node3D.new()
+	var committed_node := Node3D.new()
+	var entities_node := Node3D.new()
+	var brush_system
+	var entity_system
+
+	func _init() -> void:
+		add_child(draft_brushes_node)
+		add_child(pending_node)
+		add_child(committed_node)
+		add_child(entities_node)
+
+	func _iter_pick_nodes() -> Array:
+		return (
+			draft_brushes_node.get_children()
+			+ pending_node.get_children()
+			+ entities_node.get_children()
+		)
+
+	func _iter_managed_brush_nodes() -> Array:
+		return (
+			draft_brushes_node.get_children()
+			+ pending_node.get_children()
+			+ committed_node.get_children()
+		)
+
+
+func _make_lookup_root() -> PrefabLookupRoot:
+	var root := PrefabLookupRoot.new()
+	root.brush_system = HFBrushSystemType.new(root)
+	root.entity_system = HFEntitySystemType.new(root)
+	return root
+
+
+func test_prefab_removes_property_identified_brushes_from_all_brush_containers():
+	for container_name in [&"pending_node", &"committed_node"]:
+		var root := _make_lookup_root()
+		var brush := DraftBrushType.new()
+		brush.brush_id = "brush_%s" % container_name
+		root.get(container_name).add_child(brush)
+		var system = HFPrefabSystemType.new(root)
+		var iid := system.register_instance("res://prefabs/test.hfprefab", [brush.brush_id], [])
+		assert_eq(brush.get_meta("hf_prefab_instance", ""), iid, "brush was found and tagged")
+		system._remove_instance_nodes(system.get_instance(iid))
+		assert_null(brush.get_parent(), "%s brush was removed" % container_name)
+		if is_instance_valid(brush):
+			brush.free()
+		root.free()
+
+
+func test_prefab_finds_brush_entities_in_the_committed_container():
+	var root := _make_lookup_root()
+	var brush_entity := DraftBrushType.new()
+	root.committed_node.add_child(brush_entity)
+	var system = HFPrefabSystemType.new(root)
+	var iid := system.register_instance("res://prefabs/test.hfprefab", [], [brush_entity])
+	assert_eq(
+		brush_entity.get_meta("hf_prefab_instance", ""), iid, "brush entity was found and tagged"
+	)
+	system._remove_instance_nodes(system.get_instance(iid))
+	assert_null(brush_entity.get_parent(), "committed brush entity was removed")
+	if is_instance_valid(brush_entity):
+		brush_entity.free()
+	root.free()
+
+
+func test_prefab_removal_warns_when_recorded_members_are_missing():
+	var root := _make_lookup_root()
+	var system = HFPrefabSystemType.new(root)
+	var rec = HFPrefabSystemType.PrefabInstanceRecord.new()
+	rec.instance_id = "pfx_missing"
+	rec.brush_ids = ["missing_brush"]
+	rec.entity_uids = ["missing_entity"]
+	system._remove_instance_nodes(rec)
+	assert_push_warning("brush 'missing_brush' was not found during removal")
+	assert_push_warning("entity 'missing_entity' was not found during removal")
+	root.free()
+
 
 # -- Helper data ----------------------------------------------------------------
 
@@ -225,6 +312,7 @@ func find_entities_by_name(_name: String) -> Array:
 extends Node3D
 var draft_brushes_node: Node3D
 var entities_node: Node3D
+var brush_system
 var entity_system
 var prefab_system
 """)
@@ -290,6 +378,7 @@ func find_entities_by_name(_name: String) -> Array:
 extends Node3D
 var draft_brushes_node: Node3D
 var entities_node: Node3D
+var brush_system
 var entity_system
 """)
 	root_script.reload()


### PR DESCRIPTION
- Fixes #66
- Resolve prefab brushes and entities through their owning systems.
- Include committed cutters in canonical brush lookup.
- Warn when removal or source capture cannot resolve a recorded member.