### PR TITLE
docs: synchronize architecture references

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,8 +38,8 @@ addons/hammerforge/
   plugin_overlays.gd     Power-user lifecycle, vertex/marquee drawing, quick properties, and coach marks
   plugin_vertex_input.gd Vertex/edge pick, drag, merge, and split dispatch
   plugin_hud.gd          HUD context, mode banner, and context-toolbar state
-  level_root.gd          Coordinator (2,844 lines), delegates to subsystems
-  input_state.gd         Drag/paint state machine (HFInputState)
+  level_root.gd          Public level facade and coordinator (2,851 lines)
+  input_state.gd         Drag/paint/extrude/vertex state machine (HFInputState)
   hf_selection_gesture.gd Select-mode LMB arbiter (native object selection, face marquee, gizmos)
   dock.gd + dock.tscn    UI dock (displayed as Build, Paint, Objects, Test), collapsible sections with persisted state
   dock_brush_handler.gd  Build-tab displacement/bevel/hollow/clip/tie handlers
@@ -102,7 +102,7 @@ addons/hammerforge/
     hf_prefab_library.gd   Prefab library dock section (search, tags, variants, drag-drop, context menu)
     hf_prefab_overlay.gd   Prefab ghost overlay (wireframe bounding box + override markers)
     hf_context_toolbar.gd  Floating contextual mini-toolbar (context-sensitive actions, group labels per tool cluster, pending-cuts buttons, bake preview toggle)
-    selection_tools_builder.gd  Builds Selection Tools section with domain sub-headers (Brush Modification, Positioning, Entity Binding, Duplicate Array)
+    selection_tools_builder.gd  Builds Selection Tools with domain sub-headers (Brush Modification, Positioning, Entity Binding, Duplicate Array)
     hf_hotkey_palette.gd   Searchable command palette with fuzzy search and live gray-out (Shift+?/F1/Ctrl+K)
     hf_viewport_context_menu.gd  Context menu (Space key) with context-sensitive sections and submenus
     hf_radial_menu.gd      Radial/pie menu (backtick key) with 8 tool sectors drawn via _draw()
@@ -117,7 +117,6 @@ addons/hammerforge/
     entity_tab_builder.gd  Builds Entity Properties + Entity I/O + I/O Wiring sections (all context-hidden until entity selected)
     hf_io_wiring_panel.gd  I/O wiring panel (quick wire, presets, highlight toggle, connection summary)
     manage_tab_builder.gd  Builds the displayed Test tab (legacy internal name retained for compatibility)
-    selection_tools_builder.gd  Builds Selection Tools section (hollow, clip, move, tie, duplicator)
     hf_ui_factory.gd       HFUIFactory: static factory for repeated UI patterns (make_label_row/spin/check/button/option/separator)
     hf_editor_theme.gd     HFEditorTheme: editor icon/color/stylebox lookup with graceful fallbacks
     hf_undo_nav.gd         HFUndoNav: per-scene EditorUndoRedoManager navigation (history_id, scene_undo_redo, navigate_to_version)
@@ -140,8 +139,6 @@ addons/hammerforge/
     hf_io_visualizer.gd    Entity I/O connection lines (Bézier curves, color-coded, highlight pulse)
     hf_io_presets.gd       Reusable I/O connection presets (built-in + user-saved, target tag mapping)
 
-  hf_log.gd               HFLog: test-aware warning wrapper (capture/suppress expected warnings in tests)
-  hf_io_runtime.gd        Runtime I/O-to-Signal dispatcher (auto-wires entity_io_outputs to Godot signals on bake/export)
     hf_subtract_preview.gd Live CSG cut overlay for overlapping subtract/additive brushes (AABB fallback, debounced, pooled)
     hf_carve_preview.gd    Green wireframe preview of carve slice pieces (confirmation before commit)
     hf_clip_preview.gd     Cyan wireframe + orange plane preview of clip halves (confirmation before commit)
@@ -151,6 +148,9 @@ addons/hammerforge/
     hf_prefab_system.gd    Prefab instance registry, variant cycling, live-linked propagation, overrides
     hf_displacement_system.gd  Displacement surface create/destroy/paint/sew/elevation/power
     hf_bevel_system.gd     Edge bevel (chamfer) and face inset
