### PR TITLE
Move bulk selection commands into plugin_selection_commands.gd

### DIFF
--- a/addons/hammerforge/plugin.gd
+++ b/addons/hammerforge/plugin.gd
@@ -14,6 +14,7 @@ const HFPluginOverlays = preload("plugin_overlays.gd")
 const HFPluginPaintInput = preload("plugin_paint_input.gd")
 const HFPluginPointerTools = preload("plugin_pointer_tools.gd")
 const HFPluginSelectionInput = preload("plugin_selection_input.gd")
+const HFPluginSelectionCommands = preload("plugin_selection_commands.gd")
 const HFPluginSelectionState = preload("plugin_selection_state.gd")
 const HFPathToolType = preload("hf_path_tool.gd")
 const HFSelectionGestureType = preload("hf_selection_gesture.gd")
@@ -1613,17 +1614,11 @@ func _face_screen_center(camera: Camera3D, brush: DraftBrush, face) -> Vector2:
 
 
 func _face_key_for(brush: DraftBrush) -> String:
-	if brush.brush_id != "":
-		return brush.brush_id
-	return str(brush.get_instance_id())
+	return HFPluginSelectionCommands.face_key_for(brush)
 
 
 func _apply_face_selection(root: Node, face_sel: Dictionary) -> void:
-	root.face_selection = face_sel
-	if root.brush_system:
-		root.brush_system._apply_face_selection()
-	root.face_selection_changed.emit()
-	_update_hud_context()
+	HFPluginSelectionCommands.apply_face_selection(self, root, face_sel)
 
 
 # ---------------------------------------------------------------------------
@@ -1632,41 +1627,7 @@ func _apply_face_selection(root: Node, face_sel: Dictionary) -> void:
 
 
 func _apply_last_texture(root: Node) -> void:
-	if _last_picked_material_index < 0:
-		if dock:
-			dock.show_toast("No texture picked yet — use T to pick first", 1)
-		return
-	if not dock:
-		return
-	dock._selected_material_index = _last_picked_material_index
-	var face_count = dock._count_selected_faces()
-	if face_count > 0:
-		dock._on_face_assign_material()
-		dock.show_toast(
-			"Applied last texture to %d face%s" % [face_count, "" if face_count == 1 else "s"], 0
-		)
-	else:
-		var applied_count := 0
-		var mat = (
-			root.material_manager.get_material(_last_picked_material_index)
-			if root.material_manager
-			else null
-		)
-		if mat:
-			for node in hf_selection:
-				if node is DraftBrush:
-					_paint_brush_with_undo(root, node, mat)
-					applied_count += 1
-		if applied_count > 0:
-			dock.show_toast(
-				(
-					"Applied last texture to %d brush%s"
-					% [applied_count, "" if applied_count == 1 else "es"]
-				),
-				0
-			)
-		else:
-			dock.show_toast("No brushes or faces selected", 1)
+	HFPluginSelectionCommands.apply_last_texture(self, root)
 
 
 # ---------------------------------------------------------------------------
@@ -1675,46 +1636,11 @@ func _apply_last_texture(root: Node) -> void:
 
 
 func _select_all_nodes(root: Node) -> void:
-	if not root:
-		return
-	var selection = get_editor_interface().get_selection()
-	if not selection:
-		return
-	# Clear face selection first so context toolbar switches to object context
-	if root.has_method("clear_face_selection"):
-		root.clear_face_selection()
-	var all_nodes: Array = root._iter_pick_nodes()
-	hf_selection.clear()
-	for node in all_nodes:
-		if is_instance_valid(node):
-			hf_selection.append(node)
-	_apply_hf_selection(selection)
-	_update_hud_context()
-	if dock:
-		dock.set_selection_count(hf_selection.size())
-		dock.set_selection_nodes(hf_selection)
-		dock.show_toast("Selected %d objects" % hf_selection.size(), 0)
+	HFPluginSelectionCommands.select_all(self, root)
 
 
 func _deselect_all_nodes(root: Node) -> void:
-	if not root:
-		return
-	var selection = get_editor_interface().get_selection()
-	if not selection:
-		return
-	if dock:
-		dock.emit_signal("selection_clear_requested")
-	hf_selection.clear()
-	selection.clear()
-	# Also clear face selection
-	if root.has_method("clear_face_selection"):
-		root.clear_face_selection()
-	elif root.get("face_selection") is Dictionary:
-		root.face_selection.clear()
-	_update_hud_context()
-	if dock:
-		dock.set_selection_count(0)
-		dock.set_selection_nodes([])
+	HFPluginSelectionCommands.deselect_all(self, root)
 
 
 # ---------------------------------------------------------------------------
