### PR TITLE
Bring the docs back in line with what the editor now does

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,7 +50,16 @@ addons/hammerforge/
   dock_visgroup_handler.gd Manage-tab visgroup/group/cordon handlers
   dock_file_handler.gd   File-dialog and import/export handlers
   dock_connections.gd    Settings and LevelRoot signal wiring
-  shortcut_hud.gd        Context-sensitive shortcut overlay (dynamic per mode) + persistent grid size indicator with flash-on-change
+  plugin_console.gd      Console main screen, dock tab icon, viewport lamp, and status-row action routing
+  hf_console_log.gd      HFConsoleLog: capped session log with levels, repeat collapsing, and a thread-safe append
+  hf_status_board.gd     HFStatusBoard: pure red/amber/green evaluation of eight level checks
+  ui/hf_console_panel.gd The Console itself (Status / Controls / Log) with tiered refresh
+  ui/hf_console_controls.gd  Every HammerForge switch, grouped, captioned, and written through the dock's own controls
+  ui/hf_console_log_view.gd  Log tab: level counts as filters, search, copy, save
+  ui/hf_status_row.gd    One board row: lamp, measurement, consequence, and the button that resolves it
+  ui/hf_status_lamp.gd   The lamp itself; the glyph is drawn, not set in a font
+  ui/hf_status_strip.gd  The same lamp in the 3D viewport toolbar, on a slower beat
+  shortcut_hud.gd        Single-row shortcut strip in the 3D toolbar (primary line per mode, full list on the tooltip) + grid size indicator with flash-on-change
   brush_instance.gd      DraftBrush node
   baker.gd               CSG -> mesh bake pipeline (per-face materials, atlas integration, snapshot-based non-blocking face bakes, convex collision shapes)
   hf_material_atlas.gd   HFMaterialAtlas: texture atlas packing for draw-call reduction
@@ -214,7 +223,8 @@ addons/hammerforge/
 - **Toast notifications.** Use `dock.show_toast(message, level)` (0=INFO, 1=WARNING, 2=ERROR) for user-facing messages. Subsystems can also emit `root.user_message.emit(text, level)` which the dock auto-routes to the toast system.
 - **Mode indicator.** Call `dock.set_mode_indicator(mode_name, stage_hint, numeric)` from `plugin.gd` to update the colored mode banner. `stage_hint` shows gesture progress (e.g. "Step 1/2: Draw base"), `numeric` shows typed input.
 - **First-run guide.** `ui/hf_tutorial_wizard.gd` presents the two-step Draw → Test Level path when `show_welcome` is true. It advances on `brush_added` and a successful `bake_finished`, persists `tutorial_step`, and can be reopened from Help. Dock `highlight_tab()` uses displayed tab aliases.