+
+  hf_log.gd               HFLog: test-aware warning wrapper (capture/suppress expected warnings in tests)
+  hf_io_runtime.gd        Runtime I/O-to-Signal dispatcher (auto-wires entity_io_outputs to Godot signals on bake/export)
 
   paint/                 Floor paint subsystem
     hf_paint_grid.gd       Grid storage
@@ -180,9 +180,9 @@ addons/hammerforge/
 - **Validation guards.** Use `HFValidation.has_draft_containers(root)`, `has_baked_container(root)`, `has_nodes(root, [...])` for compound container guards in subsystems. Single-property checks (`if not root.entities_node:`) can stay inline — same line count, less import noise.
 - **Dialog tracking.** Plugin-spawned `ConfirmationDialog`/`AcceptDialog` instances must be registered with `_dialog_manager.add(dlg, base_control)` (`HFDialogManager` instance held by `plugin.gd`). It auto-removes from tracking when the dialog leaves the tree, and frees all live dialogs on plugin teardown via `_cleanup_pending_dialogs()`.
 - **No circular preloads.** Subsystem files must not `preload("../level_root.gd")`. Use raw ints for default parameters and `root.EnumName.*` at runtime.
-- **LevelRoot is the public API.** Its methods are thin one-line delegates to subsystems. External callers (`plugin.gd`, `dock.gd`) always go through `LevelRoot`.
+- **LevelRoot is the public level API.** It owns containers, exported settings, signals, runtime setup, and cross-system coordination. Operations delegate to focused subsystems where a subsystem owns the behavior; external editor callers use the LevelRoot facade instead of reaching into subsystem internals.
 - **Input state machine.** `HFDragSystem` owns the `HFInputState` instance. Drag state transitions are explicit (`begin_drag` -> `advance_to_height` -> `end_drag`). Extrude uses `begin_extrude` -> `end_extrude`. Modes are classified as *transient* (DRAG_BASE, DRAG_HEIGHT, EXTRUDE, SURFACE_PAINT — own temporary preview nodes) or *persistent* (VERTEX_EDIT — user-toggled, survives undo/redo). `HFInputState.is_transient_preview_mode()` encodes this distinction; plugin.gd's `version_changed` handler uses it to force-reset only transient modes.
-- **Direct typed calls.** `plugin.gd` and `dock.gd` use typed references (`LevelRoot`, `DockType`) with direct method calls instead of `has_method`/`call`.
+- **Typed boundaries with deliberate adapters.** `plugin.gd` and `dock.gd` use typed `LevelRoot`/dock references for their stable public boundary. Focused static `plugin_*.gd` adapters accept the EditorPlugin as `Object` and may use `get`, `has_method`, or `call` to avoid a circular script dependency. Compatibility integrations and undo/redo method-name dispatch are also intentionally dynamic; do not introduce dynamic access inside otherwise typed subsystem APIs without a concrete boundary reason.
 - **Brush visual layers.** Ordinary additive brushes use their material/tinted surface without a topology overlay. Subtract brushes keep one red semantic wireframe; brush entities keep one understated blue overlay. `DraftBrush.get_editor_outline_lines()` is the canonical hover/gizmo outline source: polyhedra keep boundaries and true creases without coplanar triangulation diagonals, while curved primitives use sparse shape-specific profiles instead of render wireframes or fallback boxes. Triangle topology is opt-in through vertex/edit tooling or Bake Preview Wireframe. `DraftBrush._sync_visual_overlays()` updates reusable semantic nodes after mesh changes and removes legacy duplicates.
 - **Transient-node replacement.** Never `queue_free()` a fixed-name visual/container node and add its replacement under the same parent in the same frame. The queued node still reserves its name, so Godot auto-renames the replacement and later lookups lose it. Reuse the existing node when possible; otherwise detach it with `remove_child()` before queueing deletion and adding the replacement. Mark private lifecycle nodes with metadata when they must be recognized across reloads.
 - **Baked-container ownership.** The top-level name `BakedGeometry` is reserved for HammerForge output. `HFBakeSystem.reconcile_baked_containers()` re-adopts that persisted node and conservatively migrates recognized legacy anonymous bake roots while leaving unrelated anonymous nodes untouched. Full-bake replacement and clear paths detach managed containers synchronously, then queue safe deletion, so there is always at most one canonical top-level baked container.
