### PR TITLE
Keep edited faces and displacement across a face rebuild

### DIFF
--- a/addons/hammerforge/brush_instance.gd
+++ b/addons/hammerforge/brush_instance.gd
@@ -96,6 +96,19 @@ func get_faces() -> Array:
 	return faces
 
 
+## Declare `faces` the authoritative geometry for this brush.
+##
+## Bevel, inset, and vertex edits change face topology or vertex positions that
+## no primitive can reproduce. Until the brush is CUSTOM, the next set_size(),
+## sides change, or scene reload runs _rebuild_faces() and replaces the edit
+## with a plain primitive. Promoting also drops the box resize handles, which is
+## the point: those handles call set_size() and would wipe the edit.
+func mark_faces_authoritative() -> void:
+	if faces.is_empty() or shape == BrushShape.CUSTOM:
+		return
+	shape = BrushShape.CUSTOM
+
+
 func set_selected_faces(indices: PackedInt32Array) -> void:
 	selected_faces = indices
 	rebuild_preview()
@@ -336,6 +349,10 @@ func _transfer_face_data(old_faces: Array, new_faces: Array) -> void:
 			new_face.custom_uvs = old_face.custom_uvs
 		if old_face.paint_layers.size() > 0:
 			new_face.paint_layers = old_face.paint_layers.duplicate(true)
+		# Displacement stores per-vertex offsets against the face corners, not
+		# absolute positions, so it survives a resize unchanged. The old face is
+		# discarded right after this, so hand the resource over rather than copy.
+		new_face.displacement = old_face.displacement
 
 
 func _build_base_mesh() -> Dictionary:

--- a/addons/hammerforge/systems/hf_bevel_system.gd
+++ b/addons/hammerforge/systems/hf_bevel_system.gd
@@ -226,6 +226,10 @@ func _find_brush(brush_id: String) -> Node3D:
 
 
 func _mark_brush_dirty(brush: Node3D) -> void:
+	# Bevel and inset add faces a primitive cannot express. Claim the face array
+	# first, or the next resize or reload rebuilds the box over the result.
+	if brush.has_method("mark_faces_authoritative"):
+		brush.mark_faces_authoritative()
 	if brush.has_method("rebuild_preview"):
 		brush.rebuild_preview()
 	if root and brush.get("brush_id") and root.has_method("tag_brush_dirty"):

--- a/addons/hammerforge/systems/hf_vertex_system.gd
+++ b/addons/hammerforge/systems/hf_vertex_system.gd
@@ -105,8 +105,8 @@ func move_vertices(delta: Vector3) -> bool:
 	# Rebuild previews
 	for brush_id in selected_vertices:
 		var brush = _find_brush(brush_id)
-		if brush and brush.has_method("rebuild_preview"):
-			brush.rebuild_preview()
+		if brush:
+			_commit_geometry(brush)
 	return true
 
 
@@ -170,8 +170,7 @@ func clip_to_convex(brush_id: String) -> bool:
 	for f in new_faces:
 		brush.faces.append(f)
 
-	if brush.has_method("rebuild_preview"):
-		brush.rebuild_preview()
+	_commit_geometry(brush)
 	if root and root.has_method("tag_brush_dirty"):
 		root.tag_brush_dirty(brush_id)
 	return true
@@ -529,6 +528,13 @@ func end_drag() -> Dictionary:
 	var changed := _drag_geometry_differs_from_origin()
 	_drag_active = false
 	var snapshots := _pre_drag_faces.duplicate(true) if changed else {}
+	if changed:
+		# Only on commit. Promoting mid-drag would leave a canceled drag with a
+		# CUSTOM brush and no resize handles even though nothing moved.
+		for brush_id in _drag_face_vertices:
+			var brush = _find_brush(brush_id)
+			if brush and brush.has_method("mark_faces_authoritative"):
+				brush.mark_faces_authoritative()
 	_clear_drag_state()
 	return snapshots
 
@@ -764,8 +770,7 @@ func split_edge(brush_id: String, edge: Array) -> bool:
 	# exactly on the surface.  Skip the heavy convexity check here; the standard
 	# validate_convexity (0.01 tolerance) is used for vertex moves where the user
 	# can break convexity.  For splits we only need to verify face integrity.
-	if brush.has_method("rebuild_preview"):
-		brush.rebuild_preview()
+	_commit_geometry(brush)
 	return true
 
 
@@ -826,8 +831,7 @@ func merge_vertices(brush_id: String, vert_indices: PackedInt32Array) -> bool:
 	if not validate_convexity(brush):
 		_restore_face_snapshots()
 		return false
-	if brush.has_method("rebuild_preview"):
-		brush.rebuild_preview()
+	_commit_geometry(brush)
 	return true
 
 
