### PR TITLE
Give bake-preview state and undo events their own modules

### DIFF
--- a/addons/hammerforge/plugin.gd
+++ b/addons/hammerforge/plugin.gd
@@ -2,6 +2,7 @@
 extends EditorPlugin
 
 const DockType = preload("dock.gd")
+const HFPluginBakePreview = preload("plugin_bake_preview.gd")
 const HFPluginCommands = preload("plugin_commands.gd")
 const HFPluginDropHandler = preload("plugin_drop_handler.gd")
 const HFPluginEditActions = preload("plugin_edit_actions.gd")
@@ -18,6 +19,7 @@ const HFPluginPrefabCommands = preload("plugin_prefab_commands.gd")
 const HFPluginSelectionInput = preload("plugin_selection_input.gd")
 const HFPluginSelectionCommands = preload("plugin_selection_commands.gd")
 const HFPluginSelectionState = preload("plugin_selection_state.gd")
+const HFPluginUndoEvents = preload("plugin_undo_events.gd")
 const HFPathToolType = preload("hf_path_tool.gd")
 const HFSelectionGestureType = preload("hf_selection_gesture.gd")
 const HFBrushChangeTrackerType = preload("hf_brush_change_tracker.gd")
@@ -1772,66 +1774,11 @@ var _bake_preview_in_flight := false
 
 
 func _on_dock_bake_state_changed(baking: bool, success: bool) -> void:
-	if not baking:
-		if _bake_preview_in_flight:
-			_bake_preview_in_flight = false
-			if not success:
-				# The preview toggle speculatively set _bake_preview_active
-				# before dispatching. Bake failed so baked_container is
-				# unchanged — flip the flag back to match the actual scene.
-				_bake_preview_active = not _bake_preview_active
-			# On success the speculative value is correct — keep it.
-		elif success:
-			# A non-preview bake replaced baked_container.  Derive the toggle
-			# from the actual preview mode that was baked — the dock dropdown
-			# may have been set to Wireframe for a normal bake.
-			var root = active_root if active_root else _get_level_root()
-			if root:
-				_bake_preview_active = root._last_bake_preview_mode == 1
-			else:
-				_bake_preview_active = false
-		# Non-preview bake failed: baked_container untouched, keep current flag.
-	_update_hud_context()
+	HFPluginBakePreview.on_bake_state_changed(self, baking, success)
 
 
 func _toggle_bake_preview(root: Node, pressed: bool) -> void:
-	if not root or not root.bake_system:
-		return
-	# Guard against overlapping bakes.
-	if (
-		(dock and dock._bake_disabled)
-		or (root.has_method("is_bake_in_flight") and root.call("is_bake_in_flight"))
-	):
-		_update_hud_context()
-		return
-	if pressed:
-		_bake_preview_active = true
-		_bake_preview_in_flight = true
-		# Wireframe preview bake — route through undo so it's reversible
-		if dock:
-			dock._set_bake_buttons_disabled(true)
-		var succeeded: bool = await root.bake(false, false, 0, 1)
-		if dock:
-			dock._set_bake_buttons_disabled(false)
-		if _bake_preview_in_flight:
-			_bake_preview_in_flight = false
-			if not succeeded:
-				_bake_preview_active = false
-		_update_hud_context()
-	else:
-		_bake_preview_active = false
-		_bake_preview_in_flight = true
-		# Re-bake full quality to replace the wireframe preview
-		if dock:
-			dock._set_bake_buttons_disabled(true)
-		var succeeded: bool = await root.bake(false, false, 0, 0)
-		if dock:
-			dock._set_bake_buttons_disabled(false)
-		if _bake_preview_in_flight:
-			_bake_preview_in_flight = false
-			if not succeeded:
-				_bake_preview_active = true
-		_update_hud_context()
+	await HFPluginBakePreview.toggle(self, root, pressed)
 
 
 func _on_context_tool_switch(tool_id: int) -> void:
@@ -1978,76 +1925,11 @@ func _on_coach_mark_dismissed(_tool_key: String, _dont_show: bool) -> void:
 
 
 func _on_undo_redo_version_changed() -> void:
