### PR TITLE
Fix box face pairing on map export and bevel corner cap winding

### DIFF
--- a/addons/hammerforge/map_io.gd
+++ b/addons/hammerforge/map_io.gd
@@ -354,7 +354,10 @@ static func _box_to_map_lines(brush: DraftBrush, adapter: HFMapAdapterType = nul
 	]
 	for i in range(corners.size()):
 		corners[i] = brush.global_transform * corners[i]
-	var face_indices = [[0, 3, 2], [5, 6, 7], [1, 2, 6], [0, 4, 7], [3, 7, 6], [0, 1, 5]]
+	# Same order as DraftBrush._build_box_faces: Right, Left, Top, Bottom, Front, Back.
+	# brush.faces is indexed with the same counter below, so the two must agree or
+	# every plane is written with another face's texture and UV settings.
+	var face_indices = [[1, 2, 6], [0, 4, 7], [3, 7, 6], [0, 1, 5], [5, 6, 7], [0, 3, 2]]
 	var brush_faces = brush.faces
 	for fi in range(face_indices.size()):
 		var face = face_indices[fi]

--- a/addons/hammerforge/systems/hf_bevel_system.gd
+++ b/addons/hammerforge/systems/hf_bevel_system.gd
@@ -104,25 +104,15 @@ func bevel_edge(brush_id: String, edge: Array, segments: int = 2, radius: float 
 		bevel_face.uv_rotation = face0.uv_rotation
 		bevel_face.ensure_geometry()
 		new_faces.append(bevel_face)
-	# Build corner cap triangle fans at each endpoint to close the gap
-	# between the two pulled-back positions and the bevel arc.
-	# At endpoint va: the arc goes from new_va0 (= arc_verts_a[0]) to
-	# new_va1 (= arc_verts_a[segments]). We fan from the original corner
-	# toward the center to fill the hole.
+	# Build corner cap triangle fans at each endpoint to close the gap between
+	# the two pulled-back positions and the bevel arc. The endpoints sit at
+	# opposite ends of the edge, so their caps face opposite ways. The arcs are
+	# translated copies of each other, so one fixed winding would point both
+	# caps the same way and turn the vb cap inward. Wind each cap against the
+	# direction that leads away from the edge instead.
 	if segments >= 1:
-		for endpoint_arc in [arc_verts_a, arc_verts_b]:
-			for i in range(segments - 1):
-				var cap = FaceData.new()
-				# Fan from the first arc point through the intermediate arc points.
-				# CW winding from outside: arc[0] → arc[i+2] → arc[i+1]
-				cap.local_verts = PackedVector3Array(
-					[endpoint_arc[0], endpoint_arc[i + 2], endpoint_arc[i + 1]]
-				)
-				cap.material_idx = face0.material_idx
-				cap.uv_projection = face0.uv_projection
-				cap.uv_scale = face0.uv_scale
-				cap.ensure_geometry()
-				new_faces.append(cap)
+		_append_endpoint_caps(new_faces, arc_verts_a, -edge_dir, face0, segments)
+		_append_endpoint_caps(new_faces, arc_verts_b, edge_dir, face0, segments)
 	# Update neighboring faces that share va or vb but are not face0/face1.
 	# Each neighbor is assigned to the side (face0 or face1) whose normal it
 	# is closer to, and its copy of va/vb is replaced with the corresponding
@@ -287,6 +277,35 @@ func _compute_centroid(verts: PackedVector3Array) -> Vector3:
 	if verts.size() > 0:
 		c /= float(verts.size())
 	return c
+
+
+## Fan the arc at one edge endpoint into triangles that face `outward`.
+## All arc points lie in a plane perpendicular to the edge, so the fan normal is
+## parallel to the edge axis and a single dot product settles the winding.
+func _append_endpoint_caps(
+	out_faces: Array[FaceData],
+	arc: PackedVector3Array,
+	outward: Vector3,
+	source_face: FaceData,
+	segments: int
+) -> void:
+	for i in range(segments - 1):
+		var a: Vector3 = arc[0]
+		var b: Vector3 = arc[i + 2]
+		var c: Vector3 = arc[i + 1]
+		# FaceData computes its normal as (c - a) x (b - a). Swapping b and c
+		# flips it, which is all a cap fan needs to change sides.
+		if (c - a).cross(b - a).dot(outward) < 0.0:
+			var swap: Vector3 = b
+			b = c
+			c = swap
+		var cap = FaceData.new()
+		cap.local_verts = PackedVector3Array([a, b, c])
+		cap.material_idx = source_face.material_idx
+		cap.uv_projection = source_face.uv_projection
+		cap.uv_scale = source_face.uv_scale
+		cap.ensure_geometry()
+		out_faces.append(cap)
 
 
 ## Compute arc vertices from `origin` sweeping from `dir0` to `dir1`

--- a/tests/test_bevel.gd
+++ b/tests/test_bevel.gd
@@ -192,6 +192,41 @@ func test_bevel_edge_basic():
 	assert_eq(brush.faces.size(), face_count_before + 4, "Two-segment bevel should add 4 faces")
 
 
+func test_bevel_edge_corner_caps_face_outward():
+	var brush = _make_box_brush()
+	var face_count_before: int = brush.faces.size()
+	# Unique vertex 0 = (0,16,0), 3 = (0,16,16). The edge runs along Z, so the
+	# cap at (0,16,0) must face -Z and the cap at (0,16,16) must face +Z.
+	assert_true(sys.bevel_edge("box_brush", [0, 3], 2, 2.0))
+	assert_eq(brush.faces.size(), face_count_before + 4)
+	var cap_a: FaceData = brush.faces[face_count_before + 2]
+	var cap_b: FaceData = brush.faces[face_count_before + 3]
+	assert_almost_eq(cap_a.normal.z, -1.0, 0.001, "Cap at Z=0 must face -Z")
+	assert_almost_eq(cap_b.normal.z, 1.0, 0.001, "Cap at Z=16 must face +Z")
+	assert_almost_eq(
+		cap_a.normal.dot(cap_b.normal), -1.0, 0.001, "Endpoint caps must oppose each other"
+	)
+
+
+func test_bevel_edge_corner_caps_point_away_from_edge_centre():
+	# Same check on an X-aligned edge, so a fix that only hard-codes the Z case
+	# cannot pass. Unique vertices 0 = (0,16,0) and 1 = (16,16,0).
+	var brush = _make_box_brush()
+	var face_count_before: int = brush.faces.size()
+	assert_true(sys.bevel_edge("box_brush", [0, 1], 3, 2.0))
+	var caps: Array[FaceData] = []
+	for i in range(face_count_before + 3, brush.faces.size()):
+		caps.append(brush.faces[i])
+	assert_eq(caps.size(), 4, "Three segments produce two caps per endpoint")
+	for cap in caps:
+		var away: Vector3 = cap.local_verts[0] - Vector3(8, 16, 0)
+		assert_gt(
+			cap.normal.dot(away.normalized()),
+			0.0,
+			"Every cap normal must point away from the edge midpoint"
+		)
+
+
 func test_bevel_edge_bad_brush():
 	var ok: bool = sys.bevel_edge("nonexistent", [0, 1])
 	assert_false(ok)

--- a/tests/test_map_export.gd
+++ b/tests/test_map_export.gd
@@ -351,6 +351,66 @@ func is_entity_node(_n):
 	return root
 
 
+func _plane_lines(text: String) -> Array[String]:
+	var out: Array[String] = []
+	for line in text.split("\n"):
+		var trimmed := line.strip_edges()
+		if trimmed.begins_with("( "):
+			out.append(trimmed)
+	return out
+
+
+func _plane_axis_key(line: String) -> String:
+	var points: Array[Vector3] = []
+	var rest := line
+	for _i in range(3):
+		var open_at := rest.find("(")
+		var close_at := rest.find(")", open_at)
+		var body := rest.substr(open_at + 1, close_at - open_at - 1).strip_edges()
+		var parts := body.split(" ", false)
+		points.append(Vector3(float(parts[0]), float(parts[1]), float(parts[2])))
+		rest = rest.substr(close_at + 1)
+	if is_equal_approx(points[0].x, points[1].x) and is_equal_approx(points[1].x, points[2].x):
+		return "+x" if points[0].x > 0.0 else "-x"
+	if is_equal_approx(points[0].y, points[1].y) and is_equal_approx(points[1].y, points[2].y):
+		return "+y" if points[0].y > 0.0 else "-y"
+	return "+z" if points[0].z > 0.0 else "-z"
+
+
+func _plane_u_offset(line: String) -> float:
+	var open_at := line.find("[")
+	var close_at := line.find("]", open_at)
+	var body := line.substr(open_at + 1, close_at - open_at - 1).strip_edges()
+	return float(body.split(" ", false)[3])
+
+
+func test_box_face_data_exports_onto_its_own_plane():
+	var brush := DraftBrush.new()
+	brush.shape = LevelRoot.BrushShape.BOX
+	brush.size = Vector3(32, 32, 32)
+	var root := _make_export_root([brush])
+	assert_eq(brush.faces.size(), 6, "Adding the box to the tree builds its six faces")
+	# One recognisable U offset per face, in _build_box_faces order.
+	for i in range(brush.faces.size()):
+		brush.faces[i].uv_offset = Vector2(float(i + 1) * 8.0, 0.0)
+	var text := MapIO.export_map_from_level(root, HFMapValve220.new())
+	var lines := _plane_lines(text)
+	assert_eq(lines.size(), 6, "A box exports six planes")
+	# _build_box_faces order: Right, Left, Top, Bottom, Front, Back.
+	var expected := {"+x": 8.0, "-x": 16.0, "+y": 24.0, "-y": 32.0, "+z": 40.0, "-z": 48.0}
+	var seen := {}
+	for line in lines:
+		var key := _plane_axis_key(line)
+		seen[key] = true
+		assert_almost_eq(
+			_plane_u_offset(line),
+			float(expected[key]),
+			0.001,
+			"Plane %s must carry the UV offset of the face with that normal" % key
+		)
+	assert_eq(seen.size(), 6, "Every box plane must be exported exactly once")
+
+
 func test_export_writes_func_detail_as_own_entity_block():
 	var world := DraftBrush.new()
 	world.shape = LevelRoot.BrushShape.BOX


### PR DESCRIPTION
Two box face bugs in the brush geometry layer.

Fixes #113. `MapIO._box_to_map_lines` walked its plane table with the same counter it used to index `brush.faces`, but the two tables were in different orders. Reordered the plane table to match `DraftBrush._build_box_faces` (Right, Left, Top, Bottom, Front, Back). The exported planes are unchanged, only which face data rides with each one.

Fixes #112. `HFBevelSystem.bevel_edge` wound both endpoint caps the same way. The two arcs are translated copies of each other, so both caps ended up with the same normal and the far one faced into the brush. Each cap is now wound against the direction leading away from the edge, so it holds for any edge orientation.

Tests added to `tests/test_map_export.gd` and `tests/test_bevel.gd`. Both fail against the old code: the map test reports all six planes carrying another face's UV offset, and the bevel test reports both caps pointing the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)