### PR TITLE
Move prefab selection commands into plugin_prefab_commands.gd

### DIFF
--- a/addons/hammerforge/plugin.gd
+++ b/addons/hammerforge/plugin.gd
@@ -14,6 +14,7 @@ const HFPluginViewportInput = preload("plugin_viewport_input.gd")
 const HFPluginOverlays = preload("plugin_overlays.gd")
 const HFPluginPaintInput = preload("plugin_paint_input.gd")
 const HFPluginPointerTools = preload("plugin_pointer_tools.gd")
+const HFPluginPrefabCommands = preload("plugin_prefab_commands.gd")
 const HFPluginSelectionInput = preload("plugin_selection_input.gd")
 const HFPluginSelectionCommands = preload("plugin_selection_commands.gd")
 const HFPluginSelectionState = preload("plugin_selection_state.gd")
@@ -1708,104 +1709,19 @@ func _handle_prefab_drop(position: Vector2, data: Variant) -> void:
 
 
 func _quick_save_prefab(root, linked: bool) -> void:
-	var brush_nodes: Array = []
-	var entity_nodes: Array = []
-	for node in hf_selection:
-		if root.is_brush_node(node):
-			brush_nodes.append(node)
-		elif root.is_entity_node(node):
-			entity_nodes.append(node)
-	if brush_nodes.is_empty() and entity_nodes.is_empty():
-		return
-	var suggested: String = root.prefab_system.suggest_prefab_name(brush_nodes, entity_nodes)
-	var path: String = root.prefab_system.quick_save_prefab(
-		brush_nodes, entity_nodes, suggested, linked
-	)
-	if path != "":
-		if dock and dock._prefab_library:
-			dock._prefab_library.on_prefab_saved()
-		if dock:
-			dock.show_toast("Saved prefab: %s%s" % [suggested, " (linked)" if linked else ""], 0)
+	HFPluginPrefabCommands.quick_save(self, root, linked)
 
 
 func _cycle_prefab_variant(root) -> void:
-	if hf_selection.is_empty():
-		return
-	var node = hf_selection[0]
-	if not is_instance_valid(node) or not (node is Node):
-		return
-	var iid: String = str(node.get_meta("hf_prefab_instance", ""))
-	if iid == "":
-		if dock:
-			dock.show_toast("Not a prefab instance", 1)
-		return
-	var full_state: Dictionary = root.state_system.capture_state(true)
-	var new_variant: String = root.prefab_system.cycle_variant(iid)
-	if new_variant != "":
-		if dock:
-			dock.show_toast("Variant: %s" % new_variant, 0)
-		var undo_redo = undo_redo_manager
-		if undo_redo:
-			undo_redo.create_action("Cycle Prefab Variant")
-			undo_redo.add_do_method(
-				root.state_system, "restore_state", root.state_system.capture_state(true)
-			)
-			undo_redo.add_undo_method(root.state_system, "restore_state", full_state)
-			undo_redo.commit_action(false)
-		_update_hud_context()
+	HFPluginPrefabCommands.cycle_variant(self, root)
 
 
 func _push_prefab_to_source(root) -> void:
-	if hf_selection.is_empty():
-		return
-	var node = hf_selection[0]
-	if not is_instance_valid(node) or not (node is Node):
-		return
-	var iid: String = str(node.get_meta("hf_prefab_instance", ""))
-	if iid == "":
-		if dock:
-			dock.show_toast("Not a prefab instance", 1)
-		return
-	var ok: bool = root.prefab_system.push_instance_to_source(iid)
-	if ok:
-		if dock:
-			dock.show_toast("Pushed changes to prefab source", 0)
-		if dock and dock._prefab_library:
-			dock._prefab_library.on_prefab_saved()
-	else:
-		if dock:
-			dock.show_toast("Failed to push to source", 1)
+	HFPluginPrefabCommands.push_to_source(self, root)
 
 
 func _propagate_prefab(root) -> void:
-	if hf_selection.is_empty():
-		return
-	var node = hf_selection[0]
-	if not is_instance_valid(node) or not (node is Node):
-		return
-	var source: String = str(node.get_meta("hf_prefab_source", ""))
-	if source == "":
-		if dock:
-			dock.show_toast("Not a prefab instance", 1)
-		return
-	var full_state: Dictionary = root.state_system.capture_state(true)
-	var count: int = root.prefab_system.propagate_from_source(source)
-	if count > 0:
-		if dock:
-			dock.show_toast(
-				"Propagated to %d linked instance%s" % [count, "" if count == 1 else "s"], 0
-			)
-		var undo_redo = undo_redo_manager
-		if undo_redo:
-			undo_redo.create_action("Propagate Prefab")
-			undo_redo.add_do_method(
-				root.state_system, "restore_state", root.state_system.capture_state(true)
-			)
-			undo_redo.add_undo_method(root.state_system, "restore_state", full_state)
-			undo_redo.commit_action(false)
-	else:
-		if dock:
-			dock.show_toast("No linked instances to propagate", 1)
+	HFPluginPrefabCommands.propagate(self, root)
 
 
 func _is_material_drag_data(data: Variant) -> bool:

--- a/addons/hammerforge/plugin_prefab_commands.gd
+++ b/addons/hammerforge/plugin_prefab_commands.gd
@@ -1,0 +1,128 @@
+@tool
+class_name HFPluginPrefabCommands
+extends RefCounted
+## Prefab commands driven from the selection: quick save, cycle variant, push to
+## source, and propagate to linked instances.
+##
+## The prefab data itself lives in HFPrefabSystem. This module is the editor side:
+## what the current selection means, what the user is told, and how a change that
+## rewrites the level reaches undo.
+
+## Meta key marking a node as an instance of a prefab.
+const INSTANCE_META := "hf_prefab_instance"
+## Meta key naming the prefab a linked instance came from.
+const SOURCE_META := "hf_prefab_source"
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+static func quick_save(plugin: Object, root: Node, linked: bool) -> void:
+	var brush_nodes: Array = []
+	var entity_nodes: Array = []
+	for node in plugin.hf_selection:
+		if root.is_brush_node(node):
+			brush_nodes.append(node)
+		elif root.is_entity_node(node):
+			entity_nodes.append(node)
+	if brush_nodes.is_empty() and entity_nodes.is_empty():
+		return
+	var suggested: String = root.prefab_system.suggest_prefab_name(brush_nodes, entity_nodes)
+	var path: String = root.prefab_system.quick_save_prefab(
+		brush_nodes, entity_nodes, suggested, linked
+	)
+	if path == "":
+		return
+	_refresh_prefab_library(plugin)
+	if plugin.dock:
+		plugin.dock.show_toast("Saved prefab: %s%s" % [suggested, " (linked)" if linked else ""], 0)
+
+
+static func cycle_variant(plugin: Object, root: Node) -> void:
+	var iid := selected_meta(plugin, INSTANCE_META)
+	if iid == "":
+		return
+	var before_state: Dictionary = root.state_system.capture_state(true)
+	var new_variant: String = root.prefab_system.cycle_variant(iid)
+	if new_variant == "":
+		return
+	if plugin.dock:
+		plugin.dock.show_toast("Variant: %s" % new_variant, 0)
+	_commit_state_change(plugin, root, "Cycle Prefab Variant", before_state)
+	plugin._update_hud_context()
+
+
+static func push_to_source(plugin: Object, root: Node) -> void:
+	var iid := selected_meta(plugin, INSTANCE_META)
+	if iid == "":
+		return
+	var ok: bool = root.prefab_system.push_instance_to_source(iid)
+	if not ok:
+		if plugin.dock:
+			plugin.dock.show_toast("Failed to push to source", 1)
+		return
+	if plugin.dock:
+		plugin.dock.show_toast("Pushed changes to prefab source", 0)
+	_refresh_prefab_library(plugin)
+
+
+static func propagate(plugin: Object, root: Node) -> void:
+	var source := selected_meta(plugin, SOURCE_META)
+	if source == "":
+		return
+	var before_state: Dictionary = root.state_system.capture_state(true)
+	var count: int = root.prefab_system.propagate_from_source(source)
+	if count <= 0:
+		if plugin.dock:
+			plugin.dock.show_toast("No linked instances to propagate", 1)
+		return
+	if plugin.dock:
+		plugin.dock.show_toast(
+			"Propagated to %d linked instance%s" % [count, "" if count == 1 else "s"], 0
+		)
+	_commit_state_change(plugin, root, "Propagate Prefab", before_state)
+
+
+# ---------------------------------------------------------------------------
+# Shared pieces
+# ---------------------------------------------------------------------------
+
+
+## Read a prefab meta value off the first selected node.
+##
+## Returns "" when there is nothing usable, warning the user only when they did
+## select a node and it simply is not a prefab instance. An empty or stale
+## selection is not worth a toast.
+static func selected_meta(plugin: Object, meta_key: String) -> String:
+	if plugin.hf_selection.is_empty():
+		return ""
+	var node = plugin.hf_selection[0]
+	if not is_instance_valid(node) or not (node is Node):
+		return ""
+	var value: String = str(node.get_meta(meta_key, ""))
+	if value == "":
+		if plugin.dock:
+			plugin.dock.show_toast("Not a prefab instance", 1)
+	return value
+
+
+## Prefab pushes rewrite brushes and entities across the level, so undo has to
+## restore the whole captured state rather than a per-node diff.
+static func _commit_state_change(
+	plugin: Object, root: Node, action_name: String, before_state: Dictionary
+) -> void:
+	var undo_redo = plugin.undo_redo_manager
+	if not undo_redo:
+		return
+	undo_redo.create_action(action_name)
+	undo_redo.add_do_method(
+		root.state_system, "restore_state", root.state_system.capture_state(true)
+	)
+	undo_redo.add_undo_method(root.state_system, "restore_state", before_state)
+	undo_redo.commit_action(false)
+
+
+static func _refresh_prefab_library(plugin: Object) -> void:
+	if plugin.dock and plugin.dock._prefab_library:
+		plugin.dock._prefab_library.on_prefab_saved()