@@ -1723,109 +1649,11 @@ func _deselect_all_nodes(root: Node) -> void:
 
 
 func _select_similar(root: Node) -> void:
-	if not root:
-		return
-	# If faces are selected, find similar faces across all brushes
-	var face_count := 0
-	for key in root.face_selection.keys():
-		face_count += root.face_selection.get(key, []).size()
-	if face_count > 0:
-		_select_similar_faces(root)
-		return
-	# Otherwise match similar brushes by size
-	if not hf_selection.is_empty():
-		_select_similar_brushes(root)
-		return
-	if dock:
-		dock.show_toast("Select a face or brush first", 1)
-
-
-func _select_similar_faces(root: Node) -> void:
-	# Gather reference face properties with world-space normals
-	var ref_faces: Array = []
-	var ref_world_normals: Array = []
-	for key in root.face_selection.keys():
-		var brush = root._find_brush_by_key(str(key))
-		if not brush:
-			continue
-		var basis: Basis = brush.global_transform.basis if brush is Node3D else Basis.IDENTITY
-		var faces: Array = brush.get_faces() if brush.has_method("get_faces") else []
-		for fi in root.face_selection.get(key, []):
-			if int(fi) >= 0 and int(fi) < faces.size():
-				ref_faces.append(faces[int(fi)])
-				ref_world_normals.append((basis * faces[int(fi)].normal).normalized())
-	if ref_faces.is_empty():
-		return
-	# Find all matching faces (same material AND similar world-space normal within ~15 degrees)
-	var face_sel: Dictionary = {}
-	var nodes: Array = root._iter_pick_nodes() if root.has_method("_iter_pick_nodes") else []
-	var total := 0
-	for node in nodes:
-		if not (node is DraftBrush):
-			continue
-		var brush := node as DraftBrush
-		var basis: Basis = brush.global_transform.basis
-		var faces: Array = brush.get_faces() if brush.has_method("get_faces") else []
-		var key: String = _face_key_for(brush)
-		var indices: Array = []
-		for i in range(faces.size()):
-			var face = faces[i]
-			if not face:
-				continue
-			var world_normal: Vector3 = (basis * face.normal).normalized()
-			for ri in range(ref_faces.size()):
-				var ref = ref_faces[ri]
-				var ref_wn: Vector3 = ref_world_normals[ri]
-				if face.material_idx == ref.material_idx and world_normal.dot(ref_wn) > 0.966:
-					indices.append(i)
-					total += 1
-					break
-		if not indices.is_empty():
-			face_sel[key] = indices
-	_apply_face_selection(root, face_sel)
-	if dock:
-		dock.show_toast("Selected %d similar face%s" % [total, "" if total == 1 else "s"], 0)
-
-
-func _select_similar_brushes(root: Node) -> void:
-	var ref_sizes: Array = []
-	for node in hf_selection:
-		if node is DraftBrush and is_instance_valid(node):
-			ref_sizes.append((node as DraftBrush).size)
-	if ref_sizes.is_empty():
-		return
-	var tolerance := 0.2
-	var picked: Array = []
-	var nodes: Array = root._iter_pick_nodes() if root.has_method("_iter_pick_nodes") else []
-	for node in nodes:
-		if not (node is DraftBrush):
-			continue
-		var sz: Vector3 = (node as DraftBrush).size
-		for ref_sz in ref_sizes:
-			if _size_similar(sz, ref_sz, tolerance):
-				picked.append(node)
-				break
-	_apply_selection_list(picked, false)
-	if dock:
-		dock.show_toast(
-			"Selected %d similar brush%s" % [picked.size(), "" if picked.size() == 1 else "es"], 0
-		)
+	HFPluginSelectionCommands.select_similar(self, root)
 
 
 func _size_similar(a: Vector3, b: Vector3, tolerance: float) -> bool:
-	var sa := _sorted_vec(a)
-	var sb := _sorted_vec(b)
-	for i in range(3):
-		var ref_val: float = maxf(sb[i], 0.01)
-		if absf(sa[i] - sb[i]) / ref_val > tolerance:
-			return false
-	return true
-
-
-func _sorted_vec(v: Vector3) -> Array:
-	var arr := [v.x, v.y, v.z]
-	arr.sort()
-	return arr
+	return HFPluginSelectionCommands.size_similar(a, b, tolerance)
 
 
 # ---------------------------------------------------------------------------
