### PR TITLE
Stop hollow, clip, and carve from eating brushes they cannot handle

### DIFF
--- a/addons/hammerforge/systems/hf_brush_system.gd
+++ b/addons/hammerforge/systems/hf_brush_system.gd
@@ -1112,6 +1112,41 @@ func _find_brush_by_key(key: String) -> DraftBrush:
 
 
 # ---------------------------------------------------------------------------
+# Shape guards for box-only operations
+# ---------------------------------------------------------------------------
+
+
+## Hollow and clip both compute world-space extents from `global_position` and
+## `size`, then rebuild the brush as axis-aligned BOX pieces.  That is only
+## truthful for an unrotated box, so anything else has to be rejected before the
+## original brush is deleted.
+func _check_axis_aligned_box(draft: DraftBrush, op_name: String) -> HFOpResult:
+	if draft.shape != root.BrushShape.BOX:
+		return HFOpResult.fail(
+			"%s: only works on box brushes" % op_name,
+			"Select a box brush, or convert this shape to a box first"
+		)
+	if not _is_axis_aligned(draft.global_transform.basis):
+		return HFOpResult.fail(
+			"%s: only works on unrotated box brushes" % op_name,
+			"Clear the brush rotation before running this operation"
+		)
+	return HFOpResult.success()
+
+
+## True when the basis leaves each axis pointing down its own world axis, so the
+## brush's world bounds really are `global_position` +/- `size * 0.5`.
+static func _is_axis_aligned(basis: Basis) -> bool:
+	var b := basis.orthonormalized()
+	const TOLERANCE := 0.9999
+	return (
+		absf(b.x.dot(Vector3.RIGHT)) >= TOLERANCE
+		and absf(b.y.dot(Vector3.UP)) >= TOLERANCE
+		and absf(b.z.dot(Vector3.BACK)) >= TOLERANCE
+	)
+
+
+# ---------------------------------------------------------------------------
 # Pre-validation (check preconditions without performing the operation)
 # ---------------------------------------------------------------------------
 
@@ -1123,6 +1158,9 @@ func can_hollow_brush(brush_id: String, wall_thickness: float) -> HFOpResult:
 	if not brush or not (brush is DraftBrush):
 		return HFOpResult.fail("Hollow: brush not found")
 	var draft := brush as DraftBrush
+	var shape_check := _check_axis_aligned_box(draft, "Hollow")
+	if not shape_check.ok:
+		return shape_check
 	var min_dim = min(draft.size.x, min(draft.size.y, draft.size.z))
 	if wall_thickness * 2.0 >= min_dim:
 		return HFOpResult.fail(
@@ -1142,6 +1180,9 @@ func can_clip_brush(brush_id: String, axis: int, split_pos: float) -> HFOpResult
 	if not brush or not (brush is DraftBrush):
 		return HFOpResult.fail("Clip: brush not found")
 	var draft := brush as DraftBrush
+	var shape_check := _check_axis_aligned_box(draft, "Clip")
+	if not shape_check.ok:
+		return shape_check
 	var pos = draft.global_position
 	var half = draft.size * 0.5
 	var brush_min: float
@@ -1183,12 +1224,11 @@ func hollow_brush_by_id(brush_id: String, wall_thickness: float) -> HFOpResult:
 	if not brush or not (brush is DraftBrush):
 		return _op_fail("Hollow: brush not found")
 	var draft := brush as DraftBrush
-	# Hollow only works on axis-aligned box brushes — reject custom geometry
-	if draft.shape == root.BrushShape.CUSTOM:
-		return _op_fail(
-			"Hollow: not supported on polygon/path brushes",
-			"Hollow only works on axis-aligned box brushes"
-		)
+	# Hollow rebuilds the brush as axis-aligned box slabs, so anything that is
+	# not an unrotated box would be silently replaced with the wrong geometry.
+	var shape_check := _check_axis_aligned_box(draft, "Hollow")
+	if not shape_check.ok:
+		return _op_fail(shape_check.message, shape_check.fix_hint)
 	var size = draft.size
 	var pos = draft.global_position
 	var mat = draft.material_override
@@ -1528,12 +1568,11 @@ func clip_brush_by_id(brush_id: String, axis: int, split_pos: float) -> HFOpResu
 	if not brush or not (brush is DraftBrush):
 		return _op_fail("Clip: brush not found")
 	var draft := brush as DraftBrush
-	# Clip only works on axis-aligned box brushes — reject custom geometry
-	if draft.shape == root.BrushShape.CUSTOM:
-		return _op_fail(
-			"Clip: not supported on polygon/path brushes",
-			"Clip only works on axis-aligned box brushes"
-		)
+	# Clip rebuilds the brush as two axis-aligned box pieces, so anything that is
+	# not an unrotated box would be silently replaced with the wrong geometry.
+	var shape_check := _check_axis_aligned_box(draft, "Clip")
+	if not shape_check.ok:
+		return _op_fail(shape_check.message, shape_check.fix_hint)
 	var pos = draft.global_position
 	var half = draft.size * 0.5
 

--- a/addons/hammerforge/systems/hf_carve_system.gd
+++ b/addons/hammerforge/systems/hf_carve_system.gd
@@ -106,6 +106,15 @@ func carve_with_brush(brush_id: String) -> HFOpResult:
 
 		targets_carved += 1
 
+	# Every overlapping brush was skipped (contact too shallow, or the carver
+	# swallows the target whole and leaves no slices).  Nothing was cut, so the
+	# carver has to stay where it is instead of being consumed for free.
+	if targets_carved == 0:
+		return _op_fail(
+			"Carve: overlap is too shallow to carve",
+			"Push the carver further into the brush you want to cut"
+		)
+
 	# Delete the carver brush
 	root.brush_system.delete_brush_by_id(brush_id)
 

--- a/tests/test_bugfix_regressions.gd
+++ b/tests/test_bugfix_regressions.gd
@@ -368,6 +368,12 @@ func test_carve_thin_overlap_single_axis_produces_no_pieces():
 
 	# The target survives (thin overlap is rejected via OR guard)
 	assert_true(is_instance_valid(b), "Target should survive thin overlap")
+	# Nothing was cut, so the carver must not be eaten either.
+	assert_false(result.ok, "Carving nothing should report failure")
+	assert_true(is_instance_valid(a), "Carver should survive when nothing is carved")
+	assert_eq(
+		draft_node.get_child_count(), child_count_before, "No brushes should be added or removed"
+	)
 
 
 # ===========================================================================

--- a/tests/test_clip_tool.gd
+++ b/tests/test_clip_tool.gd
@@ -182,6 +182,32 @@ func test_clip_on_edge_is_rejected():
 	assert_not_null(sys.find_brush_by_id("brush_1"), "Clip on brush edge should be rejected")
 
 
+func test_clip_rejects_non_box_shape():
+	# Clip builds two axis-aligned boxes. A wedge must not be swapped for them.
+	var b = _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "brush_1")
+	b.shape = root.BrushShape.WEDGE
+	var result = sys.clip_brush_by_id("brush_1", 1, 0.0)
+	assert_false(result.ok, "Clip should reject a wedge")
+	assert_true(is_instance_valid(b), "The wedge must survive a rejected clip")
+	assert_eq(root.draft_brushes_node.get_child_count(), 1, "No clip pieces should be created")
+
+
+func test_can_clip_brush_rejects_non_box_shape():
+	var b = _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "brush_1")
+	b.shape = root.BrushShape.CAPSULE
+	assert_false(sys.can_clip_brush("brush_1", 1, 0.0).ok, "Pre-check should reject a capsule")
+
+
+func test_clip_rejects_rotated_box():
+	# The split plane is computed in world space, so a turned box would come back
+	# as two unrotated pieces that do not match what the user had.
+	var b = _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "brush_1")
+	b.rotation_degrees = Vector3(0, 30, 0)
+	var result = sys.clip_brush_by_id("brush_1", 1, 0.0)
+	assert_false(result.ok, "Clip should reject a rotated box")
+	assert_true(is_instance_valid(b), "The rotated box must survive a rejected clip")
+
+
 func test_clip_empty_id_noop():
 	_make_brush(Vector3.ZERO, Vector3(32, 32, 32), "brush_1")
 	sys.clip_brush_by_id("", 1, 0.0)

