### PR TITLE
Let MultiMesh consolidation see meshes inside chunk holders

### DIFF
--- a/addons/hammerforge/systems/hf_bake_system.gd
+++ b/addons/hammerforge/systems/hf_bake_system.gd
@@ -1584,28 +1584,32 @@ static func _transform_aabb(local_bounds: AABB, world_transform: Transform3D) ->
 
 
 ## Consolidate identical meshes in the baked container into MultiMeshInstance3D nodes.
-## Groups MeshInstance3D children by mesh resource identity (same Mesh = same group).
-## Groups with 2+ instances are replaced with a single MultiMeshInstance3D.
+## Walks the whole container, since chunked bakes nest their meshes under
+## BakedChunk_* nodes and detail brushes sit under Nonstructural.
+## Instances are grouped by mesh resource identity and material, so a group only
+## ever collapses into something that draws the same way.  Groups with 2+
+## instances are replaced with a single MultiMeshInstance3D on the container.
 func _consolidate_to_multimesh(container: Node3D) -> void:
 	if not container:
 		return
-	# Group MeshInstance3D children by mesh resource
-	var mesh_groups: Dictionary = {}  # Mesh -> Array[MeshInstance3D]
-	for child in container.get_children():
-		if not (child is MeshInstance3D):
-			continue
-		var mi: MeshInstance3D = child
+	var mesh_groups: Dictionary = {}  # [Mesh, Material] -> Array[MeshInstance3D]
+	var group_order: Array = []
+	for node in _collect_mesh_instances(container):
+		var mi: MeshInstance3D = node
 		if not mi.mesh:
 			continue
-		var key: Mesh = mi.mesh
+		var key: Array = [mi.mesh, _instance_material(mi)]
 		if not mesh_groups.has(key):
 			mesh_groups[key] = []
+			group_order.append(key)
 		mesh_groups[key].append(mi)
 	var consolidated := 0
-	for mesh_key: Mesh in mesh_groups:
-		var instances: Array = mesh_groups[mesh_key]
+	var emptied: Array = []
+	for key: Array in group_order:
+		var instances: Array = mesh_groups[key]
 		if instances.size() < 2:
 			continue
+		var mesh_key: Mesh = key[0]
 		# Build MultiMesh
 		var mm = MultiMesh.new()
 		mm.transform_format = MultiMesh.TRANSFORM_3D
@@ -1614,25 +1618,39 @@ func _consolidate_to_multimesh(container: Node3D) -> void:
 		for i in range(instances.size()):
 			var mi: MeshInstance3D = instances[i]
 			mm.set_instance_transform(i, _multimesh_transform(mi, container))
-		# Carry material from first instance
+		# Carry the material the whole group shares
 		var mmi = MultiMeshInstance3D.new()
 		mmi.multimesh = mm
 		mmi.name = (
 			"MMI_%s" % mesh_key.resource_name if mesh_key.resource_name else "MMI_%d" % consolidated
 		)
-		var first_mi: MeshInstance3D = instances[0]
-		if first_mi.get_surface_override_material(0):
-			mmi.material_override = first_mi.get_surface_override_material(0)
-		elif first_mi.material_override:
-			mmi.material_override = first_mi.material_override
+		mmi.material_override = key[1]
 		container.add_child(mmi)
-		# Remove originals
+		# Remove originals, remembering the holders they came out of
 		for mi: MeshInstance3D in instances:
-			mi.get_parent().remove_child(mi)
+			var parent: Node = mi.get_parent()
+			if parent:
+				parent.remove_child(mi)
+				if parent != container and not emptied.has(parent):
+					emptied.append(parent)
 			mi.queue_free()
 		consolidated += 1
+	# Drop chunk/detail holders that gave up every child to a MultiMesh.
+	for holder: Node in emptied:
+		if holder.get_child_count() == 0 and holder.get_parent():
+			holder.get_parent().remove_child(holder)
+			holder.queue_free()
 	if consolidated > 0:
 		root._log("MultiMesh: consolidated %d groups" % consolidated)
+
+
+## The material a MeshInstance3D actually draws with, so two instances are only
+## merged when the merged node can reproduce both.
+static func _instance_material(mi: MeshInstance3D) -> Material:
+	var surface := mi.get_surface_override_material(0)
+	if surface:
+		return surface
+	return mi.material_override
 
 
 static func _multimesh_transform(instance: Node3D, container: Node3D) -> Transform3D:

