### PR TITLE
Guard the grid delegates so runtime brush creation cannot crash

### DIFF
--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -631,15 +631,20 @@ func _process_hflevel_saves() -> void:
 
 
 func update_editor_grid(camera: Camera3D, mouse_pos: Vector2) -> void:
-	grid_system.update_editor_grid(camera, mouse_pos)
+	if grid_system:
+		grid_system.update_editor_grid(camera, mouse_pos)
 
 
 func _refresh_grid_plane() -> void:
-	grid_system.refresh_grid_plane()
+	if grid_system:
+		grid_system.refresh_grid_plane()
 
 
+# Reached from HFBrushSystem, which stays alive at runtime while grid_system does
+# not, so this one has to tolerate a missing grid.
 func _record_last_brush(center: Vector3) -> void:
-	grid_system.record_last_brush(center)
+	if grid_system:
+		grid_system.record_last_brush(center)
 
 
 func _set_grid_visible(value: bool) -> void:

--- a/tests/test_export_playtest.gd
+++ b/tests/test_export_playtest.gd
@@ -50,6 +50,33 @@ func _should_initialize_editor_systems() -> bool:
 	runtime_root.free()
 
 
+func test_runtime_brush_creation_survives_missing_grid_system():
+	# HFBrushSystem stays alive at runtime and calls back into _record_last_brush,
+	# which used to dereference the unloaded grid_system.
+	var runtime_script := GDScript.new()
+	runtime_script.source_code = """
+extends "res://addons/hammerforge/level_root.gd"
+func _should_initialize_editor_systems() -> bool:
+	return false
+"""
+	assert_eq(runtime_script.reload(), OK)
+	var runtime_root = runtime_script.new()
+	runtime_root.auto_spawn_player = false
+	runtime_root.commit_freeze = false
+	add_child(runtime_root)
+	assert_null(runtime_root.grid_system, "grid_system stays unloaded at runtime")
+
+	var brush = runtime_root.brush_system.create_brush_from_info(
+		{"shape": 0, "size": Vector3.ONE, "center": Vector3.ZERO}
+	)
+	assert_not_null(brush, "Runtime brush creation should succeed without a grid")
+
+	# The other two grid delegates take the same unguarded shape, so pin them too.
+	runtime_root.update_editor_grid(null, Vector2.ZERO)
+	runtime_root._refresh_grid_plane()
+	runtime_root.free()
+
+
 func test_editor_only_systems_are_loaded_on_demand():
 	var source := FileAccess.get_file_as_string("res://addons/hammerforge/level_root.gd")
 	for path in [


### PR DESCRIPTION
Fixes #86.

`_should_initialize_editor_systems()` leaves `grid_system` null outside the editor, but `HFBrushSystem` is a core subsystem and stays alive. Every `add_brush()` and `create_brush_from_info()` calls back into `LevelRoot._record_last_brush()`, which dereferenced the null grid. That is the crash path: the first brush added at runtime brings the build down.

`update_editor_grid()` and `_refresh_grid_plane()` had the same unguarded shape. Only `_record_last_brush` is reachable at runtime today (the other two are called from `plugin_viewport_input.gd` and `hf_drag_system.gd`, both editor-only), but they now match the check the rest of the grid delegates already had.

Test: `test_runtime_brush_creation_survives_missing_grid_system` builds a LevelRoot with editor systems disabled and creates a brush through `brush_system`. With the guard removed it fails with `Invalid call. Nonexistent function 'record_last_brush' in base 'Nil'`, which is the exact error from the issue. Full GUT run: 1904 tests, 1897 passing, 0 failing.