--- a/tests/test_plugin_prefab_commands.gd
+++ b/tests/test_plugin_prefab_commands.gd
@@ -1,0 +1,351 @@
+extends GutTest
+## Boundary coverage for the extracted prefab selection commands.
+
+const HFPluginPrefabCommands = preload("res://addons/hammerforge/plugin_prefab_commands.gd")
+
+
+class FakeStateSystem:
+	extends RefCounted
+
+	var captures := 0
+	var restored: Array = []
+
+	func capture_state(_full: bool = false) -> Dictionary:
+		captures += 1
+		return {"seq": captures}
+
+	func restore_state(state: Dictionary) -> void:
+		restored.append(state)
+
+
+class FakePrefabSystem:
+	extends RefCounted
+
+	var suggested_name := "Crate"
+	var save_path := "res://prefabs/crate.tres"
+	var next_variant := ""
+	var push_ok := true
+	var propagate_count := 0
+	var saved_calls: Array = []
+	var pushed: Array = []
+	var propagated: Array = []
+	var cycled: Array = []
+
+	func suggest_prefab_name(_brushes: Array, _entities: Array) -> String:
+		return suggested_name
+
+	func quick_save_prefab(brushes: Array, entities: Array, name: String, linked: bool) -> String:
+		saved_calls.append(
+			{"brushes": brushes.size(), "entities": entities.size(), "name": name, "linked": linked}
+		)
+		return save_path
+
+	func cycle_variant(iid: String) -> String:
+		cycled.append(iid)
+		return next_variant
+
+	func push_instance_to_source(iid: String) -> bool:
+		pushed.append(iid)
+		return push_ok
+
+	func propagate_from_source(source: String) -> int:
+		propagated.append(source)
+		return propagate_count
+
+
+class FakeRoot:
+	extends Node3D
+
+	var prefab_system := FakePrefabSystem.new()
+	var state_system := FakeStateSystem.new()
+	var brush_nodes: Array = []
+	var entity_nodes: Array = []
+
+	func is_brush_node(node) -> bool:
+		return brush_nodes.has(node)
+
+	func is_entity_node(node) -> bool:
+		return entity_nodes.has(node)
+
+
+class FakePrefabLibrary:
+	extends RefCounted
+
+	var refreshes := 0
+
+	func on_prefab_saved() -> void:
+		refreshes += 1
+
+
+class FakeDock:
+	extends RefCounted
+
+	var toasts: Array = []
+	var _prefab_library := FakePrefabLibrary.new()
+
+	func show_toast(message: String, level: int = 0) -> void:
+		toasts.append({"message": message, "level": level})
+
+	func last_toast() -> Dictionary:
+		return toasts[-1] if not toasts.is_empty() else {}
+
+
+class FakeUndoRedo:
+	extends RefCounted
+
+	var actions: Array = []
+	var do_args: Array = []
+	var undo_args: Array = []
+	var commits := 0
+
+	func create_action(name: String, _mode: int = 0, _obj = null, _backward: bool = false) -> void:
+		actions.append(name)
+
+	func add_do_method(_target, _method: String, arg) -> void:
+		do_args.append(arg)
+
+	func add_undo_method(_target, _method: String, arg) -> void:
+		undo_args.append(arg)
+
+	func commit_action(_execute: bool = true) -> void:
+		commits += 1
+
+
+class FakePlugin:
+	extends RefCounted
+
+	var dock := FakeDock.new()
+	var hf_selection: Array = []
+	var undo_redo_manager = null
+	var hud_updates := 0
+
+	func _update_hud_context() -> void:
+		hud_updates += 1
+
+
+var plugin: FakePlugin
+var root: FakeRoot
+
+
+func before_each():
+	plugin = FakePlugin.new()
+	root = FakeRoot.new()
+	add_child_autoqfree(root)
+
+
+func after_each():
+	plugin = null
+	root = null
+
+
+func _make_node(metas: Dictionary = {}) -> Node3D:
+	var node := Node3D.new()
+	for key in metas:
+		node.set_meta(str(key), metas[key])
+	root.add_child(node)
+	return node
+
+
+func _instance_node() -> Node3D:
+	return _make_node({"hf_prefab_instance": "iid_1", "hf_prefab_source": "res://p/crate.tres"})
+
+
+# ---------------------------------------------------------------------------
+# Reading the selection
+# ---------------------------------------------------------------------------
+
+
+func test_empty_selection_is_silent():
+	var value := HFPluginPrefabCommands.selected_meta(plugin, "hf_prefab_instance")
+	assert_eq(value, "")
+	assert_eq(plugin.dock.toasts.size(), 0, "Nothing selected is not worth warning about")
+
+
+func test_freed_selection_entry_is_silent():
+	var node := Node3D.new()
+	plugin.hf_selection = [node]
+	node.free()
+
+	var value := HFPluginPrefabCommands.selected_meta(plugin, "hf_prefab_instance")
+
+	assert_eq(value, "")
+	assert_eq(plugin.dock.toasts.size(), 0, "A stale selection entry should not warn")
+
+
+func test_non_prefab_node_warns():
+	plugin.hf_selection = [_make_node()]
+
+	var value := HFPluginPrefabCommands.selected_meta(plugin, "hf_prefab_instance")
+
+	assert_eq(value, "")
+	assert_eq(plugin.dock.last_toast().get("message"), "Not a prefab instance")
+	assert_eq(plugin.dock.last_toast().get("level"), 1)
+
+
+func test_prefab_instance_returns_its_id_without_warning():
+	plugin.hf_selection = [_instance_node()]
+
+	assert_eq(HFPluginPrefabCommands.selected_meta(plugin, "hf_prefab_instance"), "iid_1")
+	assert_eq(plugin.dock.toasts.size(), 0)
+
+
+# ---------------------------------------------------------------------------
+# Quick save
+# ---------------------------------------------------------------------------
+
+
+func test_quick_save_ignores_a_selection_with_nothing_savable():
+	plugin.hf_selection = [_make_node()]
+
+	HFPluginPrefabCommands.quick_save(plugin, root, false)
+
+	assert_eq(root.prefab_system.saved_calls.size(), 0)
+	assert_eq(plugin.dock.toasts.size(), 0)
+
+
+func test_quick_save_splits_brushes_from_entities():
+	var brush := _make_node()
+	var entity := _make_node()
+	root.brush_nodes = [brush]
+	root.entity_nodes = [entity]
+	plugin.hf_selection = [brush, entity]
+
+	HFPluginPrefabCommands.quick_save(plugin, root, false)
+
+	assert_eq(root.prefab_system.saved_calls.size(), 1)
+	assert_eq(root.prefab_system.saved_calls[0]["brushes"], 1)
+	assert_eq(root.prefab_system.saved_calls[0]["entities"], 1)
+	assert_eq(plugin.dock._prefab_library.refreshes, 1)
+	assert_eq(plugin.dock.last_toast().get("message"), "Saved prefab: Crate")
+
+
+func test_quick_save_marks_a_linked_prefab_in_the_toast():
+	var brush := _make_node()
+	root.brush_nodes = [brush]
+	plugin.hf_selection = [brush]
+
+	HFPluginPrefabCommands.quick_save(plugin, root, true)
+
+	assert_true(root.prefab_system.saved_calls[0]["linked"])
+	assert_eq(plugin.dock.last_toast().get("message"), "Saved prefab: Crate (linked)")
+
+
+func test_quick_save_that_writes_nothing_does_not_claim_success():
+	var brush := _make_node()
+	root.brush_nodes = [brush]
+	plugin.hf_selection = [brush]
+	root.prefab_system.save_path = ""
+
+	HFPluginPrefabCommands.quick_save(plugin, root, false)
+
+	assert_eq(plugin.dock.toasts.size(), 0)
+	assert_eq(plugin.dock._prefab_library.refreshes, 0)
+
+
+# ---------------------------------------------------------------------------
+# Cycle variant
+# ---------------------------------------------------------------------------
+
+
+func test_cycle_variant_undoes_to_the_state_captured_before_the_cycle():
+	plugin.hf_selection = [_instance_node()]
+	plugin.undo_redo_manager = FakeUndoRedo.new()
+	root.prefab_system.next_variant = "Damaged"
+
+	HFPluginPrefabCommands.cycle_variant(plugin, root)
+
+	var undo_redo: FakeUndoRedo = plugin.undo_redo_manager
+	assert_eq(undo_redo.actions, ["Cycle Prefab Variant"])
+	assert_eq(undo_redo.undo_args[0], {"seq": 1}, "Undo restores the pre-cycle capture")
+	assert_eq(undo_redo.do_args[0], {"seq": 2}, "Redo restores the state after cycling")
+	assert_eq(undo_redo.commits, 1)
+	assert_eq(plugin.hud_updates, 1)
+
+
+func test_cycle_variant_with_no_other_variant_records_nothing():
+	plugin.hf_selection = [_instance_node()]
+	plugin.undo_redo_manager = FakeUndoRedo.new()
+	root.prefab_system.next_variant = ""
+
+	HFPluginPrefabCommands.cycle_variant(plugin, root)
+
+	var undo_redo: FakeUndoRedo = plugin.undo_redo_manager
+	assert_eq(undo_redo.actions.size(), 0, "Nothing changed, so nothing goes on the undo stack")
+	assert_eq(plugin.dock.toasts.size(), 0)
+
+
+func test_cycle_variant_still_applies_without_an_undo_manager():
+	plugin.hf_selection = [_instance_node()]
+	root.prefab_system.next_variant = "Damaged"
+
+	HFPluginPrefabCommands.cycle_variant(plugin, root)
+
+	assert_eq(root.prefab_system.cycled, ["iid_1"])
+	assert_eq(plugin.dock.last_toast().get("message"), "Variant: Damaged")
+
+
+# ---------------------------------------------------------------------------
+# Push to source
+# ---------------------------------------------------------------------------
+
+
+func test_push_to_source_refreshes_the_library_on_success():
+	plugin.hf_selection = [_instance_node()]
+
+	HFPluginPrefabCommands.push_to_source(plugin, root)
+
+	assert_eq(root.prefab_system.pushed, ["iid_1"])
+	assert_eq(plugin.dock.last_toast().get("message"), "Pushed changes to prefab source")
+	assert_eq(plugin.dock._prefab_library.refreshes, 1)
+
+
+func test_failed_push_warns_and_leaves_the_library_alone():
+	plugin.hf_selection = [_instance_node()]
+	root.prefab_system.push_ok = false
+
+	HFPluginPrefabCommands.push_to_source(plugin, root)
+
+	assert_eq(plugin.dock.last_toast().get("message"), "Failed to push to source")
+	assert_eq(plugin.dock.last_toast().get("level"), 1)
+	assert_eq(plugin.dock._prefab_library.refreshes, 0, "A failed push has nothing to show")
+
+
+# ---------------------------------------------------------------------------
+# Propagate
+# ---------------------------------------------------------------------------
+
+
+func test_propagate_undoes_to_the_state_captured_before_propagating():
+	plugin.hf_selection = [_instance_node()]
+	plugin.undo_redo_manager = FakeUndoRedo.new()
+	root.prefab_system.propagate_count = 3
+
+	HFPluginPrefabCommands.propagate(plugin, root)
+
+	var undo_redo: FakeUndoRedo = plugin.undo_redo_manager
+	assert_eq(undo_redo.actions, ["Propagate Prefab"])
+	assert_eq(undo_redo.undo_args[0], {"seq": 1}, "Undo restores the pre-propagate capture")
+	assert_eq(plugin.dock.last_toast().get("message"), "Propagated to 3 linked instances")
+
+
+func test_propagate_reads_the_source_meta_not_the_instance_id():
+	plugin.hf_selection = [_instance_node()]
+	root.prefab_system.propagate_count = 1
+
+	HFPluginPrefabCommands.propagate(plugin, root)
+
+	assert_eq(root.prefab_system.propagated, ["res://p/crate.tres"])
+	assert_eq(plugin.dock.last_toast().get("message"), "Propagated to 1 linked instance")
+
+
+func test_propagate_with_no_linked_instances_records_nothing():
+	plugin.hf_selection = [_instance_node()]
+	plugin.undo_redo_manager = FakeUndoRedo.new()
+	root.prefab_system.propagate_count = 0
+
+	HFPluginPrefabCommands.propagate(plugin, root)
+
+	var undo_redo: FakeUndoRedo = plugin.undo_redo_manager
+	assert_eq(undo_redo.actions.size(), 0)
+	assert_eq(plugin.dock.last_toast().get("message"), "No linked instances to propagate")
+	assert_eq(plugin.dock.last_toast().get("level"), 1)


