### PR TITLE
Keep the menu path intact when the overlay toast wraps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,11 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 - **The power-user overlay toast names both places that can turn them on.** The
   switch lives in the Console's Controls tab and in the dock under
   Test -> Settings; the toast pointed only at the dock, which was the whole
-  story before the Console existed. The user guide documented the radial menu,
-  coach marks and the replay timeline without mentioning they are opt-in at all,
-  so pressing the documented key produced a toast instead of the feature.
+  story before the Console existed. The menu path inside it is joined with
+  non-breaking spaces so the toast never wraps between "Test" and "Settings" and
+  leaves the arrow dangling at a line end. The user guide documented the radial
+  menu, coach marks and the replay timeline without mentioning they are opt-in at
+  all, so pressing the documented key produced a toast instead of the feature.
 - **HammerForge is findable in the editor.** It now takes a place in the
   main-screen switcher with its own mark — the one row of the editor chrome that
   draws a plugin icon at all. Godot 4.7's bottom panel is text-only, and a docked

--- a/addons/hammerforge/plugin.gd
+++ b/addons/hammerforge/plugin.gd
@@ -57,9 +57,11 @@ const SELECT_DRAG_THRESHOLD := 6.0
 ## Two places carry this switch, and the toast names both. The dock is the
 ## shorter trip from the viewport the reader just pressed a key in; the
 ## Console is where every other HammerForge setting now lives.
+## The menu path is joined with non-breaking spaces so the toast never wraps
+## between "Test" and "Settings" and leaves the arrow dangling at a line end.
 const POWER_USER_OVERLAYS_HINT := (
-	"Power-user overlays are off \u2014 turn them on in Test \u2192 Settings,"
-	+ " or the Console's Controls tab"
+	"Power-user overlays are off \u2014 turn them on in"
+	+ " Test\u00a0\u2192\u00a0Settings, or the Console's Controls tab"
 )
 var last_3d_camera: Camera3D = null
 var last_3d_mouse_pos := Vector2.ZERO


### PR DESCRIPTION
## Summary

Follow-up to #110, from actually looking at the toast it changed.

Rendering the real `HFToast` widget with the real `POWER_USER_OVERLAYS_HINT` at the dock's width put the line break between **"Test"** and **"Settings"** — the arrow dangled at the end of the first line and a menu path the reader is meant to follow was split across two. Joining that path with non-breaking spaces moves the break to the sentence instead.

One string constant and the CHANGELOG bullet that already describes it. The label's `AUTOWRAP_WORD` was never the problem; *where* it chose to break was.

## Before / After Behavior

- **Before:** `Power-user overlays are off — turn them on in Test →` / `Settings, or the Console's Controls tab`
- **After:** `Power-user overlays are off — turn them on in` / `Test → Settings, or the Console's Controls tab`

Same message, same length, same wrapping behaviour — only the break point moves. Nothing else about the toast, the overlays, or their default changes.

## Related Issue

Follow-up to #110.

## Checks

- [x] `gdformat --check addons/hammerforge/` passes — 157 files unchanged
- [x] `gdlint addons/hammerforge/` passes — no problems found
- [x] `godot --headless -s res://addons/gut/gut_cmdln.gd --path .` passes — 125 scripts, 2,202 tests, 2,195 passing, 0 failing, 7 pre-existing risky
- [x] Docs updated together where behavior changed — the `[Unreleased]` bullet describing this toast now mentions the non-breaking path, in the same commit
- [x] `git diff --check` is clean and relative Markdown links resolve
- [x] No MCP tokens, `user://` settings, verification logs, editor screenshots, or local client overrides committed
- [x] `addons/godot_mcp` left untouched

**How this was verified, and how it was not.** The toast fires from a keypress in the 3D viewport, and simulating that keypress on this machine is blocked by Windows Defender — the script was rejected as malicious content, and working around that is not something to do for a screenshot. Instead the widget itself was rendered offscreen with the constant read from the loaded script, which is what surfaced the bad break in the first place. The keypress path itself stays covered by `test_core_loop_overlays.gd`.