@@ -202,7 +202,7 @@ addons/hammerforge/
 - **Managed selection scope.** Input forwarding is global, but HammerForge edits are not. `classify_selection_scope()` separates empty, native-only, HammerForge-only, and mixed selections. Empty/native-only keyboard commands pass through to Godot; a mixed selection is stopped with “Edit HammerForge and Godot nodes separately” so generic edits cannot bypass HammerForge IDs, caches, or undo. Apply the same guard before selection-dependent actions dispatched by the context toolbar, viewport context menu, hotkey palette, or radial menu, and expose `mixed_selection` in their state so unavailable actions do not advertise a partial edit. Global managed shortcuts also yield whenever an unrelated editor control owns keyboard focus; only the 3D viewport, the real Scene tree, or an explicitly marked HammerForge surface may dispatch them. HammerForge-only commands stay consumed even when their operation reports a no-op.
 - **External-tool exclusivity.** Activating an external `HFEditorTool` calls `_prepare_tool_transition()`, exits conflicting vertex/paint state, and deactivates the previous external tool. While one is active, every mouse event is dispatched to it before built-in vertex/select/draw handling. Even when its handler returns PASS for a miss, `plugin.gd` returns immediately so the same physical event can reach Godot navigation but cannot leak into another HammerForge tool. Switching to a built-in tool or vertex mode deactivates the external tool.
 - **Brush/material caching.** `hf_brush_system.gd` uses `_brush_cache: Dictionary` for O(1) brush ID lookup, `_brush_count: int` for O(1) count, and `_material_cache: Dictionary` for material instance reuse. All CRUD methods maintain these caches.
-- **Undo/redo dynamic dispatch.** The `_commit_state_action` pattern in `dock.gd` intentionally uses string method names for undo/redo -- this is the one exception to the typed-calls rule.
+- **Undo/redo dynamic dispatch.** The `_commit_state_action` pattern in `dock.gd` intentionally uses string method names for undo/redo. This is one of the documented dynamic boundaries alongside focused plugin adapters and compatibility integrations.
 - **Undo/redo helper.** Use `HFUndoHelper` for editor actions to ensure consistent history and state snapshot restores. Pass a `collation_tag` for operations that fire rapidly (nudge, resize, paint) — consecutive actions with the same tag within 1 second are merged into one undo entry. Collation also requires matching `full_state` scope — a `full_state=true` action will not merge with a prior `full_state=false` run.
 - **Undo/redo history binding.** HammerForge actions go into the **scene history** (not global) because `create_action()` passes `null` context and the first do/undo object is a Node (LevelRoot). Dock history UI (`_update_history_buttons`, `_on_history_undo/redo`) resolves the correct history via `_get_scene_history_id()` → `undo_redo.get_object_history_id(level_root)`. Never hard-code `EditorUndoRedoManager.GLOBAL_HISTORY` — use `_get_scene_undo_redo()` to get the `UndoRedo` object for the active scene.
 - **Transactions.** For multi-step operations (hollow, clip, tie), use `state_system.begin_transaction()` / `commit_transaction()` / `rollback_transaction()` to group mutations atomically. If any step fails, `rollback_transaction()` restores the snapshot.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -1,6 +1,6 @@
 # HammerForge Spec
 
-Last updated: September 2, 2026
+Last updated: September 3, 2026
 
 This document describes HammerForge's architecture and data flow.
 
@@ -12,7 +12,7 @@ This document describes HammerForge's architecture and data flow.
 
 ## Architecture
 
