### PR TITLE
Respect brush rotation and shape in carve and snap

### DIFF
--- a/addons/hammerforge/hf_snap_system.gd
+++ b/addons/hammerforge/hf_snap_system.gd
@@ -7,6 +7,29 @@ const DraftBrush = preload("brush_instance.gd")
 
 enum SnapMode { GRID = 1, VERTEX = 2, CENTER = 4, EDGE = 8, PERPENDICULAR = 16 }
 
+## Past this many faces a brush's `faces` array is engine tessellation rather
+## than geometry anyone could aim at: a cylinder brush is one FaceData per
+## triangle, a sphere is thousands. Those brushes keep the bounding box they
+## always had, now oriented by the brush transform. Hand built geometry
+## (polygon, path, merged, bevelled, vertex edited) sits well under this.
+const MAX_SNAP_FACES := 64
+
+## Corner order for _box_corners(), and the 12 box edges as index pairs into it.
+const BOX_EDGE_INDICES: Array = [
+	[0, 1],
+	[0, 2],
+	[0, 4],
+	[1, 3],
+	[1, 5],
+	[2, 3],
+	[2, 6],
+	[3, 7],
+	[4, 5],
+	[4, 6],
+	[5, 7],
+	[6, 7],
+]
+
 var root: Node3D
 var enabled_modes: int = SnapMode.GRID
 var snap_threshold: float = 2.0
@@ -105,46 +128,108 @@ func _collect_candidates(exclude_ids: Array, point: Vector3 = Vector3.ZERO) -> P
 		var brush := node as DraftBrush
 		if exclude_ids.has(str(brush.brush_id)):
 			continue
-		var pos := brush.global_position
-		var half := brush.size * 0.5
 		if do_center:
-			out.append(pos)
-		var corners := PackedVector3Array(
-			[
-				pos + Vector3(-half.x, -half.y, -half.z),
-				pos + Vector3(-half.x, -half.y, half.z),
-				pos + Vector3(-half.x, half.y, -half.z),
-				pos + Vector3(-half.x, half.y, half.z),
-				pos + Vector3(half.x, -half.y, -half.z),
-				pos + Vector3(half.x, -half.y, half.z),
-				pos + Vector3(half.x, half.y, -half.z),
-				pos + Vector3(half.x, half.y, half.z),
-			]
-		)
+			out.append(brush.global_position)
+		if not (do_vertex or do_edge or do_perp):
+			continue
+		# Snap points live in brush space. Going through the transform is what
+		# carries the rotation and scale that world axis offsets threw away.
+		var xform := brush.global_transform
+		var geometry := _snap_geometry_local(brush)
+		var local_verts: PackedVector3Array = geometry["verts"]
+		var verts := PackedVector3Array()
+		for local_vert in local_verts:
+			verts.append(xform * local_vert)
 		if do_vertex:
-			out.append_array(corners)
+			out.append_array(verts)
 		if do_edge or do_perp:
-			# 12 AABB edges, same corner order as vertex snap.
-			var edges := [
-				[0, 1],
-				[0, 2],
-				[0, 4],
-				[1, 3],
-				[1, 5],
-				[2, 3],
-				[2, 6],
-				[3, 7],
-				[4, 5],
-				[4, 6],
-				[5, 7],
-				[6, 7],
-			]
-			for edge in edges:
+			for edge in geometry["edges"]:
+				var a: Vector3 = verts[edge[0]]
+				var b: Vector3 = verts[edge[1]]
 				if do_edge:
-					out.append((corners[edge[0]] + corners[edge[1]]) * 0.5)
+					out.append((a + b) * 0.5)
 				if do_perp:
-					out.append(_closest_point_on_segment(point, corners[edge[0]], corners[edge[1]]))
+					out.append(_closest_point_on_segment(point, a, b))
 	return out