@@ -1834,35 +1662,11 @@ func _sorted_vec(v: Vector3) -> Array:
 
 
 func _show_selection_filter() -> void:
-	if not _selection_filter:
-		return
-	var root = active_root if active_root else _get_level_root()
-	_selection_filter.show_for(root, hf_selection)
-	# Position near the mouse
-	var popup_pos := Vector2i(int(last_3d_mouse_pos.x), int(last_3d_mouse_pos.y))
-	_selection_filter.popup(Rect2i(popup_pos, Vector2i.ZERO))
+	HFPluginSelectionCommands.show_selection_filter(self)
 
 
 func _on_selection_filter_applied(nodes: Array, faces: Dictionary) -> void:
-	var root = active_root if active_root else _get_level_root()
-	if not root:
-		return
-	# Apply face selection if provided
-	if not faces.is_empty():
-		_apply_face_selection(root, faces)
-		var total := 0
-		for key in faces.keys():
-			total += faces[key].size()
-		if dock:
-			dock.show_toast("Selected %d face%s" % [total, "" if total == 1 else "s"], 0)
-	elif not nodes.is_empty():
-		# Node-only filter — clear any stale face selection first
-		_apply_face_selection(root, {})
-		_apply_selection_list(nodes, false)
-		if dock:
-			dock.show_toast(
-				"Selected %d node%s" % [nodes.size(), "" if nodes.size() == 1 else "s"], 0
-			)
+	HFPluginSelectionCommands.on_filter_applied(self, nodes, faces)
 
 
 # ---------------------------------------------------------------------------