-HammerForge uses a coordinator + subsystems pattern. `LevelRoot` is a 2,844-line coordinator that owns container nodes, exported properties, and signals, and delegates work to subsystem classes. Each subsystem receives a reference to `LevelRoot` in its constructor. Default editor UX is the core loop (Draw → material → entity → bake → Test Level); radial menu, coach marks, and operation replay install only when `power_user_overlays` is enabled.
+HammerForge uses a coordinator + subsystems pattern. `LevelRoot` is a 2,851-line public level facade and coordinator that owns container nodes, exported properties, signals, runtime setup, and cross-system coordination. Concrete subsystems receive a reference to `LevelRoot` in their constructor. Export templates eagerly construct only the brush, entity, bake, paint, and file core; editor builds dynamically load the authoring graph. Default editor UX is the core loop (Draw → material → entity → bake → Test Level); radial menu, coach marks, and operation replay install only when `power_user_overlays` is enabled.
 
 ### Signals (Central Registry)
 All signals are defined on `LevelRoot`. Subsystems emit them via `root.<signal>.emit(...)`. UI and other consumers subscribe instead of polling.
@@ -42,11 +42,12 @@ All signals are defined on `LevelRoot`. Subsystems emit them via `root.<signal>.
 
 | Script | Role |
 |--------|------|
-| `plugin.gd` | EditorPlugin entry point, input routing, undo/redo, sticky LevelRoot discovery |
-| `level_root.gd` | Thin coordinator: containers, exports, signals, delegates to subsystems |
-| `dock.gd` + `dock.tscn` | UI dock (4 tabs: Build, Paint, Objects, Test), collapsible sections, tool state |
+| `plugin.gd` | EditorPlugin lifecycle, composition, undo wiring, sticky LevelRoot discovery, and high-level coordination |
+| `plugin_*.gd` | Focused viewport input, selection, command, HUD, overlay, edit-action, and drag-and-drop adapters |
+| `level_root.gd` | Public level facade: containers, exports, signals, runtime setup, coordination, and subsystem delegation |
+| `dock.gd` + `dock.tscn` | UI coordinator (4 tabs: Build, Paint, Objects, Test) with workflows delegated to `dock_*_handler.gd` and `dock_connections.gd` |
 | `ui/collapsible_section.gd` | Reusable `HFCollapsibleSection` toggle-header VBoxContainer |
-| `input_state.gd` | Drag/paint/extrude state machine (`Mode` enum: IDLE, DRAG_BASE, DRAG_HEIGHT, SURFACE_PAINT, EXTRUDE) |
+| `input_state.gd` | Drag/paint/extrude/vertex state machine (`Mode` enum: IDLE, DRAG_BASE, DRAG_HEIGHT, SURFACE_PAINT, EXTRUDE, VERTEX_EDIT) |
 | `hf_selection_gesture.gd` | Native Object Select / modal Face Select gesture ownership and recovery state |
 | `hf_brush_change_tracker.gd` | Stable-ID reconciliation for Godot-owned gizmo, Inspector, and undo/redo brush changes |
 | `brush_gizmo_plugin.gd` | Semantic brush/entity gizmos, filled native hit targets, and shape-aware resize handles |
@@ -100,10 +101,16 @@ All signals are defined on `LevelRoot`. Subsystems emit them via `root.<signal>.
 | `hf_visgroup_system.gd` | `HFVisgroupSystem` | Visgroups (visibility groups), brush/entity grouping |
 | `hf_carve_system.gd` | `HFCarveSystem` | Boolean-subtract carve (progressive-remainder box slicing) |
 | `hf_io_visualizer.gd` | `HFIOVisualizer` | Entity I/O connection lines in viewport (ImmediateMesh) |
+| `hf_io_presets.gd` | `HFIOPresets` | Built-in and user-saved I/O connection presets with target-tag mapping |
 | `hf_subtract_preview.gd` | `HFSubtractPreview` | Live CSG cut overlay between subtract and additive brushes, with a wireframe AABB fallback (debounced, pooled) |