-	## Cancel any in-flight *transient* tool preview (drag, extrude) when the
-	## undo/redo version changes.  Without this, preview MeshInstance3D nodes
-	## created mid-operation become orphaned because the scene state they
-	## reference no longer matches.
-	##
-	## VERTEX_EDIT is a persistent mode — commit_action() fires
-	## version_changed after every merge/split/move, so resetting it here
-	## would desynchronize the plugin's _vertex_mode flag from input_state.
-	var root: LevelRoot = active_root if active_root else _get_level_root()
-	if not root or not is_instance_valid(root):
-		return
-	# Native Inspector/gizmo commits and their Undo/Redo are owned by Godot, so
-	# reconcile their final brush signature after the editor finishes the action.
-	_queue_managed_brush_reconcile()
-	if root.drag_system and root.drag_system.input_state:
-		var ist: HFInputStateType = root.drag_system.input_state
-		# Only reset transient preview modes that own temporary scene nodes.
-		# VERTEX_EDIT and IDLE are left alone — see HFInputState.is_transient_preview_mode().
-		if HFInputStateType.is_transient_preview_mode(ist.mode):
-			ist._force_reset()
-	# Subtract preview may reference stale brush data — rebuild
-	if root.subtract_preview and root.subtract_preview.is_enabled():
-		root.subtract_preview.request_update()
-	# Sync preview toggle with the restored scene state.  Skip if a preview
-	# bake is in flight — that version_changed came from our own commit, not
-	# from the user pressing Ctrl+Z.
-	if not _bake_preview_in_flight:
-		var restored_preview: bool = root._last_bake_preview_mode == 1  # WIREFRAME only
-		if _bake_preview_active != restored_preview:
-			_bake_preview_active = restored_preview
-			_update_hud_context()
+	HFPluginUndoEvents.on_version_changed(self)
 
 
 func _on_replay_requested(entry_index: int) -> void:
-	if not _operation_replay or not is_instance_valid(_operation_replay):
-		return
-	var target_version: int = _operation_replay.get_entry_version(entry_index)
-	if target_version < 0:
-		if dock:
-			dock.show_toast("Replay: no undo version recorded for this operation", 1)
-		return
-	if not undo_redo_manager or not active_root:
-		if dock:
-			dock.show_toast("Replay: no undo history available", 1)
-		return
-	var history_id: int = undo_redo_manager.get_object_history_id(active_root)
-	var ur: UndoRedo = undo_redo_manager.get_history_undo_redo(history_id)
-	if not ur:
-		if dock:
-			dock.show_toast("Replay: no undo history available", 1)
-		return
-	var current_version: int = ur.get_version()
-	if target_version == current_version:
-		if dock:
-			dock.show_toast("Already at this operation", 0)
-		return
-	# Undo or redo to reach the target version
-	var steps := 0
-	if target_version < current_version:
-		while ur.get_version() > target_version and ur.has_undo():
-			ur.undo()
-			steps += 1
-		if dock:
-			dock.show_toast("Replay: undid %d step%s" % [steps, "" if steps == 1 else "s"], 0)
-	else:
-		while ur.get_version() < target_version and ur.has_redo():
-			ur.redo()
-			steps += 1
-		if dock:
-			dock.show_toast("Replay: redid %d step%s" % [steps, "" if steps == 1 else "s"], 0)
+	HFPluginUndoEvents.on_replay_requested(self, entry_index)
 
 
 func _get_level_root() -> Node:

--- a/addons/hammerforge/plugin_bake_preview.gd
+++ b/addons/hammerforge/plugin_bake_preview.gd
@@ -1,0 +1,83 @@
+@tool
+class_name HFPluginBakePreview
+extends RefCounted
+## Owner of the wireframe bake-preview toggle state.
+##
+## Two flags on the plugin describe it. `_bake_preview_active` is what the toolbar
+## shows. `_bake_preview_in_flight` marks a bake this module started, so the undo
+## handler can tell our own commit apart from the user pressing Ctrl+Z.
+##
+## Every read and write of both flags goes through here, because the toggle is set
+## speculatively before an async bake and has to be walked back when the bake fails
+## or the scene is undone out from under it.
+
+## PreviewMode.WIREFRAME. The only mode the toolbar toggle represents; Proxy is
+## reachable from the dock dropdown but does not light the toggle.
+const WIREFRAME_MODE := 1
+
+
+## React to a bake finishing anywhere in the editor, ours or not.
+static func on_bake_state_changed(plugin: Object, baking: bool, success: bool) -> void:
+	if not baking:
+		if plugin._bake_preview_in_flight:
+			plugin._bake_preview_in_flight = false
+			if not success:
+				# The toggle speculatively set _bake_preview_active before
+				# dispatching. Bake failed so baked_container is unchanged —
+				# flip the flag back to match the actual scene.
+				plugin._bake_preview_active = not plugin._bake_preview_active
+			# On success the speculative value is correct — keep it.
+		elif success:
+			# A non-preview bake replaced baked_container. Derive the toggle
+			# from the actual preview mode that was baked — the dock dropdown
+			# may have been set to Wireframe for a normal bake.
+			var root = plugin.active_root if plugin.active_root else plugin._get_level_root()
+			if root:
+				plugin._bake_preview_active = root._last_bake_preview_mode == WIREFRAME_MODE
+			else:
+				plugin._bake_preview_active = false
+		# Non-preview bake failed: baked_container untouched, keep current flag.
+	plugin._update_hud_context()
+
+
+## Turn the wireframe preview on or off by re-baking at the matching quality.
+##
+## The bake is awaited directly rather than dispatched through UndoRedo: an async
+## action cannot be replayed by the undo system, so routing it there would record
+## a step that does nothing on redo.
+static func toggle(plugin: Object, root: Node, pressed: bool) -> void:
+	if not root or not root.bake_system:
+		return
+	# Guard against overlapping bakes.
+	if (
+		(plugin.dock and plugin.dock._bake_disabled)
+		or (root.has_method("is_bake_in_flight") and root.call("is_bake_in_flight"))
+	):
+		plugin._update_hud_context()
+		return
+	var preview_mode: int = WIREFRAME_MODE if pressed else 0
+	plugin._bake_preview_active = pressed
+	plugin._bake_preview_in_flight = true
+	if plugin.dock:
+		plugin.dock._set_bake_buttons_disabled(true)
+	var succeeded: bool = await root.bake(false, false, 0, preview_mode)
+	if plugin.dock:
+		plugin.dock._set_bake_buttons_disabled(false)
+	if plugin._bake_preview_in_flight:
+		plugin._bake_preview_in_flight = false
+		if not succeeded:
+			plugin._bake_preview_active = not pressed
+	plugin._update_hud_context()
+
+
+## Bring the toggle back in line with the scene after an undo or redo.
+##
+## Skipped while one of our own preview bakes is in flight, because that
+## version_changed came from our commit rather than from the user.
+static func sync_after_undo(plugin: Object, root: Node) -> void:
+	if plugin._bake_preview_in_flight:
+		return
+	var restored: bool = root._last_bake_preview_mode == WIREFRAME_MODE
+	if plugin._bake_preview_active != restored:
+		plugin._bake_preview_active = restored
+		plugin._update_hud_context()

