### PR TITLE
Key snap vertices by Vector3i instead of a formatted string

### DIFF
--- a/addons/hammerforge/hf_snap_system.gd
+++ b/addons/hammerforge/hf_snap_system.gd
@@ -30,6 +30,10 @@ const BOX_EDGE_INDICES: Array = [
 	[6, 7],
 ]
 
+## Millimetre precision for _vertex_key. Two vertices closer than 1/1000 of a
+## unit are the same snap target.
+const VERTEX_KEY_SCALE := 1000.0
+
 var root: Node3D
 var enabled_modes: int = SnapMode.GRID
 var snap_threshold: float = 2.0
@@ -204,7 +208,7 @@ static func _face_snap_geometry(faces: Array) -> Dictionary:
 				continue
 			var lo := mini(ia, ib)
 			var hi := maxi(ia, ib)
-			var edge_key := "%d|%d" % [lo, hi]
+			var edge_key := Vector2i(lo, hi)
 			if seen_edges.has(edge_key):
 				continue
 			seen_edges[edge_key] = true
@@ -212,8 +216,15 @@ static func _face_snap_geometry(faces: Array) -> Dictionary:
 	return {"verts": verts, "edges": edges}
 
 
-static func _vertex_key(v: Vector3) -> String:
-	return "%.3f,%.3f,%.3f" % [v.x, v.y, v.z]
+## Vertices dedupe at millimetre precision. Keying by Vector3i holds that
+## tolerance without formatting a string per vertex, which matters because this
+## runs for every vertex of every non box brush on every mouse motion event.
+static func _vertex_key(v: Vector3) -> Vector3i:
+	return Vector3i(
+		roundi(v.x * VERTEX_KEY_SCALE),
+		roundi(v.y * VERTEX_KEY_SCALE),
+		roundi(v.z * VERTEX_KEY_SCALE)
+	)
 
 
 ## The 8 corners of a box, in the order BOX_EDGE_INDICES expects.

--- a/tests/test_snap_system.gd
+++ b/tests/test_snap_system.gd
@@ -318,6 +318,50 @@ func test_vertex_snap_uses_face_vertices_not_the_size_box():
 	)
 
 
+func test_face_vertices_dedupe_across_the_faces_that_share_them():
+	# Every corner of a cube belongs to three faces. The snap geometry keys
+	# vertices to collapse those into one candidate, so a key change that loses
+	# the tolerance would show up here as 24 candidates instead of 8.
+	snap.set_mode(HFSnapSystem.SnapMode.VERTEX, true)
+	snap.set_mode(HFSnapSystem.SnapMode.GRID, false)
+	var b := _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "cube")
+	b.shape = DraftBrush.BrushShape.CUSTOM
+	var candidates: PackedVector3Array = snap._collect_candidates([])
+	assert_eq(candidates.size(), 8, "A cube has 8 unique corners")
+
+
+func test_face_edges_dedupe_across_the_two_faces_that_share_them():
+	snap.set_mode(HFSnapSystem.SnapMode.EDGE, true)
+	snap.set_mode(HFSnapSystem.SnapMode.GRID, false)
+	var b := _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "cube")
+	b.shape = DraftBrush.BrushShape.CUSTOM
+	var candidates: PackedVector3Array = snap._collect_candidates([])
+	assert_eq(candidates.size(), 12, "A cube has 12 unique edges, each shared by two faces")
+
+
+func test_vertices_inside_the_key_tolerance_collapse():
+	# The key rounds to a thousandth of a unit. Nudging one corner by less than
+	# that must not split it into a second candidate.
+	snap.set_mode(HFSnapSystem.SnapMode.VERTEX, true)
+	snap.set_mode(HFSnapSystem.SnapMode.GRID, false)
+	var b := _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "cube")
+	b.shape = DraftBrush.BrushShape.CUSTOM
+	var moved := 0
+	for face in b.faces:
+		var updated := PackedVector3Array()
+		for v in face.local_verts:
+			if v.is_equal_approx(Vector3(16, 16, 16)) and moved < 2:
+				moved += 1
+				updated.append(Vector3(16.0001, 16.0001, 16.0001))
+			else:
+				updated.append(v)
+		face.local_verts = updated
+		face.ensure_geometry()
+	assert_eq(moved, 2, "Two of the three faces at that corner were nudged")
+	var candidates: PackedVector3Array = snap._collect_candidates([])
+	assert_eq(candidates.size(), 8, "A sub tolerance nudge is still the same corner")
+
+
 func test_tessellated_primitive_falls_back_to_its_bounding_box():
 	snap.set_mode(HFSnapSystem.SnapMode.VERTEX, true)
 	snap.set_mode(HFSnapSystem.SnapMode.GRID, false)


### PR DESCRIPTION
Fixes #122.

`HFSnapSystem._face_snap_geometry` runs for every non box brush on every mouse motion event during a drag, and keyed every vertex and every edge by a formatted string. A brush near the 64 face cap cost roughly 256 string formats on its own before any hashing.

`Vector3i` and `Vector2i` key by value, so the dedupe keeps its millimetre tolerance without formatting anything.

Measured with 300 brushes and 200 motion events, Vertex plus Edge plus Perpendicular on:

| level | before | after |
| --- | --- | --- |
| one brush in ten non box | 10.33 ms per event | 3.97 ms per event |
| all non box | 77.46 ms per event | 14.52 ms per event |

Godot does not document whether `Vector3i` works as a Dictionary key, so I checked on 4.7.stable directly. It keys by value, distinct values stay distinct, and `roundi(x * 1000)` agrees with `"%.3f"` on 20000 random samples across the range a level uses.

Three tests added around the dedupe, since the keying is what changed. The tolerance one fails if the quantisation is wrong: raising the scale to 100000 makes a sub tolerance nudge split one corner into two candidates, and the test reports 9 where it wants 8.

Full suite 2217 passing.