--- a/addons/hammerforge/plugin_selection_commands.gd
+++ b/addons/hammerforge/plugin_selection_commands.gd
@@ -1,0 +1,273 @@
+@tool
+class_name HFPluginSelectionCommands
+extends RefCounted
+## User-invoked bulk selection commands: Select All, Deselect All, Select Similar,
+## the selection filter popup, and Apply Last Texture.
+##
+## These are the commands a shortcut, the hotkey palette, or the context toolbar
+## fires. Pointer arbitration lives in HFPluginSelectionInput and EditorSelection
+## synchronization lives in HFPluginSelectionState.
+
+## Faces whose world normals are within ~15 degrees count as the same direction.
+const SIMILAR_NORMAL_DOT := 0.966
+## Fractional size difference two brushes may have and still be "similar".
+const SIMILAR_SIZE_TOLERANCE := 0.2
+
+# ---------------------------------------------------------------------------
+# Face selection
+# ---------------------------------------------------------------------------
+
+
+static func face_key_for(brush: DraftBrush) -> String:
+	if brush.brush_id != "":
+		return brush.brush_id
+	return str(brush.get_instance_id())
+
+
+static func apply_face_selection(plugin: Object, root: Node, face_sel: Dictionary) -> void:
+	root.face_selection = face_sel
+	if root.brush_system:
+		root.brush_system._apply_face_selection()
+	root.face_selection_changed.emit()
+	plugin._update_hud_context()
+
+
+# ---------------------------------------------------------------------------
+# Apply Last Texture
+# ---------------------------------------------------------------------------
+
+
+static func apply_last_texture(plugin: Object, root: Node) -> void:
+	if plugin._last_picked_material_index < 0:
+		if plugin.dock:
+			plugin.dock.show_toast("No texture picked yet — use T to pick first", 1)
+		return
+	if not plugin.dock:
+		return
+	plugin.dock._selected_material_index = plugin._last_picked_material_index
+	var face_count = plugin.dock._count_selected_faces()
+	if face_count > 0:
+		plugin.dock._on_face_assign_material()
+		plugin.dock.show_toast(
+			"Applied last texture to %d face%s" % [face_count, "" if face_count == 1 else "s"], 0
+		)
+		return
+	var applied_count := 0
+	var mat = (
+		root.material_manager.get_material(plugin._last_picked_material_index)
+		if root.material_manager
+		else null
+	)
+	if mat:
+		for node in plugin.hf_selection:
+			if node is DraftBrush:
+				plugin._paint_brush_with_undo(root, node, mat)
+				applied_count += 1
+	if applied_count > 0:
+		plugin.dock.show_toast(
+			(
+				"Applied last texture to %d brush%s"
+				% [applied_count, "" if applied_count == 1 else "es"]
+			),
+			0
+		)
+	else:
+		plugin.dock.show_toast("No brushes or faces selected", 1)
+
+
+# ---------------------------------------------------------------------------
+# Select All / Deselect All
+# ---------------------------------------------------------------------------
+
+
+static func select_all(plugin: Object, root: Node) -> void:
+	if not root:
+		return
+	var selection = plugin.get_editor_interface().get_selection()
+	if not selection:
+		return
+	# Clear face selection first so context toolbar switches to object context
+	if root.has_method("clear_face_selection"):
+		root.clear_face_selection()
+	var all_nodes: Array = root._iter_pick_nodes()
+	plugin.hf_selection.clear()
+	for node in all_nodes:
+		if is_instance_valid(node):
+			plugin.hf_selection.append(node)
+	plugin._apply_hf_selection(selection)
+	plugin._update_hud_context()
+	if plugin.dock:
+		plugin.dock.set_selection_count(plugin.hf_selection.size())
+		plugin.dock.set_selection_nodes(plugin.hf_selection)
+		plugin.dock.show_toast("Selected %d objects" % plugin.hf_selection.size(), 0)
+
+
+static func deselect_all(plugin: Object, root: Node) -> void:
+	if not root:
+		return
+	var selection = plugin.get_editor_interface().get_selection()
+	if not selection:
+		return
+	if plugin.dock:
+		plugin.dock.emit_signal("selection_clear_requested")
+	plugin.hf_selection.clear()
+	selection.clear()
+	# Also clear face selection
+	if root.has_method("clear_face_selection"):
+		root.clear_face_selection()
+	elif root.get("face_selection") is Dictionary:
+		root.face_selection.clear()
+	plugin._update_hud_context()
+	if plugin.dock:
+		plugin.dock.set_selection_count(0)
+		plugin.dock.set_selection_nodes([])
+
+
+# ---------------------------------------------------------------------------
+# Select Similar
+# ---------------------------------------------------------------------------
+
+
+static func select_similar(plugin: Object, root: Node) -> void:
+	if not root:
+		return
+	# If faces are selected, find similar faces across all brushes
+	var face_count := 0
+	for key in root.face_selection.keys():
+		face_count += root.face_selection.get(key, []).size()
+	if face_count > 0:
+		select_similar_faces(plugin, root)
+		return
+	# Otherwise match similar brushes by size
+	if not plugin.hf_selection.is_empty():
+		select_similar_brushes(plugin, root)
+		return
+	if plugin.dock:
+		plugin.dock.show_toast("Select a face or brush first", 1)
+
+
+static func select_similar_faces(plugin: Object, root: Node) -> void:
+	# Gather reference face properties with world-space normals
+	var ref_faces: Array = []
+	var ref_world_normals: Array = []
+	for key in root.face_selection.keys():
+		var brush = root._find_brush_by_key(str(key))
+		if not brush:
+			continue
+		var basis: Basis = brush.global_transform.basis if brush is Node3D else Basis.IDENTITY
+		var faces: Array = brush.get_faces() if brush.has_method("get_faces") else []
+		for fi in root.face_selection.get(key, []):
+			if int(fi) >= 0 and int(fi) < faces.size():
+				ref_faces.append(faces[int(fi)])
+				ref_world_normals.append((basis * faces[int(fi)].normal).normalized())
+	if ref_faces.is_empty():
+		return
+	# Find all matching faces (same material AND similar world-space normal)
+	var face_sel: Dictionary = {}
+	var nodes: Array = root._iter_pick_nodes() if root.has_method("_iter_pick_nodes") else []
+	var total := 0
+	for node in nodes:
+		if not (node is DraftBrush):
+			continue
+		var brush := node as DraftBrush
+		var basis: Basis = brush.global_transform.basis
+		var faces: Array = brush.get_faces() if brush.has_method("get_faces") else []
+		var key: String = face_key_for(brush)
+		var indices: Array = []
+		for i in range(faces.size()):
+			var face = faces[i]
+			if not face:
+				continue
+			var world_normal: Vector3 = (basis * face.normal).normalized()
+			for ri in range(ref_faces.size()):
+				var ref = ref_faces[ri]
+				var ref_wn: Vector3 = ref_world_normals[ri]
+				if (
+					face.material_idx == ref.material_idx
+					and world_normal.dot(ref_wn) > SIMILAR_NORMAL_DOT
+				):
+					indices.append(i)
+					total += 1
+					break
+		if not indices.is_empty():
+			face_sel[key] = indices
+	apply_face_selection(plugin, root, face_sel)
+	if plugin.dock:
+		plugin.dock.show_toast("Selected %d similar face%s" % [total, "" if total == 1 else "s"], 0)
+
+
+static func select_similar_brushes(plugin: Object, root: Node) -> void:
+	var ref_sizes: Array = []
+	for node in plugin.hf_selection:
+		if node is DraftBrush and is_instance_valid(node):
+			ref_sizes.append((node as DraftBrush).size)
+	if ref_sizes.is_empty():
+		return
+	var picked: Array = []
+	var nodes: Array = root._iter_pick_nodes() if root.has_method("_iter_pick_nodes") else []
+	for node in nodes:
+		if not (node is DraftBrush):
+			continue
+		var sz: Vector3 = (node as DraftBrush).size
+		for ref_sz in ref_sizes:
+			if size_similar(sz, ref_sz, SIMILAR_SIZE_TOLERANCE):
+				picked.append(node)
+				break
+	plugin._apply_selection_list(picked, false)
+	if plugin.dock:
+		plugin.dock.show_toast(
+			"Selected %d similar brush%s" % [picked.size(), "" if picked.size() == 1 else "es"], 0
+		)
+
+
+static func size_similar(a: Vector3, b: Vector3, tolerance: float) -> bool:
+	var sa := sorted_vec(a)
+	var sb := sorted_vec(b)
+	for i in range(3):
+		var ref_val: float = maxf(sb[i], 0.01)
+		if absf(sa[i] - sb[i]) / ref_val > tolerance:
+			return false
+	return true
+
+
+static func sorted_vec(v: Vector3) -> Array:
+	var arr := [v.x, v.y, v.z]
+	arr.sort()
+	return arr
+
+
+# ---------------------------------------------------------------------------
+# Selection Filter popup
+# ---------------------------------------------------------------------------
+
+
+static func show_selection_filter(plugin: Object) -> void:
+	if not plugin._selection_filter:
+		return
+	var root = plugin.active_root if plugin.active_root else plugin._get_level_root()
+	plugin._selection_filter.show_for(root, plugin.hf_selection)
+	# Position near the mouse
+	var popup_pos := Vector2i(int(plugin.last_3d_mouse_pos.x), int(plugin.last_3d_mouse_pos.y))
+	plugin._selection_filter.popup(Rect2i(popup_pos, Vector2i.ZERO))
+
+
+static func on_filter_applied(plugin: Object, nodes: Array, faces: Dictionary) -> void:
+	var root = plugin.active_root if plugin.active_root else plugin._get_level_root()
+	if not root:
+		return
+	# Apply face selection if provided
+	if not faces.is_empty():
+		apply_face_selection(plugin, root, faces)
+		var total := 0
+		for key in faces.keys():
+			total += faces[key].size()
+		if plugin.dock:
+			plugin.dock.show_toast("Selected %d face%s" % [total, "" if total == 1 else "s"], 0)
+	elif not nodes.is_empty():
+		# Node-only filter — clear any stale face selection first
+		apply_face_selection(plugin, root, {})
+		plugin._apply_selection_list(nodes, false)
+		if plugin.dock:
+			plugin.dock.show_toast(
+				"Selected %d node%s" % [nodes.size(), "" if nodes.size() == 1 else "s"], 0
+			)