### PR DESCRIPTION
Part of #41.

Quick save, cycle variant, push to source, and propagate were four copies of the same shape in plugin.gd: read a prefab meta off the first selected node, warn if it is not an instance, call into `HFPrefabSystem`, toast the result, then capture-and-restore the whole level state for undo. The prefab data has always lived in `HFPrefabSystem`; what was in plugin.gd is the editor side, and that now has an owner.

Two things collapsed on the way.

The selection preamble is one function, `selected_meta`, differing only by which meta key it reads. Its behaviour is preserved exactly, including the part that is easy to lose: an empty or stale selection returns quietly, and only a real node that is not a prefab instance gets the "Not a prefab instance" warning.

The undo block is one function too. Both callers built the same create/do/undo/commit sequence, and the reason it restores whole captured state rather than a per-node diff is written on it now instead of being implied.

plugin.gd keeps thin delegates because `plugin_commands.gd` and `plugin_input_router.gd` call all four by name. No behaviour changed.

plugin.gd goes from 2,226 to 2,142 lines.

Tests: new `tests/test_plugin_prefab_commands.gd`, 16 cases. The two that matter most pin the undo ordering: cycle and propagate must both capture state *before* the prefab system runs, so undo restores the pre-change snapshot and redo restores the post-change one. The rest cover the silent-versus-warning selection paths, that a save returning no path does not claim success or refresh the library, that a failed push warns and leaves the library alone, and that propagate reads the source meta rather than the instance id.