+
+
+## Snap targets for one brush in brush-local space: unique vertices, plus the
+## unique edges between them as index pairs into that vertex list.
+##
+## A brush that carries its own faces is described by them, so a wedge, prism,
+## polygon, path or merged brush snaps to real corners instead of the corners of
+## a box it does not fill. Everything else falls back to its bounding box.
+func _snap_geometry_local(brush: DraftBrush) -> Dictionary:
+	# A BOX brush is defined by its size: _rebuild_faces regenerates its faces
+	# from size alone, so its corners are the size corners. Boxes are most of a
+	# level, so take them straight rather than deduping six faces every query.
+	if brush.shape == DraftBrush.BrushShape.BOX:
+		return {"verts": _box_corners(brush.size * 0.5), "edges": BOX_EDGE_INDICES}
+	var faces: Array = brush.faces
+	if not faces.is_empty() and faces.size() <= MAX_SNAP_FACES:
+		var face_geometry := _face_snap_geometry(faces)
+		var face_verts: PackedVector3Array = face_geometry["verts"]
+		if face_verts.size() >= 2:
+			return face_geometry
+	return {"verts": _box_corners(brush.size * 0.5), "edges": BOX_EDGE_INDICES}
+
+
+## Unique vertices and unique edges read off a brush's faces. A hull corner
+## belongs to three or more faces and an edge to two, so both are deduped by
+## rounded position.
+static func _face_snap_geometry(faces: Array) -> Dictionary:
+	var verts := PackedVector3Array()
+	var index_by_key: Dictionary = {}
+	for face in faces:
+		if face == null:
+			continue
+		for v in face.local_verts:
+			var key := _vertex_key(v)
+			if not index_by_key.has(key):
+				index_by_key[key] = verts.size()
+				verts.append(v)
+	var edges: Array = []
+	var seen_edges: Dictionary = {}
+	for face in faces:
+		if face == null:
+			continue
+		var ring: PackedVector3Array = face.local_verts
+		var count := ring.size()
+		if count < 2:
+			continue
+		for i in range(count):
+			var ia: int = index_by_key.get(_vertex_key(ring[i]), -1)
+			var ib: int = index_by_key.get(_vertex_key(ring[(i + 1) % count]), -1)
+			if ia < 0 or ib < 0 or ia == ib:
+				continue
+			var lo := mini(ia, ib)
+			var hi := maxi(ia, ib)
+			var edge_key := "%d|%d" % [lo, hi]
+			if seen_edges.has(edge_key):
+				continue
+			seen_edges[edge_key] = true
+			edges.append([lo, hi])
+	return {"verts": verts, "edges": edges}
+
+
+static func _vertex_key(v: Vector3) -> String:
+	return "%.3f,%.3f,%.3f" % [v.x, v.y, v.z]
+
+
+## The 8 corners of a box, in the order BOX_EDGE_INDICES expects.
+static func _box_corners(half: Vector3) -> PackedVector3Array:
+	return PackedVector3Array(
+		[
+			Vector3(-half.x, -half.y, -half.z),
+			Vector3(-half.x, -half.y, half.z),
+			Vector3(-half.x, half.y, -half.z),
+			Vector3(-half.x, half.y, half.z),
+			Vector3(half.x, -half.y, -half.z),
+			Vector3(half.x, -half.y, half.z),
+			Vector3(half.x, half.y, -half.z),
+			Vector3(half.x, half.y, half.z),
+		]
+	)
 
 
 func _closest_point_on_segment(point: Vector3, a: Vector3, b: Vector3) -> Vector3:

--- a/addons/hammerforge/systems/hf_brush_system.gd
+++ b/addons/hammerforge/systems/hf_brush_system.gd
@@ -1120,8 +1120,12 @@ func _find_brush_by_key(key: String) -> DraftBrush:
 ## `size`, then rebuild the brush as axis-aligned BOX pieces.  That is only
 ## truthful for an unrotated box, so anything else has to be rejected before the
 ## original brush is deleted.