@@ -993,6 +997,16 @@ func _write_drag_geometry(world_delta: Vector3) -> bool:
 			face.local_verts = updated_vertices
 			face.ensure_geometry()
 	return touched
+
+
+## Vertex edits move geometry no primitive can reproduce. Claim the face array
+## before refreshing, or the next resize or reload rebuilds the primitive over
+## the edit. Cheap to repeat: promotion is a no-op once the brush is CUSTOM.
+func _commit_geometry(brush: Node3D) -> void:
+	if brush.has_method("mark_faces_authoritative"):
+		brush.mark_faces_authoritative()
+	if brush.has_method("rebuild_preview"):
+		brush.rebuild_preview()
 
 
 func _rebuild_drag_previews() -> void:

--- a/tests/test_bevel.gd
+++ b/tests/test_bevel.gd
@@ -184,16 +184,12 @@ func test_inset_face_too_large_distance():
 func test_bevel_edge_basic():
 	var brush = _make_box_brush()
 	var face_count_before: int = brush.faces.size()
-	# Edge between vertex 0 and 1 of the box (shared by top and front faces)
-	# Vertex 0 = (0,16,0), Vertex 1 = (16,16,0)
+	# Unique vertex 0 = (0,16,0), 3 = (0,16,16). That edge is shared by the top
+	# and left faces, so the bevel has the two adjacent faces it needs.
 	var ok: bool = sys.bevel_edge("box_brush", [0, 3], 2, 2.0)
-	# The edge [0,3] maps to unique vertices — let's use a known shared edge
-	# Top face has (0,16,0), (16,16,0) and Front face has (0,16,0), (16,16,0)
-	# These are indices in the unique vertex list
-	assert_true(ok or not ok, "Bevel should not crash")
-	# If ok, we should have new bevel faces
-	if ok:
-		assert_true(brush.faces.size() > face_count_before, "Bevel should add faces")
+	assert_true(ok, "Bevel should succeed on an edge shared by two faces")
+	# 2 segments = 2 strip quads, plus one corner cap per endpoint.
+	assert_eq(brush.faces.size(), face_count_before + 4, "Two-segment bevel should add 4 faces")
 
 
 func test_bevel_edge_bad_brush():
@@ -219,10 +215,12 @@ func test_bevel_edge_needs_two_indices():
 
 func test_bevel_edge_segments_clamped():
 	var brush = _make_box_brush()
-	# Even with segments=0, it should clamp to 1
+	var face_count_before: int = brush.faces.size()
+	# Unique vertices 0 = (0,16,0) and 1 = (16,16,0), shared by top and front.
+	# segments=0 clamps to 1, which is a chamfer: one strip quad, no caps.
 	var ok: bool = sys.bevel_edge("box_brush", [0, 1], 0, 2.0)
-	# May fail due to edge not being shared, but should not crash
-	assert_true(ok or not ok, "Should not crash with clamped segments")
+	assert_true(ok, "Bevel should succeed with segments clamped up to 1")
+	assert_eq(brush.faces.size(), face_count_before + 1, "Clamped segments should add 1 face")
 
 
 func test_bevel_edge_single_segment_is_chamfer():
@@ -235,9 +233,45 @@ func test_bevel_edge_single_segment_is_chamfer():
 	# Front: (0,16,0), (0,0,0), (16,0,0), (16,16,0)
 	# Shared edge: (0,16,0)-(16,16,0) = unique indices 0 and 1
 	var ok: bool = sys.bevel_edge("box_brush", [0, 1], 1, 2.0)
