### PR TITLE
Show the mark in BRAND.md instead of sketching it in block characters

### DIFF
--- a/docs/brand/BRAND.md
+++ b/docs/brand/BRAND.md
@@ -6,10 +6,12 @@
 
 ## The mark
 
-```
-  ██▛▀▜
-  ███▄▟
-```
+<p>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="png/mark-dark-256.png">
+    <img alt="The HammerForge mark" src="png/mark-light-256.png" width="132">
+  </picture>
+</p>
 
 A filled solid with a corner bitten out, and an outlined square overhanging that
 corner.


### PR DESCRIPTION
The sketch used half-block characters in a fenced code block, which renders as a small grey smear on GitHub rather than anything resembling the mark.

Uses the rendered mark instead, light and dark, so the document opens on the thing it describes.