### PR TITLE
Point the power-user overlay toast at both places that carry the switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   an engine error alongside it.
 
 ### Changed
+- **The power-user overlay toast names both places that can turn them on.** The
+  switch lives in the Console's Controls tab and in the dock under
+  Test -> Settings; the toast pointed only at the dock, which was the whole
+  story before the Console existed. The user guide documented the radial menu,
+  coach marks and the replay timeline without mentioning they are opt-in at all,
+  so pressing the documented key produced a toast instead of the feature.
 - **HammerForge is findable in the editor.** It now takes a place in the
   main-screen switcher with its own mark — the one row of the editor chrome that
   draws a plugin icon at all. Godot 4.7's bottom panel is text-only, and a docked

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The default editor is the five-step greybox path. Extra overlays stay off until 
 4. **Bake**
 5. **Test Level**
 
-Turn on **Test → Settings → Power-user overlays** for the radial menu, coach marks, and operation replay timeline. Command palette, context toolbar, tutorial, Space context menu, and HUD stay available either way.
+Turn on **Power-user overlays** for the radial menu, coach marks, and operation replay timeline — in the Console's **Controls** tab, or in the dock under **Test → Settings**. Command palette, context toolbar, tutorial, Space context menu, and HUD stay available either way.
 
 ## Editor UX
 
@@ -262,7 +262,7 @@ HammerForge's dock is designed to stay out of your way while keeping everything 
 - **Command palette** (Shift+? or F1 or Ctrl+K) -- searchable action palette with fuzzy search, "Did you mean" suggestions, and live gray-out for unavailable actions
 - **Viewport context menu** (Space) -- context-sensitive right-click-style menu with grid snap presets, UV operations, draw shapes, and toggle items; sections adapt to current selection
 - **Predictable camera navigation** -- plain RMB always controls Godot's 3D camera while HammerForge is idle, regardless of selection or persistent tool mode; while held, native WASD flight and mixed mouse input cannot trigger HammerForge actions. Only an active gesture or modal interaction may consume the initial press
-- **Radial menu** (`` ` ``, opt-in) -- 8-sector pie menu for quick tool switching (Box, Cylinder, Select, Paint, Vertex, Tex Pick, Measure, Clip). Enable **Power-user overlays** in Test → Settings
+- **Radial menu** (`` ` ``, opt-in) -- 8-sector pie menu for quick tool switching (Box, Cylinder, Select, Paint, Vertex, Tex Pick, Measure, Clip). Enable **Power-user overlays** in the Console's Controls tab or Test → Settings
 - **Quick property popups** (double-tap G G / B B / R R) -- inline numeric entry for grid snap, brush size, and paint radius without leaving the viewport
 - **Grid size indicator** -- persistent "Grid: N" display in viewport HUD with flash-on-change feedback; `[` / `]` keys halve/double grid snap instantly
 - **Coach marks** (opt-in) -- first-use step-by-step guides for advanced tools (Polygon, Path, Carve, Vertex, Extrude, etc.) with "Don't show again" persistence

--- a/addons/hammerforge/plugin.gd
+++ b/addons/hammerforge/plugin.gd
@@ -54,7 +54,13 @@ var _focus_recovery_queued := false
 var _applying_hf_selection := false
 var _face_mode_saved_object_selection: Array = []
 const SELECT_DRAG_THRESHOLD := 6.0
-const POWER_USER_OVERLAYS_HINT := "Enable Power-user overlays in Test → Settings"
+## Two places carry this switch, and the toast names both. The dock is the
+## shorter trip from the viewport the reader just pressed a key in; the
+## Console is where every other HammerForge setting now lives.
+const POWER_USER_OVERLAYS_HINT := (
+	"Power-user overlays are off \u2014 turn them on in Test \u2192 Settings,"
+	+ " or the Console's Controls tab"
+)
 var last_3d_camera: Camera3D = null
 var last_3d_mouse_pos := Vector2.ZERO
 var _rmb_camera_navigation := HFPluginViewportInput.RmbCameraNavigationSession.new()