--- a/addons/hammerforge/plugin_undo_events.gd
+++ b/addons/hammerforge/plugin_undo_events.gd
@@ -1,0 +1,79 @@
+@tool
+class_name HFPluginUndoEvents
+extends RefCounted
+## What the plugin does when the undo version moves: reconciling scene state that
+## an undo or redo invalidated, and replaying the history to a chosen operation.
+
+const HFInputStateType = preload("input_state.gd")
+const HFBakePreview = preload("plugin_bake_preview.gd")
+
+
+## Reconcile everything that an undo or redo can leave stale.
+##
+## Transient tool previews (drag, extrude) own temporary MeshInstance3D nodes that
+## reference scene state which no longer exists, so they are torn down. VERTEX_EDIT
+## is deliberately left alone: it is a persistent, user-toggled mode, and
+## commit_action() fires version_changed after every merge, split, and move, so
+## resetting it here would desynchronize the plugin's _vertex_mode flag from
+## input_state.
+static func on_version_changed(plugin: Object) -> void:
+	var root: LevelRoot = plugin.active_root if plugin.active_root else plugin._get_level_root()
+	if not root or not is_instance_valid(root):
+		return
+	# Native Inspector/gizmo commits and their Undo/Redo are owned by Godot, so
+	# reconcile their final brush signature after the editor finishes the action.
+	plugin._queue_managed_brush_reconcile()
+	if root.drag_system and root.drag_system.input_state:
+		var ist: HFInputStateType = root.drag_system.input_state
+		# Only reset transient preview modes that own temporary scene nodes.
+		if HFInputStateType.is_transient_preview_mode(ist.mode):
+			ist._force_reset()
+	# Subtract preview may reference stale brush data — rebuild
+	if root.subtract_preview and root.subtract_preview.is_enabled():
+		root.subtract_preview.request_update()
+	HFBakePreview.sync_after_undo(plugin, root)
+
+
+## Walk the undo history to the version a replay timeline entry was recorded at.
+static func on_replay_requested(plugin: Object, entry_index: int) -> void:
+	if not plugin._operation_replay or not is_instance_valid(plugin._operation_replay):
+		return
+	var target_version: int = plugin._operation_replay.get_entry_version(entry_index)
+	if target_version < 0:
+		_warn(plugin, "Replay: no undo version recorded for this operation")
+		return
+	if not plugin.undo_redo_manager or not plugin.active_root:
+		_warn(plugin, "Replay: no undo history available")
+		return
+	var history_id: int = plugin.undo_redo_manager.get_object_history_id(plugin.active_root)
+	var ur: UndoRedo = plugin.undo_redo_manager.get_history_undo_redo(history_id)
+	if not ur:
+		_warn(plugin, "Replay: no undo history available")
+		return
+	var current_version: int = ur.get_version()
+	if target_version == current_version:
+		_inform(plugin, "Already at this operation")
+		return
+	# Undo or redo to reach the target version. Both loops also stop when the
+	# history runs out, so a version that is no longer reachable cannot spin.
+	var steps := 0
+	if target_version < current_version:
+		while ur.get_version() > target_version and ur.has_undo():
+			ur.undo()
+			steps += 1
+		_inform(plugin, "Replay: undid %d step%s" % [steps, "" if steps == 1 else "s"])
+	else:
+		while ur.get_version() < target_version and ur.has_redo():
+			ur.redo()
+			steps += 1
+		_inform(plugin, "Replay: redid %d step%s" % [steps, "" if steps == 1 else "s"])
+
+
+static func _inform(plugin: Object, message: String) -> void:
+	if plugin.dock:
+		plugin.dock.show_toast(message, 0)
+
+
+static func _warn(plugin: Object, message: String) -> void:
+	if plugin.dock:
+		plugin.dock.show_toast(message, 1)

--- a/tests/test_bugfix_regressions.gd
+++ b/tests/test_bugfix_regressions.gd
@@ -860,9 +860,12 @@ func test_nudge_keys_respect_selection_ownership_before_being_consumed():
 	assert_false(HammerForgePlugin.should_yield_global_shortcut_to_focus(hf_surface))
 	assert_false(HammerForgePlugin.should_yield_global_shortcut_to_focus(null))
 