--- a/tests/test_bake_system.gd
+++ b/tests/test_bake_system.gd
@@ -945,6 +945,73 @@ func test_multimesh_consolidation_preserves_world_transforms():
 	assert_eq(mmi.multimesh.instance_count, 2)
 
 
+func test_multimesh_consolidation_reaches_into_chunks():
+	## Chunked bakes nest meshes under BakedChunk_* nodes, so scanning only the
+	## container's immediate children found nothing to consolidate.
+	var container := Node3D.new()
+	container.name = "BakedGeometry"
+	root.add_child(container)
+	var shared_mesh := BoxMesh.new()
+	var chunks: Array = []
+	for i in 2:
+		var chunk := Node3D.new()
+		chunk.name = "BakedChunk_%d_0_0" % i
+		container.add_child(chunk)
+		var body := StaticBody3D.new()
+		body.name = "FloorCollision"
+		chunk.add_child(body)
+		var mi := MeshInstance3D.new()
+		mi.name = "BakedMesh_0"
+		mi.mesh = shared_mesh
+		chunk.add_child(mi)
+		mi.position = Vector3(i * 32, 0, 0)
+		chunks.append(chunk)
+
+	bake_sys._consolidate_to_multimesh(container)
+
+	var mmi: MultiMeshInstance3D = null
+	for child in container.get_children():
+		if child is MultiMeshInstance3D:
+			mmi = child
+			break
+	assert_not_null(mmi, "Meshes inside BakedChunk_* nodes should be consolidated")
+	if mmi == null:
+		return
+	assert_eq(mmi.multimesh.instance_count, 2, "Both chunk meshes should be instanced")
+	for chunk: Node3D in chunks:
+		assert_null(
+			chunk.get_node_or_null("BakedMesh_0"), "The original chunk mesh should be removed"
+		)
+		assert_not_null(
+			chunk.get_node_or_null("FloorCollision"), "Chunk collision must survive consolidation"
+		)
+
+
+func test_multimesh_consolidation_keeps_distinct_materials_apart():
+	## Two instances of one mesh with different materials cannot be drawn by a
+	## single MultiMeshInstance3D, so they must not be merged.
+	var container := Node3D.new()
+	root.add_child(container)
+	var shared_mesh := BoxMesh.new()
+	for i in 2:
+		var mi := MeshInstance3D.new()
+		mi.mesh = shared_mesh
+		mi.material_override = StandardMaterial3D.new()
+		container.add_child(mi)
+
+	bake_sys._consolidate_to_multimesh(container)
+
+	var mmi_count := 0
+	var mesh_count := 0
+	for child in container.get_children():
+		if child is MultiMeshInstance3D:
+			mmi_count += 1
+		elif child is MeshInstance3D:
+			mesh_count += 1
+	assert_eq(mmi_count, 0, "Different materials should not be collapsed together")
+	assert_eq(mesh_count, 2, "Both original meshes should be left alone")
+
+
 func test_apply_preview_visuals_full_mode_skips_chunks():
 	## Full mode should not apply any override, even to nested children.
 	var container = Node3D.new()


### PR DESCRIPTION
Fixes #85.

`_consolidate_to_multimesh()` scanned only the container's immediate children. `bake_chunked()` nests every mesh under a `BakedChunk_*` node, and `_append_nonstructural_brushes()` nests detail meshes under `Nonstructural`, so with the default `bake_chunk_size` of 32 the function found zero meshes and exited.

It now walks the container with `_collect_mesh_instances()`, the same helper `_generate_occluders()` already uses, and removes each original from whatever holder it actually lives in. A holder left with no children is dropped; a chunk that still holds its `FloorCollision` body stays put, so collision is not lost.

One thing came out of the change. Instances were grouped by mesh resource alone, and the MultiMesh took its material from the first instance in the group. That was harmless while the function never ran, but making it run would have started silently overwriting materials. Grouping is now by mesh and material together.

Worth noting for expectations: CSG baking hands back one fresh ArrayMesh per chunk, so a plain chunked bake of identical brushes still has nothing to consolidate. This fixes the traversal, not mesh deduplication.

Tests: `test_multimesh_consolidation_reaches_into_chunks` builds a container with two `BakedChunk_*` holders sharing a mesh and asserts the MultiMesh is created, the originals are gone, and chunk collision survives. It fails on the old immediate-children scan. `test_multimesh_consolidation_keeps_distinct_materials_apart` pins the material grouping. Targeted run of `test_bake_system.gd`: 129/129 passing.