--- a/tests/test_hollow_tool.gd
+++ b/tests/test_hollow_tool.gd
@@ -155,6 +155,32 @@ func test_hollow_accepts_valid_thickness():
 	assert_eq(children.size(), 6, "Should accept valid thickness")
 
 
+func test_hollow_rejects_non_box_shape():
+	# Hollow builds 6 axis-aligned slabs. A cylinder must not be swapped for them.
+	var b = _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "brush_1")
+	b.shape = root.BrushShape.CYLINDER
+	var result = sys.hollow_brush_by_id("brush_1", 4.0)
+	assert_false(result.ok, "Hollow should reject a cylinder")
+	assert_true(is_instance_valid(b), "The cylinder must survive a rejected hollow")
+	assert_eq(root.draft_brushes_node.get_child_count(), 1, "No wall brushes should be created")
+
+
+func test_can_hollow_brush_rejects_non_box_shape():
+	var b = _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "brush_1")
+	b.shape = root.BrushShape.SPHERE
+	assert_false(sys.can_hollow_brush("brush_1", 4.0).ok, "Pre-check should reject a sphere")
+
+
+func test_hollow_rejects_rotated_box():
+	# Bounds are read straight off global_position and size, which is a lie once
+	# the brush is turned.
+	var b = _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "brush_1")
+	b.rotation_degrees = Vector3(0, 45, 0)
+	var result = sys.hollow_brush_by_id("brush_1", 4.0)
+	assert_false(result.ok, "Hollow should reject a rotated box")
+	assert_true(is_instance_valid(b), "The rotated box must survive a rejected hollow")
+
+
 func test_hollow_empty_id_noop():
 	_make_brush(Vector3.ZERO, Vector3(32, 32, 32), "brush_1")
 	sys.hollow_brush_by_id("", 2.0)


### PR DESCRIPTION
Three destructive brush ops deleted user geometry when their preconditions did not hold.

- Fixes #87. `hollow_brush_by_id` and `can_hollow_brush` now require an unrotated BOX. Before this, only CUSTOM was rejected, so a cylinder was deleted and replaced with 6 box slabs, and `can_hollow_brush` did not look at the shape at all.
- Fixes #88. Same for `clip_brush_by_id` and `can_clip_brush`. A rotated box is also rejected now, because the split plane is computed in world space and the pieces came back unrotated.
- Fixes #84. `carve_with_brush` deleted the carver and returned success even when every overlapping brush was skipped for shallow contact. It now fails and leaves the carver in place when nothing was cut.

Both hollow and clip share one guard, `_check_axis_aligned_box`, so the shape and rotation rules cannot drift apart.

Tests: 6 new cases in `test_hollow_tool.gd` and `test_clip_tool.gd` covering non-box shapes, rotated boxes, and the pre-check path. The existing carve thin-overlap regression test now also asserts the carver survives and the result is a failure. Full GUT run: 1909 tests, 1902 passing, 0 failing.