-- **Dynamic contextual hints.** `shortcut_hud.gd` shows per-mode viewport hints (e.g. "Click to place corner → drag to set size → release for height"). Hints auto-dismiss after 4s fade tween and persist dismissal via `is_hint_dismissed()`/`dismiss_hint()` on `hf_user_prefs.gd`. Mode key is computed from HUD context dict.
+- **Dynamic contextual hints.** `shortcut_hud.gd` shows per-mode viewport hints (e.g. "Click to place corner → drag to set size → release for height"). A hint replaces the shortcut line for the 4s of its fade tween rather than stacking under it, because the HUD is one row inside the 3D toolbar. Dismissal persists via `is_hint_dismissed()`/`dismiss_hint()` on `hf_user_prefs.gd`. Mode key is computed from HUD context dict.
+- **Toolbar layout.** Anything added to `CONTAINER_SPATIAL_EDITOR_MENU` is a child of a `BoxContainer`: it is positioned by the container, sized to its minimum, and its own anchors are ignored. A plain `Control` reports a minimum of zero, so it will be given a zero-width slot and draw over its neighbour. Report `_get_minimum_size()`. Overlays that need to cover the viewport instead set `z_index` (see `hf_radial_menu.gd`), because the 3D viewport is a later sibling and paints over anything that does not.
 - **Searchable shortcut dialog.** `ui/hf_shortcut_dialog.gd` extends `AcceptDialog` with a search `LineEdit` and `Tree`. Categories populated from `HFKeymap.get_category()`. Replaces the static shortcuts popup.
 - **Subtract preview.** `systems/hf_subtract_preview.gd` is a `RefCounted` subsystem. After a 0.15s debounce it CSG-intersects each subtract DraftBrush with overlapping additives (max 8 subtractors) and shows the cut volume as a translucent mesh. Mesh AABBs are the broad-phase and the immediate wireframe fallback. Toggle via `show_subtract_preview` on LevelRoot. Call `destroy()` (not `clear()`) when the subsystem is no longer needed.
 - **Undo/redo preview cleanup.** `plugin.gd` connects to `EditorUndoRedoManager.version_changed` and calls `HFInputState._force_reset()` for transient preview modes (drag, extrude, surface paint). This cascades through `_on_input_state_force_reset` to free preview nodes. VERTEX_EDIT is excluded because `commit_action()` fires `version_changed` after every vertex operation — resetting it would desync `_vertex_mode` from `input_state.mode`. `level_root.gd _exit_tree()` also calls `subtract_preview.destroy()`, `extrude_tool.cancel_extrude()`, and `drag_system._clear_preview()` to ensure preview nodes don't outlive the tree.