--- a/docs/HammerForge_Editor_Smoke_Checklist.md
+++ b/docs/HammerForge_Editor_Smoke_Checklist.md
@@ -79,8 +79,9 @@ It writes one PNG per tab under `user://console_preview/`.
 
 ### 0. Core Loop Default
 - Confirm the dock leads with **Test Level** on the Test tab.
-- Confirm **Test → Settings → Power-user overlays** is unchecked on a fresh prefs file.
-- Press backtick and Ctrl+Shift+T. Confirm a toast tells you to enable Power-user overlays rather than opening the radial menu or replay timeline.
+- Confirm **Power-user overlays** is unchecked on a fresh prefs file, both in **Test → Settings** and in the Console's **Controls** tab.
+- Press backtick and Ctrl+Shift+T. Confirm a toast names **both** places to turn them on, rather than opening the radial menu or replay timeline.
+- Turn them on from the Console's Controls tab and confirm the dock checkbox follows, then confirm the radial menu opens.
 - Enable the checkbox, then confirm the radial menu and replay timeline work. Disable it again and confirm they disappear.
 - Confirm **Subtract Preview** is the subtract-preview checkbox label.
 

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -106,6 +106,8 @@ Use **Don't show at startup** to hide it on future launches. Reopen or restart t
 
 ## Coach Marks (First-Use Tool Guides)
 
+**Opt-in.** This is one of the power-user overlays, off by default so the core loop stays quiet. Turn on **Power-user overlays** in the Console's **Controls** tab, or in the dock under **Test -> Settings**.
+
 When you activate an advanced tool for the first time, a floating overlay appears with step-by-step instructions. Coach marks are available for 10 tools:
 
 | Tool | Trigger | Steps shown |
@@ -124,6 +126,8 @@ When you activate an advanced tool for the first time, a floating overlay appear
 Each guide has a "Don't show again" checkbox. Dismissed guides are persisted in user prefs. Guides trigger from keyboard shortcuts, the command palette, and context toolbar actions.
 
 ## Operation Replay Timeline
+
+**Opt-in.** This is one of the power-user overlays, off by default so the core loop stays quiet. Turn on **Power-user overlays** in the Console's **Controls** tab, or in the dock under **Test -> Settings**.
 
 Press **Ctrl+Shift+T** to toggle a compact timeline showing your recent operations (up to 20). Each operation appears as a color-coded icon:
 