-	if ok:
-		# 1 segment = 1 new face (chamfer)
-		assert_eq(brush.faces.size(), face_count_before + 1, "Chamfer should add 1 face")
+	assert_true(ok, "Chamfer should succeed on a shared edge")
+	# 1 segment = 1 new face (chamfer)
+	assert_eq(brush.faces.size(), face_count_before + 1, "Chamfer should add 1 face")
+
+
+# ---------------------------------------------------------------------------
+# Edited faces survive a resize
+# ---------------------------------------------------------------------------
+
+
+func test_bevel_edge_promotes_brush_to_custom_shape():
+	var brush = _make_box_brush()
+	assert_eq(brush.shape, DraftBrush.BrushShape.BOX, "Fixture starts as a box")
+	assert_true(sys.bevel_edge("box_brush", [0, 1], 1, 2.0))
+	assert_eq(
+		brush.shape,
+		DraftBrush.BrushShape.CUSTOM,
+		"Bevel must claim the face array so a rebuild cannot overwrite it"
+	)
+
+
+func test_beveled_faces_survive_resize():
+	var brush = _make_box_brush()
+	var face_count_before: int = brush.faces.size()
+	assert_true(sys.bevel_edge("box_brush", [0, 1], 2, 2.0))
+	var beveled_count: int = brush.faces.size()
+	assert_eq(beveled_count, face_count_before + 4)
+	brush.set_size(Vector3(48, 48, 48))
+	assert_eq(brush.faces.size(), beveled_count, "Resize must not rebuild the box over a bevel")
+
+
+func test_inset_faces_survive_resize():
+	var brush = _make_box_brush()
+	var face_count_before: int = brush.faces.size()
+	assert_true(sys.inset_face("box_brush", 0, 2.0, 0.0))
+	var inset_count: int = brush.faces.size()
+	assert_eq(inset_count, face_count_before + 4)
+	brush.set_size(Vector3(48, 48, 48))
+	assert_eq(brush.faces.size(), inset_count, "Resize must not rebuild the box over an inset")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_displacement.gd
+++ b/tests/test_displacement.gd
@@ -84,6 +84,16 @@ func _make_quad_brush(brush_id: String = "test_brush") -> Node3D:
 	return brush
 
 
+## A real six-face box, built by DraftBrush itself, so a later set_size() takes
+## the production _rebuild_faces() path with matching old and new face counts.
+func _make_solid_box_brush(brush_id: String = "box_brush") -> DraftBrush:
+	var brush = DraftBrush.new()
+	brush.brush_id = brush_id
+	root.draft_brushes_node.add_child(brush)
+	brush.size = Vector3(32, 32, 32)
+	return brush
+
+
 func _make_tri_brush(brush_id: String = "tri_brush") -> Node3D:
 	var brush = DraftBrush.new()
 	brush.brush_id = brush_id
@@ -539,3 +549,42 @@ func test_sew_all_no_crash():
 		level_root_source.contains("func get_all_draft_brushes() -> Array:"),
 		"Production LevelRoot must expose the same editable brush collection",
 	)
+
+
+# ---------------------------------------------------------------------------
+# Displacement survives a face rebuild
+# ---------------------------------------------------------------------------
+
+
+func test_displacement_survives_brush_resize():
+	var brush := _make_solid_box_brush()
+	assert_eq(brush.faces.size(), 6, "The fixture must be a real six-face box")
+	assert_true(sys.create_displacement("box_brush", 0, 3), "Displacement should be created")
+	var disp = brush.faces[0].displacement
+	assert_not_null(disp)
+	disp.set_distance(1, 1, 12.0)
+
+	brush.set_size(Vector3(64, 64, 64))
+
+	assert_eq(brush.faces.size(), 6, "Resize still rebuilds a box")
+	assert_not_null(
+		brush.faces[0].displacement, "Resize must not drop the displacement on a rebuilt face"
+	)
+	assert_eq(
+		brush.faces[0].displacement.get_distance(1, 1),
+		12.0,
+		"The sculpted elevation must come across with the resource"
+	)
+
+
+func test_displacement_is_not_smeared_onto_other_faces_by_resize():
+	var brush := _make_solid_box_brush()
+	assert_true(sys.create_displacement("box_brush", 0, 3))
+
+	brush.set_size(Vector3(64, 64, 64))
+
+	var carrying := 0
+	for face in brush.faces:
+		if face.displacement != null:
+			carrying += 1
+	assert_eq(carrying, 1, "Only the displaced face should carry displacement after a rebuild")

--- a/tests/test_vertex_edges.gd
+++ b/tests/test_vertex_edges.gd
@@ -259,6 +259,33 @@ func test_merge_requires_at_least_two():
 	assert_false(ok, "Merge should fail with only 1 vertex")
 
 
+func test_split_edge_promotes_brush_to_custom_shape():
+	var brush = _make_box_brush(Vector3.ZERO, Vector3(4, 4, 4), "b1")
+	assert_eq(brush.shape, DraftBrush.BrushShape.BOX, "Fixture starts as a box")
+	vs.set_selection([brush])
+	var edges = vs.get_brush_edges(brush)
+	assert_true(vs.split_edge("b1", edges[0]), "Split should succeed on a convex box")
+	assert_eq(
+		brush.shape,
+		DraftBrush.BrushShape.CUSTOM,
+		"A split edge must claim the face array so a rebuild cannot overwrite it"
+	)
+
+
+func test_split_edge_survives_resize():
+	var brush = _make_box_brush(Vector3.ZERO, Vector3(4, 4, 4), "b1")
+	vs.set_selection([brush])
+	var edges = vs.get_brush_edges(brush)
+	assert_true(vs.split_edge("b1", edges[0]))
+	assert_eq(vs.get_brush_vertices(brush).size(), 9)
+
+	brush.set_size(Vector3(8, 8, 8))
+
+	assert_eq(
+		vs.get_brush_vertices(brush).size(), 9, "Resize must not rebuild the box over a split edge"
+	)
+
+
 # ===========================================================================
 # Sub-mode
 # ===========================================================================