-func _check_axis_aligned_box(draft: DraftBrush, op_name: String) -> HFOpResult:
-	if draft.shape != root.BrushShape.BOX:
+## Shared by Hollow, Clip and Carve. All three read world bounds off
+## global_position and size and write axis-aligned boxes back, so all three need
+## the same brush. Static so a system that has no HFBrushSystem to hand can
+## still ask, instead of keeping a second copy of the rule.
+static func _check_axis_aligned_box(draft: DraftBrush, op_name: String) -> HFOpResult:
+	if draft.shape != DraftBrush.BrushShape.BOX:
 		return HFOpResult.fail(
 			"%s: only works on box brushes" % op_name,
 			"Select a box brush, or convert this shape to a box first"

--- a/addons/hammerforge/systems/hf_carve_preview.gd
+++ b/addons/hammerforge/systems/hf_carve_preview.gd
@@ -85,6 +85,13 @@ func _rebuild() -> void:
 		return
 
 	var carver_draft := carver as DraftBrush
+	# Preview what carve will actually do. It refuses anything that is not an
+	# unrotated box, so drawing slice pieces for one would promise a cut the
+	# operation is going to turn down.
+	if not HFBrushSystem._check_axis_aligned_box(carver_draft, "Carve").ok:
+		clear()
+		return
+
 	var carver_pos: Vector3 = carver_draft.global_position
 	var carver_size: Vector3 = carver_draft.size
 	var carver_aabb := AABB(carver_pos - carver_size * 0.5, carver_size)
@@ -96,6 +103,10 @@ func _rebuild() -> void:
 
 	for target in targets:
 		var target_draft := target as DraftBrush
+		# One unsuitable target refuses the whole carve, so preview nothing.
+		if not HFBrushSystem._check_axis_aligned_box(target_draft, "Carve").ok:
+			clear()
+			return
 		var target_pos: Vector3 = target_draft.global_position
 		var target_size: Vector3 = target_draft.size
 		var target_aabb := AABB(target_pos - target_size * 0.5, target_size)

--- a/addons/hammerforge/systems/hf_carve_system.gd
+++ b/addons/hammerforge/systems/hf_carve_system.gd
@@ -40,7 +40,9 @@ func carve_with_brush(brush_id: String) -> HFOpResult:
 	# owner as Hollow and Clip.
 	var carver_check: HFOpResult = HFBrushSystem._check_axis_aligned_box(carver_draft, "Carve")
 	if not carver_check.ok:
-		return carver_check
+		# Through _op_fail, not straight back: every other refusal in here warns
+		# the user, and a silent one just looks like the carve did nothing.
+		return _op_fail(carver_check.message, carver_check.fix_hint)
 
 	var carver_pos: Vector3 = carver_draft.global_position
 	var carver_size: Vector3 = carver_draft.size

--- a/addons/hammerforge/systems/hf_carve_system.gd
+++ b/addons/hammerforge/systems/hf_carve_system.gd
@@ -34,6 +34,14 @@ func carve_with_brush(brush_id: String) -> HFOpResult:
 		return _op_fail("Carve: brush '%s' not found" % brush_id)
 
 	var carver_draft := carver as DraftBrush
+	# Carve reads world bounds off global_position and size, and rebuilds every
+	# target as axis-aligned boxes. Neither holds for a rotated brush or a shape
+	# that is not a box, so refuse before anything is deleted. Same rule and same
+	# owner as Hollow and Clip.
+	var carver_check: HFOpResult = HFBrushSystem._check_axis_aligned_box(carver_draft, "Carve")
+	if not carver_check.ok:
+		return carver_check
+
 	var carver_pos: Vector3 = carver_draft.global_position
 	var carver_size: Vector3 = carver_draft.size
 	var carver_aabb := AABB(carver_pos - carver_size * 0.5, carver_size)
@@ -45,14 +53,24 @@ func carve_with_brush(brush_id: String) -> HFOpResult:
 			"Carve: no overlapping brushes found", "Move the carver so it overlaps other brushes"
 		)
 