@@ -515,6 +519,9 @@ The menu only activates when idle (no active drag, paint, or external tool opera
 With a mixed HammerForge/Godot selection, managed selection commands are unavailable. The final context-menu action handler also checks again before editing, so stale menu state cannot produce a partial change.
 
 ### Radial Menu
+
+**Opt-in.** This is one of the power-user overlays, off by default so the core loop stays quiet. Turn on **Power-user overlays** in the Console's **Controls** tab, or in the dock under **Test -> Settings**.
+
 Press **`` ` ``** (backtick) to open an 8-sector pie menu centered on the cursor. Move the mouse to highlight a sector, then left-click to select:
 
 | Sector | Action |

--- a/tests/test_core_loop_overlays.gd
+++ b/tests/test_core_loop_overlays.gd
@@ -4,6 +4,7 @@ extends GutTest
 const HammerForgePlugin = preload("res://addons/hammerforge/plugin.gd")
 const HFPluginOverlays = preload("res://addons/hammerforge/plugin_overlays.gd")
 const HFUserPrefsType = preload("res://addons/hammerforge/hf_user_prefs.gd")
+const HFConsoleControlsType = preload("res://addons/hammerforge/ui/hf_console_controls.gd")
 
 
 func test_should_install_overlays_false_without_prefs():
@@ -22,10 +23,36 @@ func test_should_install_overlays_follows_pref():
 	assert_true(HammerForgePlugin.should_install_power_user_overlays(prefs))
 
 
-func test_unavailable_overlay_hint_points_at_settings():
+func test_unavailable_overlay_hint_names_both_places_that_carry_the_switch():
+	# The toast is the only thing the reader has to go on after a key press did
+	# nothing, so it names the dock — the shorter trip from the viewport — and
+	# the Console, where every other HammerForge setting now lives.
 	var hint := HammerForgePlugin.power_user_overlay_unavailable_message()
 	assert_string_contains(hint, "Power-user overlays")
 	assert_string_contains(hint, "Settings")
+	assert_string_contains(hint, "Console")
+
+
+func test_the_console_really_does_carry_the_switch_the_hint_points_at():
+	# If the toggle is ever dropped from the Controls tab, the toast starts
+	# sending people somewhere it is not.
+	var found := false
+	for group in HFConsoleControlsType.GROUPS:
+		for spec in group["rows"]:
+			if str(spec.get("pref", "")) == "power_user_overlays":
+				found = true
+	assert_true(found, "The hint points at the Console's Controls tab")
+
+
+func test_the_dock_really_does_carry_the_switch_the_hint_points_at():
+	var source := FileAccess.get_file_as_string(
+		"res://addons/hammerforge/ui/manage_tab_builder.gd"
+	)
+	assert_string_contains(
+		source,
+		'_make_check("Power-user overlays"',
+		"The hint points at Test -> Settings in the dock"
+	)
 
 
 func test_overlay_callbacks_delegate_to_the_overlay_module():


### PR DESCRIPTION
## Summary

The loose end from #109, done as one change to code, hint and docs rather than docs alone.

Press `` ` `` without the overlays enabled and the toast said **"Enable Power-user overlays in Test → Settings"**. That was the whole story until the Console landed; the switch now also sits in its **Controls** tab. The toast is the only thing a reader has to go on after a key press did nothing, so it names both — the dock first, because it is the shorter trip from the viewport they just pressed a key in, and the Console second, because that is where every other HammerForge setting now lives.

Looking at it turned up something worse than an out-of-date string. **`docs/HammerForge_UserGuide.md` documents the radial menu, coach marks and the operation replay timeline as if they are always available** — "Press `` ` `` to open an 8-sector pie menu". All three are opt-in behind `power_user_overlays`, and none of those three sections said so, so a reader following the guide got a toast instead of the feature. Each section now opens by saying it is opt-in and where the switch is.

Two drift guards go in beside the existing wording test, because a hint that names a place is only useful while the switch is still there: one asserts the Controls tab still carries a `power_user_overlays` row, the other that `manage_tab_builder.gd` still builds its **Power-user overlays** checkbox.

## Before / After Behavior

- **Before:** the toast named only the dock. The user guide described three opt-in features as though they were always on, with no mention of the switch; following it produced a toast rather than the feature.
- **After:** the toast reads *"Power-user overlays are off — turn them on in Test → Settings, or the Console's Controls tab"*. All three user-guide sections lead with an opt-in note naming both places, and README's two references name both.

Nothing changes about when the overlays install, what they do, or the default (still off — the core-loop freeze in `should_install_power_user_overlays()` is untouched).

**Checked rather than assumed:** the toast's `Label` already sets `AUTOWRAP_WORD`, so the longer message wraps inside its panel instead of overflowing.

## Related Issue

Follow-up to #108 and #109.

## Checks

- [x] `gdformat --check addons/hammerforge/` passes — 157 files unchanged
- [x] `gdlint addons/hammerforge/` passes — no problems found
- [x] `godot --headless -s res://addons/gut/gut_cmdln.gd --path .` passes — 125 scripts, 2,202 tests, 2,195 passing, 0 failing, 7 pre-existing risky
- [x] Docs updated together where behavior changed — README, user guide, smoke checklist, and `[Unreleased]` in CHANGELOG, in the same commit as the string they describe
- [x] `git diff --check` is clean and relative Markdown links resolve
- [x] No MCP tokens, `user://` settings, verification logs, editor screenshots, or local client overrides committed
- [x] `addons/godot_mcp` left untouched