+| `hf_carve_preview.gd` | `HFCarvePreview` | Green wireframe preview of carve slice pieces before confirmation |
+| `hf_clip_preview.gd` | `HFClipPreview` | Clip-plane and retained-half preview before confirmation |
+| `hf_hollow_preview.gd` | `HFHollowPreview` | Yellow wireframe preview of hollow wall pieces before confirmation |
 | `hf_vertex_system.gd` | `HFVertexSystem` | Vertex/edge selection, move, split, merge with convexity validation. Edge sub-mode with wireframe overlay |
 | `hf_spawn_system.gd` | `HFSpawnSystem` | Player spawn lookup, validation (floor/collision/headroom), auto-fix, debug visualisation |
 | `hf_prefab_system.gd` | `HFPrefabSystem` | Prefab instance registry (stable entity UIDs), variant cycling, live-linked propagation, override tracking, push-to-source |
+| `hf_displacement_system.gd` | `HFDisplacementSystem` | Displacement surface creation, painting, sewing, elevation, and power changes |
+| `hf_bevel_system.gd` | `HFBevelSystem` | Edge bevel (chamfer) and face inset operations |
 
 ### Other Modules
 
@@ -345,23 +352,20 @@ Surface paint is a per-face splat system. It updates preview materials and can b
 ## Data Flow
 
 ```
-plugin.gd (input)
-  -> level_root.gd (coordinator)
-    -> hf_drag_system.gd    (draw tool: drag lifecycle + preview)
-    -> hf_extrude_tool.gd   (extrude up/down: face pick + drag + commit)
-    -> hf_brush_system.gd   (brush CRUD, pending cuts, materials)
-    -> hf_paint_system.gd   (floor + surface paint)
-    -> hf_bake_system.gd    (CSG assembly + mesh output)
-    -> hf_state_system.gd   (undo/redo state capture)
-    -> hf_file_system.gd    (persistence, threaded I/O)
-    -> hf_grid_system.gd    (editor grid)
-    -> hf_entity_system.gd  (entity placement)
-    -> hf_visgroup_system.gd (visgroups + grouping)
+Godot editor input and UI
+  -> plugin.gd                  (lifecycle, composition, discovery, undo wiring)
+     -> plugin_*.gd             (viewport, selection, commands, HUD, overlays, edits, drops)
+     -> HFToolRegistry          (plugin-owned built-in/external tools)
+     -> dock.gd
+        -> dock_*_handler.gd    (tab workflows, files, visgroups, connections)
+     -> level_root.gd           (public level facade and cross-system coordination)
+        -> runtime core         (brush, entity, bake, paint, file)
+        -> editor-only graph    (drag, grid, snap, state, validation, previews, authoring tools)
 ```
 
-All public methods on `LevelRoot` are thin one-line delegates to the appropriate subsystem. This preserves the existing API so `plugin.gd` and `dock.gd` call `root.bake()`, `root.begin_drag()`, etc. without change.
+`LevelRoot` preserves the public level API used by `plugin.gd` and `dock.gd` (`root.bake()`, `root.begin_drag()`, and similar operations). It delegates cohesive behavior to subsystems while retaining container ownership, exported settings, signals, runtime lifecycle, and cross-system coordination; its methods are therefore not uniformly one-line delegates.
 
-`plugin.gd`'s `_forward_3d_gui_input()` is a ~50-line dispatcher that routes to focused handlers: `_handle_paint_input()`, `_handle_keyboard_input()`, `_handle_rmb_cancel()`, `_handle_select_mouse()`, `_handle_extrude_mouse()`, `_handle_draw_mouse()`, `_handle_mouse_motion()`. A shared `_get_nudge_direction()` helper is used by both `_forward_3d_gui_input()` and `_shortcut_input()`.
+`plugin.gd`'s `_forward_3d_gui_input()` is a two-line boundary that delegates viewport arbitration to `HFPluginViewportInput.handle()`. That module coordinates the focused paint, keyboard, RMB, selection, extrude, draw, motion, vertex, and external-tool paths. Other `plugin_*.gd` modules similarly own selection state, commands, HUD state, overlays, edit actions, and viewport drops.
 
 ## Input State Machine
 