-	var preview_start := source.find("func _toggle_bake_preview")
-	var preview_end := source.find("func _on_context_tool_switch", preview_start)
-	var preview_branch := source.substr(preview_start, preview_end - preview_start)
+	var bake_preview_source := FileAccess.get_file_as_string(
+		"res://addons/hammerforge/plugin_bake_preview.gd"
+	)
+	var preview_start := bake_preview_source.find("static func toggle")
+	var preview_end := bake_preview_source.find("static func sync_after_undo", preview_start)
+	var preview_branch := bake_preview_source.substr(preview_start, preview_end - preview_start)
 	assert_true(preview_branch.contains("await root.bake"))
 	assert_false(
 		preview_branch.contains("_commit_state_action"),

--- a/tests/test_plugin_bake_preview.gd
+++ b/tests/test_plugin_bake_preview.gd
@@ -1,0 +1,227 @@
+extends GutTest
+## Boundary coverage for the extracted bake-preview toggle state.
+
+const HFPluginBakePreview = preload("res://addons/hammerforge/plugin_bake_preview.gd")
+
+
+class FakeBakeSystem:
+	extends RefCounted
+
+
+class FakeRoot:
+	extends Node3D
+
+	var bake_system := FakeBakeSystem.new()
+	var _last_bake_preview_mode := 0
+	var bake_in_flight := false
+	var bake_succeeds := true
+	var bake_calls: Array = []
+
+	func is_bake_in_flight() -> bool:
+		return bake_in_flight
+
+	func bake(_selection: bool, _dirty: bool, _layer: int, preview_mode: int) -> bool:
+		bake_calls.append(preview_mode)
+		if bake_succeeds:
+			_last_bake_preview_mode = preview_mode
+		return bake_succeeds
+
+
+class FakeDock:
+	extends RefCounted
+
+	var _bake_disabled := false
+	var button_states: Array = []
+
+	func _set_bake_buttons_disabled(disabled: bool) -> void:
+		button_states.append(disabled)
+
+
+class FakePlugin:
+	extends RefCounted
+
+	var dock := FakeDock.new()
+	var active_root: Node = null
+	var _bake_preview_active := false
+	var _bake_preview_in_flight := false
+	var hud_updates := 0
+
+	func _update_hud_context() -> void:
+		hud_updates += 1
+
+	func _get_level_root() -> Node:
+		return active_root
+
+
+var plugin: FakePlugin
+var root: FakeRoot
+
+
+func before_each():
+	plugin = FakePlugin.new()
+	root = FakeRoot.new()
+	add_child_autoqfree(root)
+	plugin.active_root = root
+
+
+func after_each():
+	plugin = null
+	root = null
+
+
+# ---------------------------------------------------------------------------
+# Toggling
+# ---------------------------------------------------------------------------
+
+
+func test_turning_the_preview_on_bakes_wireframe():
+	await HFPluginBakePreview.toggle(plugin, root, true)
+
+	assert_eq(root.bake_calls, [HFPluginBakePreview.WIREFRAME_MODE])
+	assert_true(plugin._bake_preview_active)
+	assert_false(plugin._bake_preview_in_flight)
+	assert_eq(plugin.dock.button_states, [true, false], "Bake buttons are released again")
+
+
+func test_turning_the_preview_off_bakes_full_quality():
+	plugin._bake_preview_active = true
+
+	await HFPluginBakePreview.toggle(plugin, root, false)
+
+	assert_eq(root.bake_calls, [0])
+	assert_false(plugin._bake_preview_active)
+
+
+func test_a_failed_preview_bake_walks_the_toggle_back():
+	# The toggle is set speculatively before the await, so a failure has to undo it.
+	root.bake_succeeds = false
+
+	await HFPluginBakePreview.toggle(plugin, root, true)
+
+	assert_false(plugin._bake_preview_active, "A bake that failed changed nothing on screen")
+	assert_false(plugin._bake_preview_in_flight)
+	assert_eq(plugin.dock.button_states, [true, false], "Buttons are released even on failure")
+
+
+func test_a_failed_restore_bake_leaves_the_preview_on():
+	plugin._bake_preview_active = true
+	root.bake_succeeds = false
+
+	await HFPluginBakePreview.toggle(plugin, root, false)
+
+	assert_true(plugin._bake_preview_active, "The wireframe bake is still what is on screen")
+
+
+func test_toggle_refuses_while_another_bake_is_running():
+	root.bake_in_flight = true
+
+	await HFPluginBakePreview.toggle(plugin, root, true)
+
+	assert_eq(root.bake_calls.size(), 0, "Overlapping bakes must not be dispatched")
+	assert_false(plugin._bake_preview_active)
+	assert_eq(plugin.hud_updates, 1, "The toolbar is still refreshed so the button unsticks")
+
+
+func test_toggle_refuses_while_the_dock_has_baking_disabled():
+	plugin.dock._bake_disabled = true
+
+	await HFPluginBakePreview.toggle(plugin, root, true)
+
+	assert_eq(root.bake_calls.size(), 0)
+
+
+# ---------------------------------------------------------------------------
+# Reacting to bakes we did not start
+# ---------------------------------------------------------------------------
+
+
+func test_our_own_failed_bake_flips_the_speculative_flag_back():
+	plugin._bake_preview_active = true
+	plugin._bake_preview_in_flight = true
+
+	HFPluginBakePreview.on_bake_state_changed(plugin, false, false)
+
+	assert_false(plugin._bake_preview_active)
+	assert_false(plugin._bake_preview_in_flight)
+
+
+func test_our_own_successful_bake_keeps_the_speculative_flag():
+	plugin._bake_preview_active = true
+	plugin._bake_preview_in_flight = true
+
+	HFPluginBakePreview.on_bake_state_changed(plugin, false, true)
+
+	assert_true(plugin._bake_preview_active)
+	assert_false(plugin._bake_preview_in_flight)
+
+
+func test_someone_elses_bake_derives_the_toggle_from_what_was_baked():
+	# The dock dropdown can request Wireframe for an ordinary bake.
+	root._last_bake_preview_mode = HFPluginBakePreview.WIREFRAME_MODE
+
+	HFPluginBakePreview.on_bake_state_changed(plugin, false, true)
+
+	assert_true(plugin._bake_preview_active)
+
+
+func test_someone_elses_proxy_bake_does_not_light_the_toggle():
+	root._last_bake_preview_mode = 2  # Proxy
+
+	HFPluginBakePreview.on_bake_state_changed(plugin, false, true)
+
+	assert_false(plugin._bake_preview_active, "Only Wireframe maps to the toolbar toggle")
+
+
+func test_someone_elses_failed_bake_leaves_the_toggle_alone():
+	plugin._bake_preview_active = true
+
+	HFPluginBakePreview.on_bake_state_changed(plugin, false, false)
+
+	assert_true(plugin._bake_preview_active, "baked_container is untouched, so is the flag")
+
+
+func test_a_bake_starting_only_refreshes_the_toolbar():
+	plugin._bake_preview_active = true
+
+	HFPluginBakePreview.on_bake_state_changed(plugin, true, false)
+
+	assert_true(plugin._bake_preview_active)
+	assert_eq(plugin.hud_updates, 1)
+
+
+# ---------------------------------------------------------------------------
+# Undo
+# ---------------------------------------------------------------------------
+
+
+func test_undo_restores_the_toggle_from_the_scene():
+	plugin._bake_preview_active = true
+	root._last_bake_preview_mode = 0
+
+	HFPluginBakePreview.sync_after_undo(plugin, root)
+
+	assert_false(plugin._bake_preview_active)
+	assert_eq(plugin.hud_updates, 1)
+
+
+func test_undo_during_our_own_bake_is_ignored():
+	# version_changed also fires for our commit, which would otherwise clobber
+	# the state the in-flight bake is about to produce.
+	plugin._bake_preview_active = true
+	plugin._bake_preview_in_flight = true
+	root._last_bake_preview_mode = 0
+
+	HFPluginBakePreview.sync_after_undo(plugin, root)
+
+	assert_true(plugin._bake_preview_active)
+	assert_eq(plugin.hud_updates, 0)
+
+
+func test_undo_that_changes_nothing_does_not_refresh_the_toolbar():
+	plugin._bake_preview_active = true
+	root._last_bake_preview_mode = HFPluginBakePreview.WIREFRAME_MODE
+
+	HFPluginBakePreview.sync_after_undo(plugin, root)
+
+	assert_true(plugin._bake_preview_active)
+	assert_eq(plugin.hud_updates, 0)

--- a/tests/test_plugin_undo_events.gd
+++ b/tests/test_plugin_undo_events.gd
@@ -1,0 +1,228 @@
+extends GutTest
+## Boundary coverage for the extracted undo/redo reconciliation and replay.
+
+const HFPluginUndoEvents = preload("res://addons/hammerforge/plugin_undo_events.gd")
+
+
+class FakeOperationReplay:
+	extends RefCounted
+
+	var versions: Dictionary = {}
+
+	func get_entry_version(index: int) -> int:
+		return int(versions.get(index, -1))
+
+
+class FakeDock:
+	extends RefCounted
+
+	var toasts: Array = []
+
+	func show_toast(message: String, level: int = 0) -> void:
+		toasts.append({"message": message, "level": level})
+
+	func last_toast() -> Dictionary:
+		return toasts[-1] if not toasts.is_empty() else {}
+
+
+class FakeUndoRedoManager:
+	extends RefCounted
+
+	var history: UndoRedo = null
+	var history_id := 7
+
+	func get_object_history_id(_object) -> int:
+		return history_id
+
+	func get_history_undo_redo(_id: int) -> UndoRedo:
+		return history
+
+
+class FakePlugin:
+	extends RefCounted
+
+	var dock := FakeDock.new()
+	var active_root: Node = null
+	var undo_redo_manager = null
+	var _operation_replay = null
+	var reconcile_queues := 0
+
+	func _queue_managed_brush_reconcile() -> void:
+		reconcile_queues += 1
+
+	func _get_level_root() -> Node:
+		return active_root
+
+
+class Counter:
+	extends RefCounted
+
+	var value := 0
+
+	func bump() -> void:
+		value += 1
+
+
+var plugin: FakePlugin
+
+
+func before_each():
+	plugin = FakePlugin.new()
+
+
+func after_each():
+	plugin = null
+
+
+## An UndoRedo with `count` committed actions, left at the newest version.
+func _history_with(count: int, counter: Counter) -> UndoRedo:
+	var ur := UndoRedo.new()
+	autofree(ur)
+	for i in count:
+		ur.create_action("Step %d" % i)
+		ur.add_do_method(counter.bump)
+		ur.add_undo_method(counter.bump)
+		ur.commit_action()
+	return ur
+
+
+func _with_history(ur: UndoRedo) -> void:
+	var manager := FakeUndoRedoManager.new()
+	manager.history = ur
+	plugin.undo_redo_manager = manager
+	plugin.active_root = Node3D.new()
+	add_child_autoqfree(plugin.active_root)
+
+
+# ---------------------------------------------------------------------------
+# Replay guards
+# ---------------------------------------------------------------------------
+
+
+func test_replay_without_a_timeline_does_nothing():
+	HFPluginUndoEvents.on_replay_requested(plugin, 0)
+	assert_eq(plugin.dock.toasts.size(), 0)
+
+
+func test_replay_of_an_unrecorded_entry_warns():
+	plugin._operation_replay = FakeOperationReplay.new()
+
+	HFPluginUndoEvents.on_replay_requested(plugin, 3)
+
+	assert_eq(
+		plugin.dock.last_toast().get("message"),
+		"Replay: no undo version recorded for this operation"
+	)
+	assert_eq(plugin.dock.last_toast().get("level"), 1)
+
+
+func test_replay_without_an_undo_manager_warns():
+	var replay := FakeOperationReplay.new()
+	replay.versions = {0: 2}
+	plugin._operation_replay = replay
+
+	HFPluginUndoEvents.on_replay_requested(plugin, 0)
+
+	assert_eq(plugin.dock.last_toast().get("message"), "Replay: no undo history available")
+
+
+func test_replay_without_a_history_object_warns():
+	var replay := FakeOperationReplay.new()
+	replay.versions = {0: 2}
+	plugin._operation_replay = replay
+	_with_history(null)
+
+	HFPluginUndoEvents.on_replay_requested(plugin, 0)
+
+	assert_eq(plugin.dock.last_toast().get("message"), "Replay: no undo history available")
+
+
+# ---------------------------------------------------------------------------
+# Replay navigation
+# ---------------------------------------------------------------------------
+
+
+func test_replay_walks_back_to_an_older_version():
+	var counter := Counter.new()
+	var ur := _history_with(3, counter)
+	var target: int = ur.get_version() - 2
+	var replay := FakeOperationReplay.new()
+	replay.versions = {0: target}
+	plugin._operation_replay = replay
+	_with_history(ur)
+
+	HFPluginUndoEvents.on_replay_requested(plugin, 0)
+
+	assert_eq(ur.get_version(), target, "History should land exactly on the target version")
+	assert_eq(plugin.dock.last_toast().get("message"), "Replay: undid 2 steps")
+
+
+func test_replay_walks_forward_to_a_newer_version():
+	var counter := Counter.new()
+	var ur := _history_with(3, counter)
+	var newest: int = ur.get_version()
+	ur.undo()
+	ur.undo()
+	var replay := FakeOperationReplay.new()
+	replay.versions = {0: newest}
+	plugin._operation_replay = replay
+	_with_history(ur)
+
+	HFPluginUndoEvents.on_replay_requested(plugin, 0)
+
+	assert_eq(ur.get_version(), newest)
+	assert_eq(plugin.dock.last_toast().get("message"), "Replay: redid 2 steps")
+
+
+func test_replay_to_the_current_version_says_so_and_moves_nothing():
+	var counter := Counter.new()
+	var ur := _history_with(2, counter)
+	var current: int = ur.get_version()
+	var replay := FakeOperationReplay.new()
+	replay.versions = {0: current}
+	plugin._operation_replay = replay
+	_with_history(ur)
+
+	HFPluginUndoEvents.on_replay_requested(plugin, 0)
+
+	assert_eq(ur.get_version(), current)
+	assert_eq(plugin.dock.last_toast().get("message"), "Already at this operation")
+	assert_eq(plugin.dock.last_toast().get("level"), 0)
+
+
+func test_replay_stops_when_the_history_runs_out():
+	# A version below everything still in the history must not spin forever.
+	var counter := Counter.new()
+	var ur := _history_with(2, counter)
+	var replay := FakeOperationReplay.new()
+	replay.versions = {0: 0}
+	plugin._operation_replay = replay
+	_with_history(ur)
+
+	HFPluginUndoEvents.on_replay_requested(plugin, 0)
+
+	assert_false(ur.has_undo(), "Every available step should have been undone")
+	assert_eq(plugin.dock.last_toast().get("message"), "Replay: undid 2 steps")
+
+
+func test_replay_reports_a_single_step_in_the_singular():
+	var counter := Counter.new()
+	var ur := _history_with(2, counter)
+	var replay := FakeOperationReplay.new()
+	replay.versions = {0: ur.get_version() - 1}
+	plugin._operation_replay = replay
+	_with_history(ur)
+
+	HFPluginUndoEvents.on_replay_requested(plugin, 0)
+
+	assert_eq(plugin.dock.last_toast().get("message"), "Replay: undid 1 step")
+
+
+# ---------------------------------------------------------------------------
+# Version change reconciliation
+# ---------------------------------------------------------------------------
+
+
+func test_version_change_without_a_root_does_nothing():
+	HFPluginUndoEvents.on_version_changed(plugin)
+	assert_eq(plugin.reconcile_queues, 0)

--- a/tests/test_selection_gesture.gd
+++ b/tests/test_selection_gesture.gd
@@ -1231,10 +1231,13 @@ func test_plugin_defers_one_shared_native_and_inspector_brush_reconcile() -> voi
 	assert_true(source.contains("func _queue_managed_brush_reconcile"))
 	assert_true(source.contains("func _reconcile_managed_brush_changes"))
 	assert_true(source.contains("_ensure_brush_change_tracker().reconcile(root)"))
-	var version_start := source.find("func _on_undo_redo_version_changed")
-	var version_end := source.find("func _on_replay_requested", version_start)
+	var undo_events_source := FileAccess.get_file_as_string(
+		"res://addons/hammerforge/plugin_undo_events.gd"
+	)
+	var version_start := undo_events_source.find("static func on_version_changed")
+	var version_end := undo_events_source.find("static func on_replay_requested", version_start)
 	assert_true(
-		source.substr(version_start, version_end - version_start).contains(
+		undo_events_source.substr(version_start, version_end - version_start).contains(
 			"_queue_managed_brush_reconcile()"
 		)
 	)


### PR DESCRIPTION
Part of #41. Two areas, one branch, because they were coupled through shared plugin state and separating them is the point.

**plugin_bake_preview.gd** owns `_bake_preview_active` and `_bake_preview_in_flight`. Three places touched those flags: the dock bake callback, the toggle itself, and a block buried inside `_on_undo_redo_version_changed`. They read as unrelated in plugin.gd but they are one mechanism — the toggle is set speculatively before an async bake, and the other two exist to walk it back when the bake fails or the scene is undone underneath it. That now lives in one file with the reasoning attached.

The two branches of `_toggle_bake_preview` were mirror images differing only in the bake mode and which way the flag flips on failure, so they are one path.

**plugin_undo_events.gd** takes the `version_changed` reconciliation and the replay timeline navigation. It calls `HFPluginBakePreview.sync_after_undo`, which turns a coupling that used to be two shared flags read from a second place into an ordinary call with one owner.

Two existing source-inspecting tests followed the code they inspect. `test_bugfix_regressions.gd` now reads `plugin_bake_preview.gd` for "async preview bake must never be dispatched through UndoRedo", and `test_selection_gesture.gd` reads `plugin_undo_events.gd` for the deferred brush reconcile. Same assertions, new location.

plugin.gd keeps thin delegates: `plugin_commands.gd` calls the toggle, and the dock signal, the UndoRedo `version_changed` signal, and `plugin_overlays.gd`'s `replay_requested` connection all bind plugin methods by name. `plugin_hud.gd` still reads `_bake_preview_active` off the plugin, so the flags stay where they are. No behaviour changed.

plugin.gd goes from 2,142 to 2,024 lines.

Tests: `tests/test_plugin_bake_preview.gd` (15 cases) and `tests/test_plugin_undo_events.gd` (10 cases). The bake preview ones pin each direction of the speculative flag: a failed preview bake clears it, a failed restore bake leaves it on, a Proxy bake by someone else does not light it, and an undo arriving during our own bake is ignored rather than clobbering the state the bake is about to produce. The replay ones drive a real `UndoRedo` with committed actions and check it lands exactly on the target version, stops when the history runs out rather than spinning, and reports one step in the singular.