--- a/tests/test_plugin_selection_commands.gd
+++ b/tests/test_plugin_selection_commands.gd
@@ -1,0 +1,370 @@
+extends GutTest
+## Boundary coverage for the extracted bulk selection commands.
+
+const HFPluginSelectionCommands = preload("res://addons/hammerforge/plugin_selection_commands.gd")
+const DraftBrushScript = preload("res://addons/hammerforge/brush_instance.gd")
+
+
+class FakeDock:
+	extends RefCounted
+
+	signal selection_clear_requested
+
+	var toasts: Array = []
+	var selection_count := -1
+	var selection_nodes: Array = []
+	var clear_requests := 0
+	var assign_calls := 0
+	var face_count := 0
+	var _selected_material_index := -1
+
+	func _init() -> void:
+		selection_clear_requested.connect(_count_clear_request)
+
+	func _count_clear_request() -> void:
+		clear_requests += 1
+
+	func show_toast(message: String, level: int = 0) -> void:
+		toasts.append({"message": message, "level": level})
+
+	func set_selection_count(count: int) -> void:
+		selection_count = count
+
+	func set_selection_nodes(nodes: Array) -> void:
+		selection_nodes = nodes.duplicate()
+
+	func _count_selected_faces() -> int:
+		return face_count
+
+	func _on_face_assign_material() -> void:
+		assign_calls += 1
+
+	func last_toast() -> Dictionary:
+		return toasts[-1] if not toasts.is_empty() else {}
+
+
+class FakeMaterialManager:
+	extends RefCounted
+
+	var material := StandardMaterial3D.new()
+
+	func get_material(_index: int) -> Material:
+		return material
+
+
+class FakeRoot:
+	extends Node3D
+
+	signal face_selection_changed
+
+	var face_selection: Dictionary = {}
+	var brush_system = null
+	var material_manager = FakeMaterialManager.new()
+	var pick_nodes: Array = []
+	var brushes_by_key: Dictionary = {}
+	var face_clears := 0
+
+	func _iter_pick_nodes() -> Array:
+		return pick_nodes
+
+	func clear_face_selection() -> void:
+		face_clears += 1
+		face_selection = {}
+
+	func _find_brush_by_key(key: String):
+		return brushes_by_key.get(key, null)
+
+
+class FakeSelection:
+	extends RefCounted
+
+	var clears := 0
+
+	func clear() -> void:
+		clears += 1
+
+
+class FakeEditorInterface:
+	extends RefCounted
+
+	var selection := FakeSelection.new()
+
+	func get_selection() -> FakeSelection:
+		return selection
+
+
+class FakePlugin:
+	extends RefCounted
+
+	var dock := FakeDock.new()
+	var hf_selection: Array = []
+	var active_root: Node = null
+	var last_3d_mouse_pos := Vector2.ZERO
+	var _selection_filter = null
+	var _last_picked_material_index := -1
+	var _editor_interface := FakeEditorInterface.new()
+	var hud_updates := 0
+	var applied_hf_selection := 0
+	var selection_lists: Array = []
+	var painted: Array = []
+
+	func get_editor_interface() -> FakeEditorInterface:
+		return _editor_interface
+
+	func _update_hud_context() -> void:
+		hud_updates += 1
+
+	func _apply_hf_selection(_selection) -> void:
+		applied_hf_selection += 1
+
+	func _apply_selection_list(nodes: Array, _additive: bool, _toggle: bool = false) -> void:
+		selection_lists.append(nodes.duplicate())
+
+	func _paint_brush_with_undo(_root: Node, brush: Node, mat: Material) -> void:
+		painted.append({"brush": brush, "material": mat})
+
+	func _get_level_root() -> Node:
+		return active_root
+
+
+var plugin: FakePlugin
+var root: FakeRoot
+
+
+func before_each():
+	plugin = FakePlugin.new()
+	root = FakeRoot.new()
+	add_child_autoqfree(root)
+	plugin.active_root = root
+
+
+func after_each():
+	plugin = null
+	root = null
+
+
+func _make_brush(size: Vector3, brush_id: String = "") -> DraftBrush:
+	var brush = DraftBrushScript.new()
+	brush.size = size
+	if brush_id != "":
+		brush.brush_id = brush_id
+	root.add_child(brush)
+	return brush
+
+
+func _make_face(normal: Vector3, material_idx: int) -> FaceData:
+	var face := FaceData.new()
+	face.normal = normal
+	face.material_idx = material_idx
+	return face
+
+
+func _face_list(faces: Array) -> Array[FaceData]:
+	# DraftBrush.faces is Array[FaceData], so an untyped literal cannot be assigned.
+	var typed: Array[FaceData] = []
+	for face in faces:
+		typed.append(face)
+	return typed
+
+
+# ---------------------------------------------------------------------------
+# Similarity math
+# ---------------------------------------------------------------------------
+
+
+func test_sorted_vec_orders_components_ascending():
+	assert_eq(HFPluginSelectionCommands.sorted_vec(Vector3(30, 10, 20)), [10.0, 20.0, 30.0])
+
+
+func test_size_similar_ignores_axis_order():
+	assert_true(
+		HFPluginSelectionCommands.size_similar(Vector3(10, 20, 30), Vector3(30, 10, 20), 0.2),
+		"A rotated brush of the same dimensions should still count as similar"
+	)
+
+
+func test_size_similar_rejects_outside_tolerance():
+	assert_false(
+		HFPluginSelectionCommands.size_similar(Vector3(10, 10, 10), Vector3(20, 20, 20), 0.2),
+		"Doubling every dimension is well outside a 20 percent tolerance"
+	)
+
+
+func test_size_similar_guards_against_zero_reference():
+	# maxf(ref, 0.01) keeps a flat brush from dividing by zero.
+	assert_false(HFPluginSelectionCommands.size_similar(Vector3(1, 1, 1), Vector3.ZERO, 0.2))
+
+
+# ---------------------------------------------------------------------------
+# Face keys
+# ---------------------------------------------------------------------------
+
+
+func test_face_key_prefers_brush_id():
+	var brush = _make_brush(Vector3.ONE, "brush_7")
+	assert_eq(HFPluginSelectionCommands.face_key_for(brush), "brush_7")
+
+
+func test_face_key_falls_back_to_instance_id():
+	var brush = _make_brush(Vector3.ONE)
+	assert_eq(HFPluginSelectionCommands.face_key_for(brush), str(brush.get_instance_id()))
+
+
+# ---------------------------------------------------------------------------
+# Select Similar routing
+# ---------------------------------------------------------------------------
+
+
+func test_select_similar_prefers_faces_when_faces_are_selected():
+	# A brush is selected too, but a live face selection wins.
+	var brush = _make_brush(Vector3(32, 32, 32), "b1")
+	plugin.hf_selection = [brush]
+	root.pick_nodes = [brush]
+	root.face_selection = {"b1": [0]}
+	root.brushes_by_key = {}  # reference lookup fails, so the face path bails out
+
+	HFPluginSelectionCommands.select_similar(plugin, root)
+
+	assert_eq(
+		plugin.selection_lists.size(), 0, "The brush path must not run while faces are selected"
+	)
+
+
+func test_select_similar_matches_brushes_by_size():
+	var reference = _make_brush(Vector3(32, 32, 32), "b1")
+	var same = _make_brush(Vector3(32, 32, 32), "b2")
+	var different = _make_brush(Vector3(128, 8, 8), "b3")
+	plugin.hf_selection = [reference]
+	root.pick_nodes = [reference, same, different]
+
+	HFPluginSelectionCommands.select_similar(plugin, root)
+
+	assert_eq(plugin.selection_lists.size(), 1, "The brush path should apply one selection list")
+	var picked: Array = plugin.selection_lists[0]
+	assert_eq(picked.size(), 2, "Both same-sized brushes should be picked")
+	assert_false(picked.has(different), "The differently sized brush must be left out")
+
+
+func test_select_similar_with_nothing_selected_warns():
+	HFPluginSelectionCommands.select_similar(plugin, root)
+	assert_eq(plugin.dock.last_toast().get("message"), "Select a face or brush first")
+	assert_eq(plugin.dock.last_toast().get("level"), 1)
+
+
+func test_select_similar_faces_matches_material_and_world_normal():
+	var reference = _make_brush(Vector3(32, 32, 32), "b1")
+	reference.faces = _face_list([_make_face(Vector3.UP, 2), _make_face(Vector3.RIGHT, 2)])
+	var other = _make_brush(Vector3(32, 32, 32), "b2")
+	other.faces = _face_list(
+		[
+			_make_face(Vector3.UP, 2),  # same material and normal
+			_make_face(Vector3.UP, 5),  # same normal, wrong material
+			_make_face(Vector3.DOWN, 2),  # same material, opposite normal
+		]
+	)
+	root.pick_nodes = [reference, other]
+	root.brushes_by_key = {"b1": reference}
+	root.face_selection = {"b1": [0]}
+
+	HFPluginSelectionCommands.select_similar_faces(plugin, root)
+
+	assert_eq(root.face_selection.get("b1"), [0], "The reference up face should stay selected")
+	assert_eq(root.face_selection.get("b2"), [0], "Only the matching face on b2 should be added")
+	assert_eq(plugin.dock.last_toast().get("message"), "Selected 2 similar faces")
+
+
+# ---------------------------------------------------------------------------
+# Apply Last Texture
+# ---------------------------------------------------------------------------
+
+
+func test_apply_last_texture_without_a_pick_warns_and_changes_nothing():
+	HFPluginSelectionCommands.apply_last_texture(plugin, root)
+	assert_eq(plugin.dock.last_toast().get("level"), 1)
+	assert_eq(plugin.dock._selected_material_index, -1, "The dock material must not be touched")
+	assert_eq(plugin.painted.size(), 0)
+
+
+func test_apply_last_texture_uses_the_face_path_when_faces_are_selected():
+	plugin._last_picked_material_index = 3
+	plugin.dock.face_count = 2
+
+	HFPluginSelectionCommands.apply_last_texture(plugin, root)
+
+	assert_eq(plugin.dock.assign_calls, 1, "Face assignment should run once")
+	assert_eq(plugin.painted.size(), 0, "Brush painting must not also run")
+	assert_eq(plugin.dock.last_toast().get("message"), "Applied last texture to 2 faces")
+
+
+func test_apply_last_texture_paints_selected_brushes_when_no_faces():
+	plugin._last_picked_material_index = 3
+	var brush = _make_brush(Vector3.ONE, "b1")
+	plugin.hf_selection = [brush]
+
+	HFPluginSelectionCommands.apply_last_texture(plugin, root)
+
+	assert_eq(plugin.dock.assign_calls, 0)
+	assert_eq(plugin.painted.size(), 1, "The selected brush should be painted")
+	assert_eq(plugin.dock.last_toast().get("message"), "Applied last texture to 1 brush")
+
+
+# ---------------------------------------------------------------------------
+# Select All / Deselect All
+# ---------------------------------------------------------------------------
+
+
+func test_select_all_collects_pick_nodes_and_clears_faces():
+	var first = _make_brush(Vector3.ONE, "b1")
+	var second = _make_brush(Vector3.ONE, "b2")
+	root.pick_nodes = [first, second]
+	root.face_selection = {"b1": [0]}
+
+	HFPluginSelectionCommands.select_all(plugin, root)
+
+	assert_eq(root.face_clears, 1, "Face selection is cleared so the toolbar shows object context")
+	assert_eq(plugin.hf_selection.size(), 2)
+	assert_eq(plugin.applied_hf_selection, 1)
+	assert_eq(plugin.dock.selection_count, 2)
+
+
+func test_deselect_all_requests_the_clear_before_clearing_selection():
+	var brush = _make_brush(Vector3.ONE, "b1")
+	plugin.hf_selection = [brush]
+	root.face_selection = {"b1": [0]}
+
+	HFPluginSelectionCommands.deselect_all(plugin, root)
+
+	assert_eq(
+		plugin.dock.clear_requests, 1, "The dock must be told before the empty-selection guard runs"
+	)
+	assert_eq(plugin.hf_selection.size(), 0)
+	assert_eq(plugin._editor_interface.selection.clears, 1)
+	assert_eq(root.face_clears, 1)
+	assert_eq(plugin.dock.selection_count, 0)
+
+
+# ---------------------------------------------------------------------------
+# Selection filter results
+# ---------------------------------------------------------------------------
+
+
+func test_filter_applied_with_nodes_clears_stale_face_selection_first():
+	var brush = _make_brush(Vector3.ONE, "b1")
+	root.face_selection = {"b1": [0]}
+
+	HFPluginSelectionCommands.on_filter_applied(plugin, [brush], {})
+
+	assert_eq(root.face_selection, {}, "A node-only filter must drop the old face selection")
+	assert_eq(plugin.selection_lists.size(), 1)
+	assert_eq(plugin.dock.last_toast().get("message"), "Selected 1 node")
+
+
+func test_filter_applied_with_faces_does_not_touch_the_node_selection():
+	var brush = _make_brush(Vector3.ONE, "b1")
+	root.pick_nodes = [brush]
+
+	HFPluginSelectionCommands.on_filter_applied(plugin, [brush], {"b1": [0, 1]})
+
+	assert_eq(root.face_selection, {"b1": [0, 1]})
+	assert_eq(plugin.selection_lists.size(), 0, "Faces win, so no node list is applied")
+	assert_eq(plugin.dock.last_toast().get("message"), "Selected 2 faces")