@@ -267,7 +277,7 @@ addons/hammerforge/
 The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs on push and PR to `main`:
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
-- **GUT unit + integration tests** -- 1,903 tests across 112 test scripts (1,896 passing plus seven intentional no-assert safety tests; 8,253 assertions; verified locally September 3, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 2,200 tests across 125 test scripts (2,193 passing plus seven intentional no-assert safety tests; 9,184 assertions; verified locally September 5, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -457,7 +457,8 @@ External tools expose `get_settings_schema()` → Array of `{name, type, label, 
 
 ## Editor UX
 - Theme-aware dock styling with comprehensive tooltips on all controls.
-- Context-sensitive shortcut HUD overlay (8 views: draw idle, dragging base, adjusting height, select, extrude idle, extruding active, floor paint, surface paint). Displays current axis lock. Updated via `plugin.gd` -> `shortcut_hud.gd:update_context()`.
+- **HammerForge Console** on its own main screen, reached from the switcher beside 2D / 3D / Script. Status (eight red/amber/green checks, each naming what was measured, the threshold, and the one action that resolves it), Controls (every switch, grouped and captioned, written through the dock's own controls), Log (HammerForge's own messages, level counts doubling as the filter). Severities come from `hf_status_board.gd`, whose `evaluate()` is pure. The overall lamp is repeated in the 3D viewport toolbar.
+- Context-sensitive shortcut HUD in the 3D viewport toolbar (8 contexts: draw idle, dragging base, adjusting height, select, extrude idle, extruding active, floor paint, surface paint). Shows the primary line for the context plus the current axis lock, with the full list on its tooltip. Updated via `plugin.gd` -> `shortcut_hud.gd:update_context()`.
 - **Customizable keyboard shortcuts** -- all bindings data-driven via `HFKeymap` JSON.
 - **Status bar mode indicator** -- shows active mode (Draw/Select/Extrude/Paint) with live state updates.
 - **Tool poll** -- buttons gray out with tooltip when action can't run (e.g. Hollow with no selection).
@@ -512,6 +513,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 38 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified locally on September 3, 2026): **1,903 tests** across **112 scripts** (**1,896 passing** plus seven intentional no-assert safety tests; **8,253 assertions**).
+Full suite (verified locally on September 5, 2026): **2,200 tests** across **125 scripts** (**2,193 passing** plus seven intentional no-assert safety tests; **9,184 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ HammerForge is a single `addons/` folder. No external tools, no custom builds, n
 
 | | |
 |---|---|
-| **Subsystem-based coordinator architecture** | **1,903 unit + integration tests** with CI on every push |
+| **Subsystem-based coordinator architecture** | **2,200 unit + integration tests** with CI on every push |
 | **15 brush shapes** (box through dodecahedron) | **150 built-in prototype textures** for instant greyboxing |
 | **Quake `.map`** + **glTF `.glb`** export | **.hflevel** native format with threaded I/O |
 | **Customizable keymaps** (JSON) | **Plugin API** for custom tools |
@@ -413,7 +413,7 @@ Shortcuts marked with **\*** are rebindable via `user://hammerforge_keymap.json`
 
 ## Testing
 
-The verified Godot 4.7 suite on September 3, 2026 contains **1,903 tests across 112 scripts**: **1,896 passing tests**, seven intentional no-assert safety tests, and **8,253 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 5, 2026 contains **2,200 tests across 125 scripts**: **2,193 passing tests**, seven intentional no-assert safety tests, and **9,184 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -263,7 +263,7 @@ Priorities are informed by a Hammer Editor gap analysis — see GAP_ANALYSIS.md 
 
 ## Done (Visual System Status — Classic Editor Feedback)
 - **Operation-coded wireframe colors (superseded by the July 2026 clarity pass)**: this release originally added green wireframe to additive brushes plus red/blue semantic overlays. Additive wireframe was later removed after user feedback; subtract/entity cues remain, and hover/selection now use structural edges only.
-- **Grid size viewport indicator**: persistent "Grid: N" label in shortcut HUD with `%g` exact formatting. Flash-on-change (bright yellow-white → fade 0.6s) via tween.
+- **Grid size viewport indicator**: persistent "Grid: N" label in the shortcut HUD. Whole numbers print as integers; fractional snaps print through `String.num()` with the padding zeros trimmed, since GDScript has no `%g`. Flash-on-change (bright yellow-white → fade 0.6s) via tween.
 - **Grid size hotkeys** (`[` / `]`): halve/double grid snap. Registered as `grid_decrease` / `grid_increase` in keymap (user-remappable). Clamped 0.125–512.
 - **Signal-driven HUD sync**: `grid_snap_applied` signal on dock ensures all grid change origins (SpinBox, snap buttons, quick-property, hotkeys, state restore) update the HUD.
 - **Test cleanup fixes**: resource leak fixes in test_brush_to_heightmap, test_context_toolbar, test_selection_features. Orphan/leak shutdown errors eliminated.
@@ -380,6 +380,41 @@ Not covered: `ORMMaterial3D` is still rejected whole (it was never atlased, so n
 Packing it would mean composing occlusion/roughness/metallic into one texture, which needs per-texel
 channel swizzling — the one operation with no native `Image` equivalent.
 
+## Done (HammerForge Console — September 2026)
+Nothing in the editor named HammerForge. The left dock's tab read **"Dock"** and carried no icon, the
+settings were split between a collapsed *Settings* section and an *Advanced Bake* section, and warnings
+went only to Godot's shared Output panel. There was nowhere to ask "is this level in a state I can bake
+and run".
+
+- **A main screen**, in the switcher beside 2D / 3D / Script, wearing the mark. That row is the only
+  part of the editor chrome that draws a plugin icon: Godot 4.7's bottom panel is text-only, and a
+  docked control's icon lives on the `EditorDock` wrapper behind `force_show_icon`. The switcher draws
+  the icon at its texture size, so `docs/brand/build.py` emits a 32px `hf_mark_editor.svg` for it.
+- **Status board** (`hf_status_board.gd`): eight checks as red / amber / green lamps — level root,
+  geometry budget, bake freshness, level check, material palette, player spawn, autosave, session log.
+  Each names what was measured, the threshold it is measured against, and the one action that resolves
+  it. Grey means "not measured", never a fault. `evaluate()` is pure, so every threshold is tested
+  without an editor. Lamps carry a drawn glyph as well as a hue.
+- **Controls tab** (`ui/hf_console_controls.gd`): every switch on one screen, grouped Viewport / Bake /
+  Safety net, captioned, and searchable by caption as well as by name. Written *through* the dock's own
+  controls, so the dock's handlers stay in charge of side effects and the two surfaces cannot disagree.
+- **Log tab** (`hf_console_log.gd`, `ui/hf_console_log_view.gd`): HammerForge's own messages, capped at
+  600 entries with repeat collapsing, BBCode escaping, and a deferred append from the bake thread pool.
+  `HFLog.warn()` and `LevelRoot`'s `user_message` signal both feed it. Level counts double as the filter.
+- **Viewport lamp** (`ui/hf_status_strip.gd`): the overall severity and summary in the 3D toolbar, on a
+  slower beat, reading the Console's own evaluation. A main screen is not visible while you build.
+- **Costs nothing idle**: the poll stops when the Console is off screen, only the visible tab is redrawn,
+  and the two reads that walk every brush and face run on a slower beat or on **Re-check**.
+- **Shortcut HUD layout faults found alongside**: it had never been laid out — a zero-minimum `Control`
+  in a `BoxContainer` toolbar, drawing seven lines out of a zero-width slot with six painted over by the
+  viewport and the seventh across the context toolbar; three labels sharing one `MarginContainer` rect;
+  and `%g`, which GDScript does not have, printing `Grid: %g` for every fractional snap.
+- 129 new tests across `test_console_log.gd`, `test_status_board.gd`, `test_console_panel.gd`, and
+  `test_shortcut_hud_layout.gd`, including drift guards that fail if a Controls switch stops addressing a
+  property `dock.gd` or `level_root.gd` declares. Total: **2,200 tests across 125 scripts**.
+- `tools/hf_console_preview.gd` renders the three tabs to PNGs so a layout change can be judged without
+  opening the editor.
+
 ## Future (Wave 3 -- Polish)
 - Multiple simultaneous cordons.
 - Multi-tool presets for common workflows.
@@ -423,7 +458,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 1,903 tests across 112 scripts, including the large brush, bake, paint, vertex, baker, brush-instance, and map-I/O systems. Remaining work is concentrated in failure semantics and scale-sensitive paths rather than wholly untested systems:
+The current suite covers 2,200 tests across 125 scripts, including the large brush, bake, paint, vertex, baker, brush-instance, and map-I/O systems. Remaining work is concentrated in failure semantics and scale-sensitive paths rather than wholly untested systems:
 - crash-safe destination replacement and truthful manual-save completion ([#33](https://github.com/saworbit/hammerforge/issues/33), [#51](https://github.com/saworbit/hammerforge/issues/51));
 - quoted `.map` property round-trips ([#32](https://github.com/saworbit/hammerforge/issues/32));
 - non-blocking threaded merge/finalization ([#35](https://github.com/saworbit/hammerforge/issues/35));

--- a/docs/HammerForge_Editor_Smoke_Checklist.md
+++ b/docs/HammerForge_Editor_Smoke_Checklist.md
@@ -574,9 +574,10 @@ It writes one PNG per tab under `user://console_preview/`.
 - Reopen a legacy scene that contains duplicated anonymous `BakedChunk_*` roots; confirm HammerForge retains the newest populated bake, removes only recognized duplicates, and leaves unrelated anonymous nodes untouched.
 
 ### 33. Grid Size Indicator and Hotkeys
-- With LevelRoot active, confirm the shortcut HUD (top-right) shows "Grid: 16" (or current snap value).
+- With LevelRoot active, confirm the shortcut HUD in the 3D viewport toolbar shows "Grid: 16" (or current snap value).
 - Change the grid snap via the dock SpinBox; confirm the HUD label updates and **flashes** briefly (yellow-white → fade).
 - Press **`]`**; confirm the grid doubles (e.g. 16 → 32) and the HUD flashes.
+- Set the snap to a fractional value (e.g. 0.125 via the dock SpinBox) and confirm the label reads "Grid: 0.125" rather than a format specifier.
 - Press **`[`**; confirm the grid halves (e.g. 32 → 16) and the HUD flashes.
 - Press **`[`** repeatedly until minimum (0.125); confirm it stops halving and displays "Grid: 0.125" exactly (not "0.13").
 - Press **`]`** repeatedly until maximum (512); confirm it stops doubling.

--- a/docs/HammerForge_Install_Upgrade.md
+++ b/docs/HammerForge_Install_Upgrade.md
@@ -14,8 +14,9 @@ This guide covers installing, upgrading, and recovering HammerForge for Godot 4.
 1. Copy `addons/hammerforge` into your project.
 2. Enable **HammerForge** in **Project → Project Settings → Plugins**.
 3. Open any 3D scene. In the empty-state banner, choose **Create Starter** for a floor, sunlight, and player spawn, or **Create Empty** for only `LevelRoot`.
-4. Verify the dock shows **Build**, **Paint**, **Objects**, and **Test**, with **Draw**, **Select**, **Paint**, **More**, and **Help** in the primary toolbar.
-5. Draw a brush, then use **Test → Test Level (Bake + Play)** to verify the complete workflow.
+4. Verify **HammerForge** appears in the main-screen switcher at the top of the editor, beside **2D**, **3D** and **Script**, wearing the HammerForge mark. Opening it shows the Console.
+5. Verify the left dock is titled **HammerForge** and shows **Build**, **Paint**, **Objects**, and **Test**, with **Draw**, **Select**, **Paint**, **More**, and **Help** in the primary toolbar.
+6. Draw a brush, then use **Test → Test Level (Bake + Play)** to verify the complete workflow.
 
 An intentional left-click with Draw active can create an empty root. Camera navigation, right-clicks, and other passive viewport input do not modify the scene.
 

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -1,15 +1,62 @@
 # HammerForge User Guide
 
-Last updated: September 3, 2026
+Last updated: September 5, 2026
 
 This guide covers the current HammerForge workflow in Godot 4.7: brush-based greyboxing, bake, entities, floor paint, and per-face materials/UVs.
 
 ## Quick Start
 1. Enable the plugin: Project -> Project Settings -> Plugins -> HammerForge.
-2. Open any 3D scene.
+2. Open any 3D scene. **HammerForge** now appears in the main-screen switcher at the top of the editor, beside 2D, 3D and Script, and the left dock is titled **HammerForge**.
 3. In the empty-state banner, click **Create Starter** to add a `LevelRoot`, floor, sunlight, and player spawn. Use **Create Empty** when you want only the root.
 4. In **Build**, choose **Draw** and drag in the viewport to set the base; click again to set the height.
 5. Open **Test** and click **Test Level (Bake + Play)**. HammerForge checks the spawn, bakes, and launches the playtest.
+
+If anything is not behaving, open the **Console** (the HammerForge entry in the switcher) and read the Status board. It is the fastest way to find out what is wrong and what fixes it.
+
+## HammerForge Console
+
+Open it from **HammerForge** in the main-screen switcher. The overall lamp also sits in the 3D viewport toolbar while you build; clicking it opens the Console.
+
+Three tabs.
+
+### Status
+
+Eight checks, each a red / amber / green lamp with what was measured, what it means, and the one button that resolves it.
+
+| Check | Green | Amber | Red |
+|---|---|---|---|
+| **Level root** | A `LevelRoot` is in the open scene | — | No `LevelRoot`, so every tool is inert — *Create Starter Level* |
+| **Geometry budget** | 50 brushes + entities or fewer | Above 50; bakes get slower | Above 100; dragging starts to stutter |
+| **Bake** | Baked meshes match the drafts | Never baked, or brushes edited since — *Bake Now* | — |
+| **Level check** | Scanned, no faults | 1–5 issues — *Check + Fix* | 6 or more |
+| **Material palette** | Materials loaded | Empty (fine for greyboxing) — *Load Palette* | Empty **and** face-material bake is on |
+| **Player spawn** | At least one spawn point | None, but auto-spawn is on — *Add Spawn Point* | None and auto-spawn is off |
+| **Autosave** | On, and a snapshot exists | Off, or nothing written yet — *Turn On* | — |
+| **Session log** | No warnings | Warnings this session — *Open Log* | Errors this session |
+
+A grey lamp means **not measured yet** — usually because no level is open. It is not a fault.
+
+Every lamp carries a shape as well as a colour (tick, exclamation, cross, dash), so the board reads the same with a red/green colour deficiency. Hover any row for the thresholds behind it. **Needs attention only** hides the checks that are already fine.
+
+The header carries the overall lamp, the live scope line (`Arena · 74 brushes · 9 entities · ~3120 verts · 256 KiB paint`), and when the board was last checked. Counts refresh once a second while the Console is open; the two measurements that walk the whole level refresh on a slower beat or when you press **Re-check**.
+
+### Controls
+
+Every HammerForge switch on one screen, grouped by what it affects:
+
+- **Viewport** — show grid, grid follows brush, shortcut HUD, power-user overlays, I/O connection lines, subtract preview, spawn debug, texture lock, cordon
+- **Bake** — merge meshes, LODs, unwrap UV0, lightmap UV2, face materials, navmesh, visible only, MultiMesh, material atlas, auto connectors, wire I/O, occluders, worker threads, freeze on commit, chunk size
+- **Safety net** — autosave (with interval and backups kept), compress saves, auto-spawn player, debug logging
+
+Each switch is captioned with what it does, and **Find a setting** searches those captions as well as the names, so "pathfinding" finds *Bake navmesh*. Turn **Descriptions** off to fit more on screen; the text stays on the tooltips. A switch with nowhere to write — no level open — is disabled rather than shown at a made-up default.
+
+These are the same settings as **Test → Settings** and **Test → Advanced Bake** in the dock. The Console writes through the dock's own controls, so the two always agree.
+
+### Log
+
+HammerForge's own messages, separate from Godot's Output panel where every addon's output is mixed together. The level buttons show how many of each arrived this session and double as the filter — click **Errors 2** to see just those two. **Follow** keeps the newest line in view, and **Copy** / **Save…** take whatever is currently shown.
+
+A message that repeats collapses to one row with a count (`(x4)`) rather than filling the buffer. The buffer holds the most recent 600 entries; the footer says how many older ones were dropped.
 
 ## Viewport Mouse Controls
 
@@ -622,7 +669,11 @@ For full details, see `docs/HammerForge_Data_Portability.md`.
 For install steps, upgrade guidance, and cache reset help, see `docs/HammerForge_Install_Upgrade.md`.
 
 ## Shortcut HUD
-The on-screen shortcut overlay updates dynamically based on your current tool and mode. Toggle it via the Show HUD checkbox in the Test tab → Settings section. It shows:
+A single-row strip in the 3D viewport toolbar, next to the Console lamp. It updates with your current tool and mode, and shows the **primary line** for that context plus the grid size indicator; the full list for the context is on its tooltip. When a contextual hint is active it takes the row for the four seconds of its fade, because the toolbar is one row high.
+
+Toggle it with **Show HUD** — in the Console's Controls tab, or in the dock under Test → Settings.
+
+The contexts and what their full lists cover:
 
 | Context | Shortcuts Shown |
 |---------|----------------|
@@ -638,7 +689,9 @@ The on-screen shortcut overlay updates dynamically based on your current tool an
 | Polygon Tool | Click to place verts, Enter: close, Escape: remove last |
 | Path Tool | Click to place waypoints, Enter: finalize, Escape: remove last |
 
-The HUD also shows current axis lock state (e.g. "[X Locked]").
+The HUD also shows current axis lock state (e.g. "[X Locked]"), and a **Grid: N** indicator that flashes when the snap changes. Fractional snaps display exactly (`Grid: 0.125`).
+
+The full list is also available two other ways: the searchable shortcut dialog (**?** button in the dock toolbar) and the command palette (**Ctrl+K**).
 
 ## Customizable Keyboard Shortcuts
 


### PR DESCRIPTION
## Summary

Documentation only — no `.gd` files change.

Two kinds of drift.

**The one #108 caused.** The Console, the main screen, the viewport lamp and the shortcut HUD row landed with the README, CHANGELOG, `BRAND.md` and the smoke checklist updated, but the rest of the repo still described the editor as it was:

- **`docs/HammerForge_UserGuide.md`** never mentioned the Console at all. That matters most — the Console is the front door now, and the guide is what someone reads before they open the editor. It gains a section covering all three tabs, including a table of what each of the eight checks means at green / amber / red and which button resolves it, and its Quick Start points at the Console when something is not behaving. Its *Shortcut HUD* section described a multi-line overlay toggled from the Test tab; the HUD is a single row in the 3D toolbar now, with the full list on its tooltip.
- **`DEVELOPMENT.md`** gains the ten new modules in its inventory, and a note about the container everything added to `CONTAINER_SPATIAL_EDITOR_MENU` lives in — that it sizes children to their minimum and ignores their anchors, and that covering the viewport needs `z_index`. That is the fact behind the shortcut HUD bug in `a349adf`, and it is not obvious from the API.
- **`HammerForge_SPEC.md`** gains the Console and corrects the HUD entry.
- **`ROADMAP.md`** records the wave, and its "Grid: N" entry no longer claims `%g` formatting, which GDScript has never had.
- **`docs/HammerForge_Install_Upgrade.md`** has the reader check for the switcher entry and the dock title, since "the dock appears" is no longer the whole story.
- **`docs/HammerForge_Editor_Smoke_Checklist.md`** checks a fractional grid snap.

**The one that predates it.** The test totals in `README.md`, `DEVELOPMENT.md`, `HammerForge_SPEC.md` and `ROADMAP.md` all still said **1,903 tests across 112 scripts** — already about 170 tests stale before #108 landed. CONTRIBUTING asks specifically that these not be copied forward from an older document, so all four now read **2,200 across 125 scripts**, verified locally on 5 September 2026.

## Before / After Behavior

No user-visible behavior change — this is documentation catching up with `#108`.

- Before: the user guide described an editor with no Console and a multi-line HUD overlay; four documents advertised a test suite ~300 tests smaller than the one that runs; the roadmap credited a `%g` format specifier that does not exist in GDScript.
- After: the guide documents the Console as the front door and the HUD as it now behaves, the totals match the suite, and the roadmap says what the code does.

**Known limitation, stated plainly:** `README.md` still points at **Test → Settings** for *Power-user overlays* in two places, rather than the Console's Controls tab. That is deliberate — `POWER_USER_OVERLAYS_HINT` in `plugin.gd` says exactly that, and `test_core_loop_overlays.gd` asserts it, so changing the docs alone would put them out of step with what the editor tells you. Worth doing as one change to code, hint and docs together, not here.

## Related Issue

Follow-up to #108.

## Checks

- [x] `gdformat --check addons/hammerforge/` passes — 157 files unchanged
- [x] `gdlint addons/hammerforge/` passes — no problems found
- [x] `godot --headless -s res://addons/gut/gut_cmdln.gd --path .` passes — 125 scripts, 2,200 tests, 2,193 passing, 0 failing, 7 pre-existing risky
- [x] Docs updated together where behavior changed — this PR *is* that
- [x] `git diff --check` is clean and relative Markdown links resolve — checked every link in all 17 Markdown files
- [x] No MCP tokens, `user://` settings, verification logs, editor screenshots, or local client overrides committed
- [x] `addons/godot_mcp` left untouched