@@ -465,7 +469,7 @@ External tools expose `get_settings_schema()` → Array of `{name, type, label, 
 - Shader-based editor grid with follow mode.
 - Grouping shortcuts: Ctrl+G (group selection), Ctrl+U (ungroup).
 - Brush operations: Ctrl+H (hollow), Shift+X (clip), Ctrl+Shift+F (floor), Ctrl+Shift+C (ceiling).
-- Direct typed calls between plugin/dock/LevelRoot (no duck-typing).
+- Typed `LevelRoot` and dock references at the stable coordinator boundary. Focused static `plugin_*.gd` adapters deliberately receive the EditorPlugin as `Object`; compatibility integrations and undo/redo method-name dispatch are also explicit dynamic boundaries.
 - O(1) brush ID lookup and brush count via `_brush_cache` / `_brush_count` in `HFBrushSystem`.
 - Material instance caching in `HFBrushSystem` (composite key: operation/solid/unshaded).
 - Persistent cordon `ImmediateMesh` reused via `clear_surfaces()` (no per-call allocation).
@@ -508,6 +512,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 38 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 2, 2026): **1,790 tests** across **104 scripts** (**1,783 passing** plus seven intentional no-assert safety tests; **7,855 assertions**).
+Full suite (verified in CI on September 3, 2026): **1,895 tests** across **111 scripts** (**1,888 passing** plus seven intentional no-assert safety tests; **8,222 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ HammerForge is a single `addons/` folder. No external tools, no custom builds, n
 
 | | |
 |---|---|
-| **Subsystem-based coordinator architecture** | **1,790 unit + integration tests** with CI on every push |
+| **Subsystem-based coordinator architecture** | **1,895 unit + integration tests** with CI on every push |
 | **15 brush shapes** (box through dodecahedron) | **150 built-in prototype textures** for instant greyboxing |
 | **Quake `.map`** + **glTF `.glb`** export | **.hflevel** native format with threaded I/O |
 | **Customizable keymaps** (JSON) | **Plugin API** for custom tools |
@@ -259,9 +259,11 @@ HammerForge uses a **coordinator + subsystems** pattern:
 `LevelRoot` always initializes the brush, entity, bake, paint, and file core needed to load and run a level. Grid, drawing, snapping, selection, previews, prefab authoring, validation, undo, and the remaining editor services are loaded only by editor builds. Export templates therefore avoid constructing the editor tool graph.
 
 ```
-plugin.gd            EditorPlugin coordinator with focused input/overlay modules
+plugin.gd            EditorPlugin lifecycle, composition, discovery, and undo wiring
+  ├─ plugin_*.gd     Input, selection, commands, HUD, overlays, edit actions, and drops
   ├─ dock.gd         Four-tab UI coordinator with focused handler modules
-  └─ level_root.gd   Thin coordinator — owns containers, exports, signals
+  ├─ HFToolRegistry  Plugin-owned external tool loading and dispatch
+  └─ level_root.gd   Public level facade; owns containers, exports, and signals
        ├─ HFBrushSystem     Brush CRUD, hollow, clip, tie, move, UV justify, caching
        ├─ HFDragSystem      Two-stage draw lifecycle + preview management
        ├─ HFExtrudeTool     Face extrusion (Up/Down) via FaceSelector
@@ -283,18 +285,19 @@ plugin.gd            EditorPlugin coordinator with focused input/overlay modules
        ├─ HFSpawnSystem     Player spawn lookup, validation, auto-fix, debug visualisation
        ├─ HFPrefabSystem    Instance registry, variant cycling, live-linked propagation
        ├─ HFDisplacementSystem  Displacement surface create/destroy/paint/sew/elevation
