### PR TITLE
Prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog, and this project follows semantic versioning.
 
 ## [Unreleased]
+
+## [0.3.0] - 2026-09-03
 ### Added
 - **PBR channels survive material atlasing** ([#24](https://github.com/saworbit/hammerforge/issues/24)): `HFMaterialAtlas` now packs normal, roughness, metallic, and emission maps into parallel atlases over the albedo layout, so one set of remapped UVs addresses all of them. Materials that supply no map for a slot contribute a flat tile carrying their own scalar. A slot the atlas cannot represent faithfully — suppliers disagreeing on `normal_scale`, on a texture-channel selector, or on a multiplier that would distort untextured tiles — is reported in `AtlasResult.skipped_channels` **and** in the editor log via `HFLog.warn()`, instead of being silently dropped. A supplied texture that cannot be read drops the whole slot rather than substituting a flat tile. Slots nobody uses cost nothing.
 - **`HFLog` capture coverage** (`tests/test_hf_log.gd`, 6 cases): warning capture, suppression, buffer lifetime, and the idle-path regression below.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,10 +10,11 @@ security issue here.
 | Version | Supported |
 |---|---|
 | `main` | Yes |
+| `0.3.x` prereleases | Yes |
 | Anything older | No |
 
-There are no tagged releases yet. Fixes land on `main`; please reproduce
-against the latest `main` before reporting.
+Security fixes land on `main` and ship in the next prerelease. Please reproduce
+against the latest `main` before reporting when practical.
 
 ## Reporting a Vulnerability
 

--- a/addons/hammerforge/plugin.cfg
+++ b/addons/hammerforge/plugin.cfg
@@ -1,6 +1,6 @@
 [plugin]
 name="HammerForge"
 description="Brush-based level editor for Godot 4.7+"
-author="Codex"
-version="0.2.1"
+author="Shane Wall"
+version="0.3.0"
 script="plugin.gd"


### PR DESCRIPTION
## Summary
- bump HammerForge plugin metadata to v0.3.0
- credit Shane Wall as the packaged plugin author
- cut the accumulated Unreleased changelog into a dated v0.3.0 section
- update the security support policy for tagged prereleases

## Release plan
- merge only after CI is green
- tag the merge commit as v0.3.0
- build a repository-derived addons/hammerforge archive
- publish v0.3.0 as a GitHub prerelease