+	# Check every target up front. Carving some and refusing the rest would leave
+	# the user with a half applied cut and no way to tell which brushes moved.
+	for target in targets:
+		var target_check: HFOpResult = HFBrushSystem._check_axis_aligned_box(
+			target as DraftBrush, "Carve"
+		)
+		if not target_check.ok:
+			return _op_fail(
+				"Carve: overlapping brush '%s' is not an unrotated box" % _brush_id_of(target),
+				"Carve rebuilds what it cuts as axis-aligned boxes. Move the carver clear of that brush."
+			)
+
 	var total_pieces := 0
 	var targets_carved := 0
 
 	for target in targets:
 		var target_draft := target as DraftBrush
-		var target_id := str(target_draft.brush_id)
-		if target_id == "" and target_draft.has_meta("brush_id"):
-			target_id = str(target_draft.get_meta("brush_id"))
+		var target_id := _brush_id_of(target_draft)
 		var target_pos: Vector3 = target_draft.global_position
 		var target_size: Vector3 = target_draft.size
 		var target_aabb := AABB(target_pos - target_size * 0.5, target_size)
@@ -226,6 +244,15 @@ func _compute_slices(
 	return slices
 
 
+## Brush ids normally live on the property, but brushes restored from a scene can
+## still carry only the metadata copy.
+static func _brush_id_of(brush: Node) -> String:
+	var bid := str(brush.get("brush_id"))
+	if bid == "" and brush.has_meta("brush_id"):
+		bid = str(brush.get_meta("brush_id"))
+	return bid
+
+
 func _make_slice(size: Vector3, center: Vector3) -> Dictionary:
 	return {
 		"shape": root.BrushShape.BOX,
@@ -242,10 +269,7 @@ func _find_overlapping_brushes(exclude_id: String, aabb: AABB) -> Array:
 		if not (node is DraftBrush):
 			continue
 		var draft := node as DraftBrush
-		var bid := str(draft.brush_id)
-		if bid == "" and draft.has_meta("brush_id"):
-			bid = str(draft.get_meta("brush_id"))
-		if bid == exclude_id:
+		if _brush_id_of(draft) == exclude_id:
 			continue
 		var node_pos: Vector3 = draft.global_position
 		var node_size: Vector3 = draft.size

--- a/tests/test_bugfix_regressions.gd
+++ b/tests/test_bugfix_regressions.gd
@@ -382,14 +382,22 @@ func _make_cylinder_brush(pos: Vector3, sz: Vector3, id: String) -> DraftBrush:
 	return b
 
 
+func _record_user_messages() -> Array:
+	var seen: Array = []
+	root.user_message.connect(func(msg, _level): seen.append(str(msg)))
+	return seen
+
+
 func test_carve_rejects_non_box_carver():
 	var carver = _make_cylinder_brush(Vector3.ZERO, Vector3(32, 32, 32), "cyl_carver")
 	var target = _make_box_brush(Vector3(16, 0, 0), Vector3(32, 32, 32), "box_target")
 	var child_count_before = draft_node.get_child_count()
 
+	var warnings := _record_user_messages()
 	var result = HFCarveSystem.new(root).carve_with_brush("cyl_carver")
 
 	assert_false(result.ok, "A cylinder carver has no axis-aligned volume to cut with")
+	assert_eq(warnings.size(), 1, "A refused carve has to say so, not look like a no-op")
 	assert_true(is_instance_valid(carver), "The carver must survive a refused carve")
 	assert_true(is_instance_valid(target), "The target must survive a refused carve")
 	assert_eq(draft_node.get_child_count(), child_count_before, "Nothing should be replaced")
@@ -414,9 +422,11 @@ func test_carve_rejects_non_box_target():
 	var target = _make_cylinder_brush(Vector3(16, 0, 0), Vector3(32, 32, 32), "cyl_target")
 	var child_count_before = draft_node.get_child_count()
 
+	var warnings := _record_user_messages()
 	var result = HFCarveSystem.new(root).carve_with_brush("box_carver")
 
 	assert_false(result.ok, "Carve cannot rebuild a cylinder as boxes")
+	assert_eq(warnings.size(), 1, "A refused carve has to say so, not look like a no-op")
 	assert_true(is_instance_valid(target), "The cylinder must not be deleted")
 	assert_true(is_instance_valid(carver), "The carver must survive a refused carve")
 	assert_eq(draft_node.get_child_count(), child_count_before, "Nothing should be replaced")

--- a/tests/test_bugfix_regressions.gd
+++ b/tests/test_bugfix_regressions.gd
@@ -376,6 +376,79 @@ func test_carve_thin_overlap_single_axis_produces_no_pieces():
 	)
 
 
+func _make_cylinder_brush(pos: Vector3, sz: Vector3, id: String) -> DraftBrush:
+	var b = _make_box_brush(pos, sz, id)
+	b.shape = DraftBrush.BrushShape.CYLINDER
+	return b
+
+
+func test_carve_rejects_non_box_carver():
+	var carver = _make_cylinder_brush(Vector3.ZERO, Vector3(32, 32, 32), "cyl_carver")
+	var target = _make_box_brush(Vector3(16, 0, 0), Vector3(32, 32, 32), "box_target")
+	var child_count_before = draft_node.get_child_count()
+
+	var result = HFCarveSystem.new(root).carve_with_brush("cyl_carver")
+
+	assert_false(result.ok, "A cylinder carver has no axis-aligned volume to cut with")
+	assert_true(is_instance_valid(carver), "The carver must survive a refused carve")
+	assert_true(is_instance_valid(target), "The target must survive a refused carve")
+	assert_eq(draft_node.get_child_count(), child_count_before, "Nothing should be replaced")
+
+
+func test_carve_rejects_rotated_carver():
+	var carver = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "rot_carver")
+	carver.rotation = Vector3(0, deg_to_rad(45.0), 0)
+	var target = _make_box_brush(Vector3(16, 0, 0), Vector3(32, 32, 32), "rot_target")
+	var child_count_before = draft_node.get_child_count()
+
+	var result = HFCarveSystem.new(root).carve_with_brush("rot_carver")
+
+	assert_false(result.ok, "A rotated carver's world bounds are not its size")
+	assert_true(is_instance_valid(carver), "The carver must survive a refused carve")
+	assert_true(is_instance_valid(target), "The target must survive a refused carve")
+	assert_eq(draft_node.get_child_count(), child_count_before, "Nothing should be replaced")
+
+
+func test_carve_rejects_non_box_target():
+	var carver = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "box_carver")
+	var target = _make_cylinder_brush(Vector3(16, 0, 0), Vector3(32, 32, 32), "cyl_target")
+	var child_count_before = draft_node.get_child_count()
+
+	var result = HFCarveSystem.new(root).carve_with_brush("box_carver")
+
+	assert_false(result.ok, "Carve cannot rebuild a cylinder as boxes")
+	assert_true(is_instance_valid(target), "The cylinder must not be deleted")
+	assert_true(is_instance_valid(carver), "The carver must survive a refused carve")
+	assert_eq(draft_node.get_child_count(), child_count_before, "Nothing should be replaced")
+
+
+func test_carve_rejects_rotated_target():
+	var carver = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "rt_carver")
+	var target = _make_box_brush(Vector3(16, 0, 0), Vector3(32, 32, 32), "rt_target")
+	target.rotation = Vector3(0, deg_to_rad(45.0), 0)
+	var child_count_before = draft_node.get_child_count()
+
+	var result = HFCarveSystem.new(root).carve_with_brush("rt_carver")
+
+	assert_false(result.ok, "Carve would replace a rotated box with world-aligned pieces")
+	assert_true(is_instance_valid(target), "The rotated box must not be deleted")
+	assert_eq(draft_node.get_child_count(), child_count_before, "Nothing should be replaced")
+
+
+func test_carve_refuses_before_carving_any_of_a_mixed_target_set():
+	var carver = _make_box_brush(Vector3.ZERO, Vector3(64, 32, 32), "mixed_carver")
+	var plain = _make_box_brush(Vector3(24, 0, 0), Vector3(32, 32, 32), "mixed_box")
+	var awkward = _make_cylinder_brush(Vector3(-24, 0, 0), Vector3(32, 32, 32), "mixed_cyl")
+	var child_count_before = draft_node.get_child_count()
+
+	var result = HFCarveSystem.new(root).carve_with_brush("mixed_carver")
+
+	assert_false(result.ok, "One unsuitable target refuses the whole carve")
+	assert_true(is_instance_valid(plain), "The box target must not be half carved")
+	assert_true(is_instance_valid(awkward), "The cylinder target must not be deleted")
+	assert_eq(draft_node.get_child_count(), child_count_before, "Nothing should be replaced")
+
+
 # ===========================================================================
 # Bug 4: Vertex input uses the view-aware, start-relative drag contract
 # ===========================================================================