-       ├─ HFBevelSystem     Edge bevel (chamfer) and face inset
-       └─ HFToolRegistry    External tool loading and dispatch
-            ├─ HFMeasureTool   Multi-ruler measurement + snap reference (tool_id=100)
-            ├─ HFDecalTool     Decal placement with live preview (tool_id=101)
-            ├─ HFPolygonTool   Convex polygon → extruded brush (tool_id=102)
-            └─ HFPathTool      Waypoint path → corridor brushes (tool_id=103)
+       └─ HFBevelSystem     Edge bevel (chamfer) and face inset
+
+HFToolRegistry
+  ├─ HFMeasureTool   Multi-ruler measurement + snap reference (tool_id=100)
+  ├─ HFDecalTool     Decal placement with live preview (tool_id=101)
+  ├─ HFPolygonTool   Convex polygon → extruded brush (tool_id=102)
+  └─ HFPathTool      Waypoint path → corridor brushes (tool_id=103)
 ```
 
 Key design choices:
 
 - **No live CSG** -- brushes are Node3D with box metadata; CSG runs only during bake
-- **RefCounted subsystems** -- each receives a LevelRoot reference; no circular preloads
+- **RefCounted subsystems** -- concrete systems receive a LevelRoot reference; editor-only systems use dynamic loading so export templates avoid the authoring graph
 - **Signal-driven UI** -- signals on LevelRoot replace polling; batched emission prevents UI thrash
 - **Tag-based invalidation** -- exact dirty tags on transform, material, UV, paint, and vertex mutations; an ID-keyed change tracker reconciles Godot-owned Inspector/gizmo commits and native undo/redo for selective Bake Changed output
 - **Command collation** -- rapid operations merge into single undo entries within a 1-second window
@@ -302,7 +305,7 @@ Key design choices:
 - **HFOpResult** -- failable operations return structured results with actionable fix hints
 - **HFGesture** -- base class for self-contained input tool gestures
 - **Explicit state machine** -- `HFInputState` manages IDLE / DRAG_BASE / DRAG_HEIGHT / SURFACE_PAINT / EXTRUDE / VERTEX_EDIT modes
-- **Type-safe calls** -- no duck-typing between modules (dynamic dispatch only in undo/redo by design)
+- **Stable public facade** -- editor and dock code use LevelRoot's public operations; focused plugin adapters use deliberate dynamic access where GDScript cannot type the EditorPlugin implementation without creating preload cycles
 
 ---
 
@@ -516,5 +519,5 @@ Run `godot --headless --import --path .` first, then re-run the test command.
 
 <p align="center">
   <strong>MIT License</strong><br>
-  <sub>Built for Godot 4.7+ | Last updated September 2, 2026</sub>
+  <sub>Built for Godot 4.7+ | Last updated September 3, 2026</sub>
 </p>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -433,7 +433,6 @@ Currently applied to two `HFBrushSystem` methods as demonstration. Roughly 300 i
 
 ### Performance enhancements (Phase 4) — needs profiling first
 - **Mesh pooling**: `SubtractPreview`, bake preview, extrude preview, and now Carve/Clip/Hollow previews all create/destroy `MeshInstance3D` nodes frequently. A shared pool with `acquire()`/`release()` could reduce GC pressure. Needs profiling to confirm allocation hotspots.
-- **Preload graph audit**: `level_root.gd` preloads 54 system types upfront. As new systems land, circular-preload risks grow. Move non-critical paths (UI panels, map adapters) to string-based `load()`.
 
 ## Out of Scope (for now)
 - Real-time CSG of full scenes.

--- a/docs/HammerForge_MVP_GUIDE.md
+++ b/docs/HammerForge_MVP_GUIDE.md
@@ -120,7 +120,7 @@ See [DEVELOPMENT.md](../DEVELOPMENT.md) for the full file tree and architecture 
 - See [Data Portability](HammerForge_Data_Portability.md) for fidelity boundaries and current save-safety limitations.
 
 ## High-Level Flow
-1. Input is handled by `plugin.gd` (EditorPlugin) with typed references to `LevelRoot` and the dock.
+1. `plugin.gd` owns the EditorPlugin lifecycle and delegates input to focused `plugin_*.gd` adapters. The coordinator keeps typed `LevelRoot` and dock references; the static adapters receive the plugin as `Object` to avoid a circular script dependency.
 2. `LevelRoot` delegates to the appropriate subsystem:
    - Draw tool -> `HFDragSystem` (drag lifecycle + preview)
    - Extrude Up/Down -> `HFExtrudeTool` (face pick + drag + commit)


### PR DESCRIPTION
## Summary
- describe the current plugin, dock, LevelRoot, and tool-registry ownership boundaries
- synchronize coordinator sizes, runtime loading, subsystem inventory, and test totals
- remove stale type-safety and preload claims and repair the development file tree

## Verification
- all local Markdown links in the edited documents resolve
- all 22 concrete system files appear in the spec inventory
- git diff --check