### PR TITLE
Move vertex edit mode and vertex undo into plugin_vertex_ops.gd

### DIFF
--- a/addons/hammerforge/plugin.gd
+++ b/addons/hammerforge/plugin.gd
@@ -8,6 +8,7 @@ const HFPluginEditActions = preload("plugin_edit_actions.gd")
 const HFPluginInputRouter = preload("plugin_input_router.gd")
 const HFPluginNumericInput = preload("plugin_numeric_input.gd")
 const HFPluginVertexInput = preload("plugin_vertex_input.gd")
+const HFPluginVertexOps = preload("plugin_vertex_ops.gd")
 const HFPluginHud = preload("plugin_hud.gd")
 const HFPluginViewportInput = preload("plugin_viewport_input.gd")
 const HFPluginOverlays = preload("plugin_overlays.gd")
@@ -1127,68 +1128,19 @@ func _update_prefab_hover_overlay(root, cam: Camera3D, pos: Vector2) -> void:
 
 
 func _toggle_vertex_mode(root: Node) -> void:
-	var enabling := not _vertex_mode
-	if enabling:
-		_close_face_select_mode("Face Select closed for vertex editing")
-	_prepare_tool_transition(root)
-	if enabling and dock and dock.paint_mode and dock.paint_mode.button_pressed:
-		dock.highlight_tab("Brush")
-	_vertex_mode = enabling
-	if _vertex_mode:
-		_deactivate_external_tool()
-		if root and root.vertex_system:
-			root.vertex_system.clear_selection()
-			# Pass current brush selection
-			var brushes: Array = []
-			for node in hf_selection:
-				if node is DraftBrush:
-					brushes.append(node)
-			root.vertex_system.set_selection(brushes)
-			root.input_state.begin_vertex_edit()
-	else:
-		if root and root.vertex_system:
-			if _vertex_drag_active:
-				root.vertex_system.cancel_drag()
-				_vertex_drag_active = false
-			root.vertex_system.clear_selection()
-			root.input_state.end_vertex_edit()
-		_clear_vertex_overlay()
-	if dock:
-		dock.set_vertex_mode(_vertex_mode)
-	_update_hud_context()
+	HFPluginVertexOps.toggle_mode(self, root)
 
 
 func _vertex_merge_selected(root: Node) -> void:
-	var vs = root.vertex_system
-	if not vs:
-		return
-	for brush_id in vs.selected_vertices:
-		var indices: PackedInt32Array = vs.selected_vertices[brush_id]
-		if indices.size() >= 2:
-			vs.merge_vertices(brush_id, indices)
+	HFPluginVertexOps.merge_selected(root)
 
 
 func _vertex_split_selected_edge(root: Node) -> void:
-	var vs = root.vertex_system
-	if not vs:
-		return
-	var sel: Array = vs.get_single_selected_edge()
-	if sel.size() == 2:
-		vs.split_edge(sel[0], sel[1])
+	HFPluginVertexOps.split_selected_edge(root)
 
 
 func _vertex_clip_to_convex(root: Node) -> void:
-	var vs = root.vertex_system
-	if not vs:
-		return
-	var clipped := false
-	for brush_id in vs.selected_vertices:
-		if vs.clip_to_convex(brush_id):
-			clipped = true
-	if clipped:
-		root.emit_signal("user_message", "Clipped to convex hull", 0)
-	else:
-		root.emit_signal("user_message", "Brush is already convex", 0)
+	HFPluginVertexOps.clip_to_convex(root)
 
 
 func _handle_vertex_input(event: InputEvent, root: Node, cam: Camera3D, pos: Vector2) -> int:
@@ -1196,47 +1148,11 @@ func _handle_vertex_input(event: InputEvent, root: Node, cam: Camera3D, pos: Vec
 
 
 func _commit_vertex_op(root: Node, pre_op_snapshots: Dictionary, action_name: String) -> void:
-	if not undo_redo_manager:
-		return
-	var post_state: Dictionary = {}
-	for brush_id in pre_op_snapshots:
-		var brush = root.brush_system.find_brush_by_id(brush_id) if root.brush_system else null
-		if brush and brush.get("faces"):
-			var current: Array = []
-			for face in brush.faces:
-				if face:
-					current.append(face.to_dict())
-			post_state[brush_id] = current
-	undo_redo_manager.create_action(action_name, 0, null, false)
-	undo_redo_manager.add_do_method(root, "_apply_vertex_faces", post_state)
-	undo_redo_manager.add_undo_method(root, "_apply_vertex_faces", pre_op_snapshots)
-	undo_redo_manager.commit_action()
-	_record_history(action_name)
+	HFPluginVertexOps.commit_op(self, root, pre_op_snapshots, action_name)
 
 
 func _commit_vertex_move(root: Node, pre_drag_snapshots: Dictionary) -> void:
-	if not undo_redo_manager:
-		return
-	# Capture current (post-move) face state as the "do" state
-	var post_state: Dictionary = {}
-	for brush_id in pre_drag_snapshots:
-		var brush = root.brush_system.find_brush_by_id(brush_id) if root.brush_system else null
-		if brush and brush.get("faces"):
-			var current: Array = []
-			for face in brush.faces:
-				if face:
-					current.append(face.to_dict())
-			post_state[brush_id] = current
-
-	# We must NOT use HFUndoHelper.commit() here because it captures undo
-	# state at commit time (post-move), which would replay the move on undo
-	# instead of reverting it.  Instead, wire undo/redo manually using the
-	# pre-drag snapshots we saved before the drag began.
-	undo_redo_manager.create_action("Move Vertices", 0, null, false)
-	undo_redo_manager.add_do_method(root, "_apply_vertex_faces", post_state)
-	undo_redo_manager.add_undo_method(root, "_apply_vertex_faces", pre_drag_snapshots)
-	undo_redo_manager.commit_action()
-	_record_history("Move Vertices")
+	HFPluginVertexOps.commit_move(self, root, pre_drag_snapshots)
 
 
 func _update_vertex_overlay(root: Node, _cam: Camera3D) -> void:

--- a/addons/hammerforge/plugin_vertex_ops.gd
+++ b/addons/hammerforge/plugin_vertex_ops.gd
@@ -1,0 +1,131 @@
+@tool
+class_name HFPluginVertexOps
+extends RefCounted
+## Vertex edit mode lifecycle and the undoable vertex operations.
+##
+## Pointer handling for the mode lives in HFPluginVertexInput and the ImmediateMesh
+## overlay lives in HFPluginOverlays. This module owns entering and leaving the
+## mode, the merge/split/clip commands, and how a vertex change reaches undo.
+
+# ---------------------------------------------------------------------------
+# Mode lifecycle
+# ---------------------------------------------------------------------------
+
+
+## Enter or leave vertex edit mode. Vertex editing is reached from Select, so
+## turning it on has to close whatever else owns the pointer first.
+static func toggle_mode(plugin: Object, root: Node) -> void:
+	# `plugin` is untyped here, so the bool needs to be declared, not inferred.
+	var enabling: bool = not plugin._vertex_mode
+	if enabling:
+		plugin._close_face_select_mode("Face Select closed for vertex editing")
+	plugin._prepare_tool_transition(root)
+	if (
+		enabling
+		and plugin.dock
+		and plugin.dock.paint_mode
+		and plugin.dock.paint_mode.button_pressed
+	):
+		plugin.dock.highlight_tab("Brush")
+	plugin._vertex_mode = enabling
+	if plugin._vertex_mode:
+		plugin._deactivate_external_tool()
+		if root and root.vertex_system:
+			root.vertex_system.clear_selection()
+			# Pass current brush selection
+			var brushes: Array = []
+			for node in plugin.hf_selection:
+				if node is DraftBrush:
+					brushes.append(node)
+			root.vertex_system.set_selection(brushes)
+			root.input_state.begin_vertex_edit()
+	else:
+		if root and root.vertex_system:
+			if plugin._vertex_drag_active:
+				root.vertex_system.cancel_drag()
+				plugin._vertex_drag_active = false
+			root.vertex_system.clear_selection()
+			root.input_state.end_vertex_edit()
+		plugin._clear_vertex_overlay()
+	if plugin.dock:
+		plugin.dock.set_vertex_mode(plugin._vertex_mode)
+	plugin._update_hud_context()
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+static func merge_selected(root: Node) -> void:
+	var vs = root.vertex_system
+	if not vs:
+		return
+	for brush_id in vs.selected_vertices:
+		var indices: PackedInt32Array = vs.selected_vertices[brush_id]
+		if indices.size() >= 2:
+			vs.merge_vertices(brush_id, indices)
+
+
+static func split_selected_edge(root: Node) -> void:
+	var vs = root.vertex_system
+	if not vs:
+		return
+	var sel: Array = vs.get_single_selected_edge()
+	if sel.size() == 2:
+		vs.split_edge(sel[0], sel[1])
+
+
+static func clip_to_convex(root: Node) -> void:
+	var vs = root.vertex_system
+	if not vs:
+		return
+	var clipped := false
+	for brush_id in vs.selected_vertices:
+		if vs.clip_to_convex(brush_id):
+			clipped = true
+	if clipped:
+		root.emit_signal("user_message", "Clipped to convex hull", 0)
+	else:
+		root.emit_signal("user_message", "Brush is already convex", 0)
+
+
+# ---------------------------------------------------------------------------
+# Undo
+# ---------------------------------------------------------------------------
+
+
+## Wire an undo action for a vertex edit that has already been applied.
+##
+## HFUndoHelper.commit() cannot be used for any of these: it captures undo state
+## at commit time, which is after the edit, so undo would replay the edit instead
+## of reverting it. The caller hands us the state it snapshotted beforehand.
+static func commit_op(
+	plugin: Object, root: Node, pre_op_snapshots: Dictionary, action_name: String
+) -> void:
+	if not plugin.undo_redo_manager:
+		return
+	var post_state := capture_face_state(root, pre_op_snapshots.keys())
+	plugin.undo_redo_manager.create_action(action_name, 0, null, false)
+	plugin.undo_redo_manager.add_do_method(root, "_apply_vertex_faces", post_state)
+	plugin.undo_redo_manager.add_undo_method(root, "_apply_vertex_faces", pre_op_snapshots)
+	plugin.undo_redo_manager.commit_action()
+	plugin._record_history(action_name)
+
+
+static func commit_move(plugin: Object, root: Node, pre_drag_snapshots: Dictionary) -> void:
+	commit_op(plugin, root, pre_drag_snapshots, "Move Vertices")
+
+
+## Serialized face state for the given brush ids, read straight off the tree.
+static func capture_face_state(root: Node, brush_ids: Array) -> Dictionary:
+	var state: Dictionary = {}
+	for brush_id in brush_ids:
+		var brush = root.brush_system.find_brush_by_id(brush_id) if root.brush_system else null
+		if brush and brush.get("faces"):
+			var current: Array = []
+			for face in brush.faces:
+				if face:
+					current.append(face.to_dict())
+			state[brush_id] = current
+	return state

--- a/tests/test_plugin_vertex_ops.gd
+++ b/tests/test_plugin_vertex_ops.gd
@@ -1,0 +1,349 @@
+extends GutTest
+## Boundary coverage for extracted vertex edit mode and vertex undo wiring.
+
+const HFPluginVertexOps = preload("res://addons/hammerforge/plugin_vertex_ops.gd")
+const DraftBrushScript = preload("res://addons/hammerforge/brush_instance.gd")
+
+
+class FakeInputState:
+	extends RefCounted
+
+	var begun := 0
+	var ended := 0
+
+	func begin_vertex_edit() -> void:
+		begun += 1
+
+	func end_vertex_edit() -> void:
+		ended += 1
+
+
+class FakeVertexSystem:
+	extends RefCounted
+
+	var selected_vertices: Dictionary = {}
+	var single_edge: Array = []
+	var convex_results: Dictionary = {}
+	var merges: Array = []
+	var splits: Array = []
+	var clips: Array = []
+	var clear_calls := 0
+	var cancel_calls := 0
+	var last_selection: Array = []
+
+	func clear_selection() -> void:
+		clear_calls += 1
+
+	func cancel_drag() -> void:
+		cancel_calls += 1
+
+	func set_selection(nodes: Array) -> void:
+		last_selection = nodes.duplicate()
+
+	func merge_vertices(brush_id, indices: PackedInt32Array) -> void:
+		merges.append({"brush_id": brush_id, "indices": indices})
+
+	func get_single_selected_edge() -> Array:
+		return single_edge
+
+	func split_edge(brush_id, edge) -> void:
+		splits.append({"brush_id": brush_id, "edge": edge})
+
+	func clip_to_convex(brush_id) -> bool:
+		clips.append(brush_id)
+		return bool(convex_results.get(brush_id, false))
+
+
+class FakeBrushSystem:
+	extends RefCounted
+
+	var brushes: Dictionary = {}
+
+	func find_brush_by_id(brush_id):
+		return brushes.get(brush_id, null)
+
+
+class FakeRoot:
+	extends Node3D
+
+	signal user_message(text: String, level: int)
+
+	var vertex_system := FakeVertexSystem.new()
+	var brush_system := FakeBrushSystem.new()
+	var input_state := FakeInputState.new()
+	var messages: Array = []
+
+	func _init() -> void:
+		user_message.connect(_record_message)
+
+	func _record_message(text: String, level: int) -> void:
+		messages.append({"text": text, "level": level})
+
+
+class FakePaintMode:
+	extends RefCounted
+
+	var button_pressed := false
+
+
+class FakeDock:
+	extends RefCounted
+
+	var paint_mode := FakePaintMode.new()
+	var highlighted: Array = []
+	var vertex_mode_states: Array = []
+
+	func highlight_tab(name: String) -> void:
+		highlighted.append(name)
+
+	func set_vertex_mode(enabled: bool) -> void:
+		vertex_mode_states.append(enabled)
+
+
+class FakeUndoRedo:
+	extends RefCounted
+
+	var actions: Array = []
+	var do_calls: Array = []
+	var undo_calls: Array = []
+	var commits := 0
+
+	func create_action(name: String, _mode: int = 0, _obj = null, _backward: bool = false) -> void:
+		actions.append(name)
+
+	func add_do_method(_target, method: String, arg) -> void:
+		do_calls.append({"method": method, "arg": arg})
+
+	func add_undo_method(_target, method: String, arg) -> void:
+		undo_calls.append({"method": method, "arg": arg})
+
+	func commit_action(_execute: bool = true) -> void:
+		commits += 1
+
+
+class FakePlugin:
+	extends RefCounted
+
+	var dock := FakeDock.new()
+	var hf_selection: Array = []
+	var undo_redo_manager = null
+	var _vertex_mode := false
+	var _vertex_drag_active := false
+	var face_select_closes: Array = []
+	var tool_transitions := 0
+	var external_deactivations := 0
+	var overlay_clears := 0
+	var hud_updates := 0
+	var history: Array = []
+
+	func _close_face_select_mode(message: String = "") -> bool:
+		face_select_closes.append(message)
+		return true
+
+	func _prepare_tool_transition(_root: Node, _notify: bool = true, _settle: bool = true) -> void:
+		tool_transitions += 1
+
+	func _deactivate_external_tool() -> void:
+		external_deactivations += 1
+
+	func _clear_vertex_overlay() -> void:
+		overlay_clears += 1
+
+	func _update_hud_context() -> void:
+		hud_updates += 1
+
+	func _record_history(action_name: String) -> void:
+		history.append(action_name)
+
+
+var plugin: FakePlugin
+var root: FakeRoot
+
+
+func before_each():
+	plugin = FakePlugin.new()
+	root = FakeRoot.new()
+	add_child_autoqfree(root)
+
+
+func after_each():
+	plugin = null
+	root = null
+
+
+func _make_brush(brush_id: String) -> DraftBrush:
+	var brush = DraftBrushScript.new()
+	brush.brush_id = brush_id
+	root.add_child(brush)
+	root.brush_system.brushes[brush_id] = brush
+	return brush
+
+
+# ---------------------------------------------------------------------------
+# Mode lifecycle
+# ---------------------------------------------------------------------------
+
+
+func test_enabling_closes_competing_pointer_owners_first():
+	var brush = _make_brush("b1")
+	plugin.hf_selection = [brush]
+
+	HFPluginVertexOps.toggle_mode(plugin, root)
+
+	assert_true(plugin._vertex_mode, "Vertex mode should be on")
+	assert_eq(plugin.face_select_closes.size(), 1, "Face Select must be closed on the way in")
+	assert_eq(plugin.tool_transitions, 1, "In-progress gestures must be settled")
+	assert_eq(plugin.external_deactivations, 1, "External tools must give up the pointer")
+	assert_eq(root.input_state.begun, 1)
+	assert_eq(root.vertex_system.last_selection, [brush], "The brush selection is handed over")
+	assert_eq(plugin.dock.vertex_mode_states, [true])
+
+
+func test_enabling_only_passes_brushes_from_the_selection():
+	var brush = _make_brush("b1")
+	var plain := Node3D.new()
+	root.add_child(plain)
+	plugin.hf_selection = [brush, plain]
+
+	HFPluginVertexOps.toggle_mode(plugin, root)
+
+	assert_eq(root.vertex_system.last_selection, [brush], "Non-brush nodes are not vertex editable")
+
+
+func test_disabling_cancels_an_active_drag_and_clears_the_overlay():
+	plugin._vertex_mode = true
+	plugin._vertex_drag_active = true
+
+	HFPluginVertexOps.toggle_mode(plugin, root)
+
+	assert_false(plugin._vertex_mode)
+	assert_eq(root.vertex_system.cancel_calls, 1, "A live drag must be cancelled, not left running")
+	assert_false(plugin._vertex_drag_active)
+	assert_eq(root.input_state.ended, 1)
+	assert_eq(plugin.overlay_clears, 1)
+	assert_eq(plugin.dock.vertex_mode_states, [false])
+
+
+func test_disabling_does_not_reclose_face_select():
+	plugin._vertex_mode = true
+
+	HFPluginVertexOps.toggle_mode(plugin, root)
+
+	assert_eq(plugin.face_select_closes.size(), 0, "Leaving the mode should not touch Face Select")
+
+
+func test_enabling_over_paint_mode_pulls_the_brush_tab_forward():
+	plugin.dock.paint_mode.button_pressed = true
+
+	HFPluginVertexOps.toggle_mode(plugin, root)
+
+	assert_eq(plugin.dock.highlighted, ["Brush"])
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+func test_merge_needs_at_least_two_vertices():
+	root.vertex_system.selected_vertices = {
+		"b1": PackedInt32Array([0]),
+		"b2": PackedInt32Array([0, 3]),
+	}
+
+	HFPluginVertexOps.merge_selected(root)
+
+	assert_eq(root.vertex_system.merges.size(), 1, "A lone vertex has nothing to merge with")
+	assert_eq(root.vertex_system.merges[0]["brush_id"], "b2")
+
+
+func test_split_needs_a_single_selected_edge():
+	root.vertex_system.single_edge = []
+	HFPluginVertexOps.split_selected_edge(root)
+	assert_eq(root.vertex_system.splits.size(), 0)
+
+	root.vertex_system.single_edge = ["b1", PackedInt32Array([0, 1])]
+	HFPluginVertexOps.split_selected_edge(root)
+	assert_eq(root.vertex_system.splits.size(), 1)
+	assert_eq(root.vertex_system.splits[0]["brush_id"], "b1")
+
+
+func test_clip_to_convex_reports_when_nothing_changed():
+	root.vertex_system.selected_vertices = {"b1": PackedInt32Array([0])}
+	root.vertex_system.convex_results = {"b1": false}
+
+	HFPluginVertexOps.clip_to_convex(root)
+
+	assert_eq(root.messages.size(), 1)
+	assert_eq(root.messages[0]["text"], "Brush is already convex")
+
+
+func test_clip_to_convex_reports_when_any_brush_changed():
+	root.vertex_system.selected_vertices = {
+		"b1": PackedInt32Array([0]),
+		"b2": PackedInt32Array([0]),
+	}
+	root.vertex_system.convex_results = {"b1": false, "b2": true}
+
+	HFPluginVertexOps.clip_to_convex(root)
+
+	assert_eq(root.vertex_system.clips.size(), 2, "Every selected brush is visited")
+	assert_eq(root.messages[0]["text"], "Clipped to convex hull")
+
+
+# ---------------------------------------------------------------------------
+# Undo
+# ---------------------------------------------------------------------------
+
+
+func test_commit_is_a_no_op_without_an_undo_manager():
+	HFPluginVertexOps.commit_op(plugin, root, {"b1": []}, "Merge Vertices")
+	assert_eq(plugin.history.size(), 0)
+
+
+func test_commit_undoes_to_the_pre_op_snapshot_not_the_current_state():
+	# The whole point of the manual wiring: undo must restore what the caller
+	# captured before the edit, not what is on the brush now.
+	var brush = _make_brush("b1")
+	brush.faces = _one_face()
+	var undo_redo := FakeUndoRedo.new()
+	plugin.undo_redo_manager = undo_redo
+	var pre_snapshot := {"b1": [{"marker": "before"}]}
+
+	HFPluginVertexOps.commit_op(plugin, root, pre_snapshot, "Split Edge")
+
+	assert_eq(undo_redo.actions, ["Split Edge"])
+	assert_eq(undo_redo.commits, 1)
+	assert_eq(undo_redo.undo_calls[0]["arg"], pre_snapshot, "Undo restores the pre-op snapshot")
+	assert_eq(undo_redo.do_calls[0]["method"], "_apply_vertex_faces")
+	var do_state: Dictionary = undo_redo.do_calls[0]["arg"]
+	assert_true(do_state.has("b1"), "Redo state is read off the brush as it stands now")
+	assert_ne(do_state, pre_snapshot)
+	assert_eq(plugin.history, ["Split Edge"])
+
+
+func test_commit_move_uses_the_move_vertices_action_name():
+	var undo_redo := FakeUndoRedo.new()
+	plugin.undo_redo_manager = undo_redo
+
+	HFPluginVertexOps.commit_move(plugin, root, {})
+
+	assert_eq(undo_redo.actions, ["Move Vertices"])
+	assert_eq(plugin.history, ["Move Vertices"])
+
+
+func test_capture_face_state_skips_brushes_that_are_gone():
+	var brush = _make_brush("b1")
+	brush.faces = _one_face()
+
+	var state := HFPluginVertexOps.capture_face_state(root, ["b1", "missing"])
+
+	assert_true(state.has("b1"))
+	assert_false(state.has("missing"), "A deleted brush must not land in the undo state")
+
+
+func _one_face() -> Array[FaceData]:
+	var face := FaceData.new()
+	face.normal = Vector3.UP
+	var typed: Array[FaceData] = [face]
+	return typed


### PR DESCRIPTION
Part of #41.

Vertex editing was split across three places with the largest part still in plugin.gd. Pointer handling was already in `plugin_vertex_input.gd` and the ImmediateMesh overlay in `plugin_overlays.gd`, but entering and leaving the mode, the merge/split/clip commands, and the undo wiring had no owner. They do now.

`_toggle_vertex_mode` was also called from five places in the tool-transition code, so moving it takes weight out of that path without moving the coordination itself.

One thing collapsed on the way. `_commit_vertex_op` and `_commit_vertex_move` were the same function apart from the action name, right down to the loop that reads face state back off the tree, so `commit_move` is now a one-line call into `commit_op`. The comment explaining why the undo is wired by hand instead of through `HFUndoHelper` was only on the move path; it applies to both, so it sits on the shared function now.

plugin.gd keeps thin delegates. `plugin_commands.gd` calls the three commands by name, `plugin_vertex_input.gd` calls both commit paths, and `test_plugin_vertex_input.gd` inspects plugin.gd source between `_handle_vertex_input` and `_commit_vertex_op`, so that ordering is preserved. No behaviour changed.

plugin.gd goes from 2,310 to 2,226 lines.

Tests: new `tests/test_plugin_vertex_ops.gd`, 13 cases. They cover that enabling closes Face Select and settles in-flight gestures before taking the pointer, that only brushes are handed to the vertex system, that leaving cancels a live drag rather than abandoning it, that merge needs two vertices and split needs exactly one edge, that clip reports "already convex" only when no brush changed, and that undo restores the caller's pre-op snapshot rather than the current state, which is the whole reason the wiring is manual.