--- a/tests/test_vertex_system.gd
+++ b/tests/test_vertex_system.gd
@@ -292,6 +292,77 @@ func test_move_with_no_selection_returns_false():
 
 
 # ===========================================================================
+# Edited geometry survives a rebuild
+# ===========================================================================
+
+
+func test_move_vertices_promotes_brush_to_custom_shape():
+	var b = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "promote1")
+	assert_eq(b.shape, DraftBrush.BrushShape.BOX, "Fixture starts as a box")
+	vs.set_selection([b])
+	vs.select_vertex("promote1", 0, false)
+	assert_true(vs.move_vertices(Vector3(4, 0, 0)))
+	assert_eq(
+		b.shape,
+		DraftBrush.BrushShape.CUSTOM,
+		"A moved vertex must claim the face array so a rebuild cannot overwrite it"
+	)
+
+
+func test_moved_vertices_survive_resize():
+	var b = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "survive1")
+	vs.set_selection([b])
+	var original_vertex: Vector3 = vs.get_brush_vertices(b)[0]
+	vs.select_vertex("survive1", 0, false)
+	assert_true(vs.move_vertices(Vector3(4, 0, 0)))
+	var moved_vertex := original_vertex + Vector3(4, 0, 0)
+
+	b.set_size(Vector3(48, 48, 48))
+
+	var found := false
+	for v in vs.get_brush_vertices(b):
+		if v.is_equal_approx(moved_vertex):
+			found = true
+			break
+	assert_true(found, "Resize must not rebuild the box over a moved vertex")
+
+
+func test_clip_to_convex_promotes_brush_to_custom_shape():
+	var b = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "clipped")
+	vs.set_selection([b])
+	_dent_box_corner(b, Vector3(16, 16, 16), Vector3.ZERO)
+	assert_false(vs.validate_convexity(b), "The fixture must start non-convex")
+	assert_true(vs.clip_to_convex("clipped"))
+	assert_eq(b.shape, DraftBrush.BrushShape.CUSTOM, "A hull rebuild is not a box any more")
+
+
+func test_committed_vertex_drag_promotes_brush_to_custom_shape():
+	var b = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "dragged")
+	vs.set_selection([b])
+	var original_vertex: Vector3 = vs.get_brush_vertices(b)[0]
+	vs.select_vertex("dragged", 0, false)
+	vs.begin_drag(b.to_global(original_vertex))
+	assert_true(vs.update_drag_absolute(Vector3(2, 0, 0)))
+	assert_false(vs.end_drag().is_empty(), "A real geometry change should retain undo data")
+	assert_eq(b.shape, DraftBrush.BrushShape.CUSTOM, "A committed drag claims the face array")
+
+
+func test_canceled_vertex_drag_leaves_brush_as_box():
+	var b = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "canceled")
+	vs.set_selection([b])
+	var original_vertex: Vector3 = vs.get_brush_vertices(b)[0]
+	vs.select_vertex("canceled", 0, false)
+	vs.begin_drag(b.to_global(original_vertex))
+	assert_true(vs.update_drag_absolute(Vector3(2, 0, 0)))
+	vs.cancel_drag()
+	assert_eq(
+		b.shape,
+		DraftBrush.BrushShape.BOX,
+		"A canceled drag changed nothing, so it must not cost the brush its resize handles"
+	)
+
+
+# ===========================================================================
 # Drag lifecycle
 # ===========================================================================
 


### PR DESCRIPTION
Three issues in the same face-rebuild path.

- #99 Bevel, inset, and vertex edits left `shape` as `BOX`, so `_update_visuals` and `set_size` both ran `_rebuild_faces` and replaced the edit with a plain box. `DraftBrush.mark_faces_authoritative` promotes the brush to `CUSTOM`, which the existing `preserve_custom_faces` gate already respects. The vertex drag promotes only on commit, so a canceled drag keeps its resize handles.
- #101 `_transfer_face_data` copied every face attribute except `displacement`, so a resize dropped the sculpted surface. Displacement offsets are relative to the face corners, so the resource carries over unchanged.
- #102 Three edge bevel tests asserted `ok or not ok` and guarded their real assertions behind `if ok`. They now use edges the box fixture is known to share between two faces and assert face counts unconditionally.

Full suite: 117 scripts, 1995 tests, 1988 passing, 0 failing.

Fixes #99
Fixes #101
Fixes #102