### PR DESCRIPTION
Part of #41.

Select All, Deselect All, Select Similar (faces and brushes), the selection filter results handler, and Apply Last Texture were all still in plugin.gd. They are user-invoked commands, which is a different job from pointer arbitration (`plugin_selection_input.gd`) and from EditorSelection bookkeeping (`plugin_selection_state.gd`). Selection work in plugin.gd now splits three ways along those lines instead of two plus a leftover pile.

The face key helper and the size similarity math moved with the commands, since nothing else in plugin.gd used them. The two magic numbers in that math are named now: `SIMILAR_NORMAL_DOT` for the roughly 15 degree normal cone, and `SIMILAR_SIZE_TOLERANCE` for the 20 percent size window.

plugin.gd keeps thin delegates for every entry point, because `plugin_commands.gd`, `plugin_input_router.gd`, `plugin_selection_input.gd`, and the `filter_applied` signal connection all reach in by method name. No behaviour changed.

plugin.gd goes from 2,506 to 2,310 lines. Reporting that as progress, not as the goal.

Tests: new `tests/test_plugin_selection_commands.gd`, 17 cases covering the similarity math including the zero-size divide guard, brush id versus instance id face keys, Select Similar routing between the face and brush paths, the Apply Last Texture face path versus brush path, that Deselect All signals the dock before clearing so the empty-selection guard behaves, and that a node-only filter drops a stale face selection first.