--- a/tests/test_snap_system.gd
+++ b/tests/test_snap_system.gd
@@ -240,3 +240,112 @@ func test_non_preview_brush_still_snaps_with_preview_present():
 	_make_brush(Vector3(10, 0, 10), Vector3(4, 4, 4), "real1")
 	var result = snap.snap_point(Vector3(10.5, 0.5, 10.5), 0.0)
 	assert_eq(result, Vector3(10, 0, 10), "Should still snap to non-preview brushes")
+
+
+# ===========================================================================
+# Brush rotation and brush shape
+# ===========================================================================
+
+
+func _assert_vector_near(actual: Vector3, expected: Vector3, msg: String) -> void:
+	assert_almost_eq(actual.x, expected.x, 0.01, msg)
+	assert_almost_eq(actual.y, expected.y, 0.01, msg)
+	assert_almost_eq(actual.z, expected.z, 0.01, msg)
+
+
+func test_vertex_snap_follows_brush_rotation():
+	snap.set_mode(HFSnapSystem.SnapMode.VERTEX, true)
+	snap.set_mode(HFSnapSystem.SnapMode.GRID, false)
+	var b := _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "rot")
+	b.rotation = Vector3(0, deg_to_rad(45.0), 0)
+	# The (16, 16, 16) corner turns 45 degrees about Y onto the X axis.
+	var rotated_corner: Vector3 = b.global_transform * Vector3(16, 16, 16)
+	_assert_vector_near(rotated_corner, Vector3(22.627, 16, 0), "Fixture sanity")
+
+	var result: Vector3 = snap.snap_point(rotated_corner + Vector3(0.4, 0, 0.3), 0.0)
+
+	_assert_vector_near(result, rotated_corner, "Vertex snap should track the rotated corner")
+
+
+func test_vertex_snap_ignores_the_unrotated_corner_position():
+	snap.set_mode(HFSnapSystem.SnapMode.VERTEX, true)
+	snap.set_mode(HFSnapSystem.SnapMode.GRID, false)
+	var b := _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "rot2")
+	b.rotation = Vector3(0, deg_to_rad(45.0), 0)
+	# Nothing sits near (16, 16, 16) once the brush is turned. A query just off
+	# that spot used to be pulled onto a corner in empty air.
+	var query := Vector3(15.5, 15.5, 15.5)
+
+	assert_eq(snap.snap_point(query, 0.0), query, "There is no corner left at the world offset")
+
+
+func test_edge_snap_follows_brush_rotation():
+	snap.set_mode(HFSnapSystem.SnapMode.EDGE, true)
+	snap.set_mode(HFSnapSystem.SnapMode.GRID, false)
+	var b := _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "rot3")
+	b.rotation = Vector3(0, deg_to_rad(45.0), 0)
+	var midpoint: Vector3 = b.global_transform * Vector3(16, 0, 16)
+
+	var result: Vector3 = snap.snap_point(midpoint + Vector3(0.3, 0.2, 0.1), 0.0)
+
+	_assert_vector_near(result, midpoint, "Edge midpoints should turn with the brush")
+
+
+func test_vertex_snap_uses_face_vertices_not_the_size_box():
+	snap.set_mode(HFSnapSystem.SnapMode.VERTEX, true)
+	snap.set_mode(HFSnapSystem.SnapMode.GRID, false)
+	var b := _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "dented")
+	# A CUSTOM brush is described by its faces, the way a polygon, path or merged
+	# brush is. Pull one corner in: the brush still reports size 32, but no
+	# geometry reaches the old corner any more.
+	b.shape = DraftBrush.BrushShape.CUSTOM
+	for face in b.faces:
+		var updated := PackedVector3Array()
+		for v in face.local_verts:
+			updated.append(Vector3(4, 4, 4) if v.is_equal_approx(Vector3(16, 16, 16)) else v)
+		face.local_verts = updated
+		face.ensure_geometry()
+
+	_assert_vector_near(
+		snap.snap_point(Vector3(4.4, 4.2, 4.1), 0.0),
+		Vector3(4, 4, 4),
+		"The moved corner is a real vertex and should be a snap target"
+	)
+	assert_eq(
+		snap.snap_point(Vector3(16, 16, 16), 0.0),
+		Vector3(16, 16, 16),
+		"The corner the brush no longer has should not be a snap target"
+	)
+
+
+func test_tessellated_primitive_falls_back_to_its_bounding_box():
+	snap.set_mode(HFSnapSystem.SnapMode.VERTEX, true)
+	snap.set_mode(HFSnapSystem.SnapMode.GRID, false)
+	var b := _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "cyl")
+	b.shape = DraftBrush.BrushShape.CYLINDER
+	assert_gt(
+		b.faces.size(),
+		HFSnapSystem.MAX_SNAP_FACES,
+		"A cylinder carries one face per triangle, which is what the cap is for"
+	)
+
+	assert_eq(
+		snap.snap_point(Vector3(15.6, 15.6, 15.6), 0.0),
+		Vector3(16, 16, 16),
+		"Tessellated primitives keep the bounding box corners they always had"
+	)
+
+
+func test_bounding_box_fallback_still_follows_rotation():
+	snap.set_mode(HFSnapSystem.SnapMode.VERTEX, true)
+	snap.set_mode(HFSnapSystem.SnapMode.GRID, false)
+	var b := _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "cyl_rot")
+	b.shape = DraftBrush.BrushShape.CYLINDER
+	b.rotation = Vector3(0, deg_to_rad(45.0), 0)
+	var rotated_corner: Vector3 = b.global_transform * Vector3(16, 16, 16)
+
+	_assert_vector_near(
+		snap.snap_point(rotated_corner + Vector3(0.3, 0, 0.2), 0.0),
+		rotated_corner,
+		"The fallback box should be oriented, not world aligned"
+	)


### PR DESCRIPTION
Two issues with the same root cause: an operation reads a brush's world bounds off `global_position` and `size`, which only describes an unrotated box.

**#98 Carve** rebuilds what it cuts as axis-aligned boxes, so a rotated or non-box target came back as world-aligned rectangles, and a non-box carver cut with its bounding box. It now refuses both, using the same `_check_axis_aligned_box` that Hollow and Clip use. That check is static now so Carve can ask without holding an `HFBrushSystem`. Every target is checked before the first delete: carving some and refusing the rest would leave a half applied cut with nothing to show which brushes moved. The carve preview refuses the same cases instead of drawing pieces that will never exist.

**#100 Snap** built its candidates from world axis offsets, so every vertex and edge of a rotated brush sat in empty air. Candidates now go through the brush transform. A brush described by its own faces uses them, so a wedge, prism, polygon, path or merged brush snaps to real corners. Boxes short circuit to their size corners, which is the same answer for no cost. Brushes whose faces are engine tessellation, a cylinder is one face per triangle, keep the bounding box they always had, now oriented by the transform.

Full suite: 117 scripts, 1994 tests, 1987 passing, 0 failing.

Fixes #98
Fixes #100
