### PR TITLE
Draw preview box outlines through HFOutlineUtil

### DIFF
--- a/addons/hammerforge/hf_outline_util.gd
+++ b/addons/hammerforge/hf_outline_util.gd
@@ -60,6 +60,17 @@ static func aabb_box_transform(aabb: AABB) -> Transform3D:
 	return Transform3D(Basis.from_scale(aabb.size), aabb.get_center())
 
 
+## One shared unit box outline. Callers scale it onto an AABB with
+## aabb_box_transform() rather than rebuilding a line mesh per box.
+static var _unit_box_mesh: ArrayMesh
+
+
+static func unit_box_line_mesh() -> ArrayMesh:
+	if _unit_box_mesh == null:
+		_unit_box_mesh = line_mesh(box_lines(Vector3.ONE))
+	return _unit_box_mesh
+
+
 static func face_boundary_lines(faces: Array) -> PackedVector3Array:
 	var lines := PackedVector3Array()
 	var seen_edges: Dictionary = {}

--- a/addons/hammerforge/systems/hf_carve_preview.gd
+++ b/addons/hammerforge/systems/hf_carve_preview.gd
@@ -7,6 +7,7 @@ extends "hf_system.gd"
 ## rather than the intersection volume in red.
 
 const DraftBrush = preload("../brush_instance.gd")
+const HFOutlineUtil = preload("../hf_outline_util.gd")
 
 var _preview_container: Node3D
 var _mesh_pool: Array = []  # Array[MeshInstance3D]
@@ -144,7 +145,8 @@ func _rebuild() -> void:
 	# Update active wireframes
 	for i in all_slices.size():
 		var mi: MeshInstance3D = _mesh_pool[i]
-		mi.mesh = _build_wireframe_mesh(all_slices[i])
+		mi.mesh = HFOutlineUtil.unit_box_line_mesh()
+		mi.transform = HFOutlineUtil.aabb_box_transform(all_slices[i])
 		mi.visible = true
 
 	# Hide unused
@@ -163,39 +165,3 @@ func _ensure_container() -> void:
 	_preview_container = Node3D.new()
 	_preview_container.name = "CarvePreview"
 	root.add_child(_preview_container)
-
-
-func _build_wireframe_mesh(aabb: AABB) -> ImmediateMesh:
-	var im = ImmediateMesh.new()
-	var min_pt = aabb.position
-	var max_pt = aabb.position + aabb.size
-	im.surface_begin(Mesh.PRIMITIVE_LINES)
-	var corners = [
-		Vector3(min_pt.x, min_pt.y, min_pt.z),
-		Vector3(max_pt.x, min_pt.y, min_pt.z),
-		Vector3(max_pt.x, max_pt.y, min_pt.z),
-		Vector3(min_pt.x, max_pt.y, min_pt.z),
-		Vector3(min_pt.x, min_pt.y, max_pt.z),
-		Vector3(max_pt.x, min_pt.y, max_pt.z),
-		Vector3(max_pt.x, max_pt.y, max_pt.z),
-		Vector3(min_pt.x, max_pt.y, max_pt.z),
-	]
-	var edges = [
-		[0, 1],
-		[1, 2],
-		[2, 3],
-		[3, 0],
-		[4, 5],
-		[5, 6],
-		[6, 7],
-		[7, 4],
-		[0, 4],
-		[1, 5],
-		[2, 6],
-		[3, 7],
-	]
-	for edge in edges:
-		im.surface_add_vertex(corners[edge[0]])
-		im.surface_add_vertex(corners[edge[1]])
-	im.surface_end()
-	return im

--- a/addons/hammerforge/systems/hf_clip_preview.gd
+++ b/addons/hammerforge/systems/hf_clip_preview.gd
@@ -6,6 +6,7 @@ extends "hf_system.gd"
 ## a quad mesh shows the cut plane itself.
 
 const DraftBrush = preload("../brush_instance.gd")
+const HFOutlineUtil = preload("../hf_outline_util.gd")
 
 var _preview_container: Node3D
 var _piece_a_mesh: MeshInstance3D
@@ -166,9 +167,11 @@ func _rebuild() -> void:
 	_ensure_container()
 
 	# Update piece wireframes
-	_piece_a_mesh.mesh = _build_wireframe_mesh(aabb_a)
+	_piece_a_mesh.mesh = HFOutlineUtil.unit_box_line_mesh()
+	_piece_a_mesh.transform = HFOutlineUtil.aabb_box_transform(aabb_a)
 	_piece_a_mesh.visible = true
-	_piece_b_mesh.mesh = _build_wireframe_mesh(aabb_b)
+	_piece_b_mesh.mesh = HFOutlineUtil.unit_box_line_mesh()
+	_piece_b_mesh.transform = HFOutlineUtil.aabb_box_transform(aabb_b)
 	_piece_b_mesh.visible = true
 
 	# Update split plane quad
@@ -199,42 +202,6 @@ func _ensure_container() -> void:
 	_plane_mesh.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 	_plane_mesh.material_override = _plane_material
 	_preview_container.add_child(_plane_mesh)
-
-
-func _build_wireframe_mesh(aabb: AABB) -> ImmediateMesh:
-	var im = ImmediateMesh.new()
-	var min_pt = aabb.position
-	var max_pt = aabb.position + aabb.size
-	im.surface_begin(Mesh.PRIMITIVE_LINES)
-	var corners = [
-		Vector3(min_pt.x, min_pt.y, min_pt.z),
-		Vector3(max_pt.x, min_pt.y, min_pt.z),
-		Vector3(max_pt.x, max_pt.y, min_pt.z),
-		Vector3(min_pt.x, max_pt.y, min_pt.z),
-		Vector3(min_pt.x, min_pt.y, max_pt.z),
-		Vector3(max_pt.x, min_pt.y, max_pt.z),
-		Vector3(max_pt.x, max_pt.y, max_pt.z),
-		Vector3(min_pt.x, max_pt.y, max_pt.z),
-	]
-	var edges = [
-		[0, 1],
-		[1, 2],
-		[2, 3],
-		[3, 0],
-		[4, 5],
-		[5, 6],
-		[6, 7],
-		[7, 4],
-		[0, 4],
-		[1, 5],
-		[2, 6],
-		[3, 7],
-	]
-	for edge in edges:
-		im.surface_add_vertex(corners[edge[0]])
-		im.surface_add_vertex(corners[edge[1]])
-	im.surface_end()
-	return im
 
 
 ## Build a translucent quad representing the split plane.

--- a/addons/hammerforge/systems/hf_hollow_preview.gd
+++ b/addons/hammerforge/systems/hf_hollow_preview.gd
@@ -5,6 +5,7 @@ extends "hf_system.gd"
 ## from a hollow operation.  Drawn in yellow wireframe over the original brush.
 
 const DraftBrush = preload("../brush_instance.gd")
+const HFOutlineUtil = preload("../hf_outline_util.gd")
 
 var _preview_container: Node3D
 var _mesh_pool: Array = []  # Array[MeshInstance3D] — 6 walls max
@@ -147,7 +148,8 @@ func _rebuild() -> void:
 	# Update active wireframes
 	for i in walls.size():
 		var mi: MeshInstance3D = _mesh_pool[i]
-		mi.mesh = _build_wireframe_mesh(walls[i])
+		mi.mesh = HFOutlineUtil.unit_box_line_mesh()
+		mi.transform = HFOutlineUtil.aabb_box_transform(walls[i])
 		mi.visible = true
 
 	# Hide unused
@@ -166,39 +168,3 @@ func _ensure_container() -> void:
 	_preview_container = Node3D.new()
 	_preview_container.name = "HollowPreview"
 	root.add_child(_preview_container)
-
-
-func _build_wireframe_mesh(aabb: AABB) -> ImmediateMesh:
-	var im = ImmediateMesh.new()
-	var min_pt = aabb.position
-	var max_pt = aabb.position + aabb.size
-	im.surface_begin(Mesh.PRIMITIVE_LINES)
-	var corners = [
-		Vector3(min_pt.x, min_pt.y, min_pt.z),
-		Vector3(max_pt.x, min_pt.y, min_pt.z),
-		Vector3(max_pt.x, max_pt.y, min_pt.z),
-		Vector3(min_pt.x, max_pt.y, min_pt.z),
-		Vector3(min_pt.x, min_pt.y, max_pt.z),
-		Vector3(max_pt.x, min_pt.y, max_pt.z),
-		Vector3(max_pt.x, max_pt.y, max_pt.z),
-		Vector3(min_pt.x, max_pt.y, max_pt.z),
-	]
-	var edges = [
-		[0, 1],
-		[1, 2],
-		[2, 3],
-		[3, 0],
-		[4, 5],
-		[5, 6],
-		[6, 7],
-		[7, 4],
-		[0, 4],
-		[1, 5],
-		[2, 6],
-		[3, 7],
-	]
-	for edge in edges:
-		im.surface_add_vertex(corners[edge[0]])
-		im.surface_add_vertex(corners[edge[1]])
-	im.surface_end()
-	return im

--- a/addons/hammerforge/systems/hf_subtract_preview.gd
+++ b/addons/hammerforge/systems/hf_subtract_preview.gd
@@ -6,6 +6,7 @@ extends "hf_system.gd"
 ## wireframes stay as a fallback when CSG is pending, capped, or empty.
 
 const DraftBrush = preload("../brush_instance.gd")
+const HFOutlineUtil = preload("../hf_outline_util.gd")
 
 var _preview_container: Node3D
 var _mesh_pool: Array = []  # Array[MeshInstance3D]
@@ -211,9 +212,9 @@ func _show_aabb_wireframes(intersections: Array) -> void:
 
 	for i in intersections.size():
 		var mi: MeshInstance3D = _mesh_pool[i]
-		mi.mesh = _build_wireframe_mesh(intersections[i])
+		mi.mesh = HFOutlineUtil.unit_box_line_mesh()
+		mi.transform = HFOutlineUtil.aabb_box_transform(intersections[i])
 		mi.material_override = _material
-		mi.transform = Transform3D.IDENTITY
 		mi.visible = true
 
 	for i in range(intersections.size(), _mesh_pool.size()):
@@ -432,39 +433,3 @@ static func world_aabb(node: Node3D) -> AABB:
 
 func _get_world_aabb(node: Node3D) -> AABB:
 	return world_aabb(node)
-
-
-func _build_wireframe_mesh(aabb: AABB) -> ImmediateMesh:
-	var im = ImmediateMesh.new()
-	var min_pt = aabb.position
-	var max_pt = aabb.position + aabb.size
-	im.surface_begin(Mesh.PRIMITIVE_LINES)
-	var corners = [
-		Vector3(min_pt.x, min_pt.y, min_pt.z),
-		Vector3(max_pt.x, min_pt.y, min_pt.z),
-		Vector3(max_pt.x, max_pt.y, min_pt.z),
-		Vector3(min_pt.x, max_pt.y, min_pt.z),
-		Vector3(min_pt.x, min_pt.y, max_pt.z),
-		Vector3(max_pt.x, min_pt.y, max_pt.z),
-		Vector3(max_pt.x, max_pt.y, max_pt.z),
-		Vector3(min_pt.x, max_pt.y, max_pt.z),
-	]
-	var edges = [
-		[0, 1],
-		[1, 2],
-		[2, 3],
-		[3, 0],
-		[4, 5],
-		[5, 6],
-		[6, 7],
-		[7, 4],
-		[0, 4],
-		[1, 5],
-		[2, 6],
-		[3, 7],
-	]
-	for edge in edges:
-		im.surface_add_vertex(corners[edge[0]])
-		im.surface_add_vertex(corners[edge[1]])
-	im.surface_end()
-	return im

--- a/tests/test_preview_shape_guards.gd
+++ b/tests/test_preview_shape_guards.gd
@@ -183,3 +183,43 @@ func test_hollow_preview_clears_when_the_brush_is_rotated_mid_drag():
 	b.rotation_degrees = Vector3(0, 45, 0)
 	hollow_preview.update_thickness(6.0)
 	_assert_no_hollow_wireframes("Rotated box after update_thickness")
+
+
+# ===========================================================================
+# Wireframe placement
+# ===========================================================================
+
+
+func test_clip_preview_places_each_piece_wireframe_on_its_own_bounds():
+	# The box outline is one shared unit mesh now, positioned by the mesh
+	# instance transform. Getting that transform wrong draws the piece in the
+	# wrong place, which the visibility checks above would not notice.
+	_make_brush()
+	clip_preview.show_preview("brush_1", 1, 0.0)
+	var a: Transform3D = clip_preview._piece_a_mesh.transform
+	var b: Transform3D = clip_preview._piece_b_mesh.transform
+	assert_almost_eq(a.origin, Vector3(0, -16, 0), Vector3.ONE * 0.001, "Lower piece centre")
+	assert_almost_eq(a.basis.get_scale(), Vector3(64, 32, 64), Vector3.ONE * 0.001, "Lower size")
+	assert_almost_eq(b.origin, Vector3(0, 16, 0), Vector3.ONE * 0.001, "Upper piece centre")
+	assert_almost_eq(b.basis.get_scale(), Vector3(64, 32, 64), Vector3.ONE * 0.001, "Upper size")
+	assert_not_null(clip_preview._piece_a_mesh.mesh, "The shared outline mesh must be assigned")
+
+
+func test_hollow_preview_places_the_top_wall_wireframe_on_the_wall_bounds():
+	_make_brush()
+	hollow_preview.show_preview("brush_1", 4.0)
+	# Wall 0 is the top slab: full width and depth, thickness tall, pushed up.
+	var t: Transform3D = hollow_preview._mesh_pool[0].transform
+	assert_almost_eq(t.origin, Vector3(0, 30, 0), Vector3.ONE * 0.001, "Top wall centre")
+	assert_almost_eq(t.basis.get_scale(), Vector3(64, 4, 64), Vector3.ONE * 0.001, "Top wall size")
+
+
+func test_preview_wireframes_share_one_outline_mesh():
+	_make_brush()
+	clip_preview.show_preview("brush_1", 1, 0.0)
+	hollow_preview.show_preview("brush_1", 4.0)
+	assert_same(
+		clip_preview._piece_a_mesh.mesh,
+		hollow_preview._mesh_pool[0].mesh,
+		"Every box outline is the same unit mesh, scaled by the instance transform"
+	)


### PR DESCRIPTION
Fixes #121.

`_build_wireframe_mesh` was written four times, byte identical, 34 lines each, in the carve, clip, hollow and subtract previews. All four built the same 8 corner and 12 edge tables and baked world coordinates into a fresh `ImmediateMesh` per box per rebuild.

They now share one unit box outline and place it with `aabb_box_transform()`, which is what `HFOutlineUtil` already exists to do. 136 lines out, and box previews render through the same path as the gizmo outlines.

One thing the change surfaced: `hf_subtract_preview` set `mi.transform = Transform3D.IDENTITY` immediately after assigning the mesh. That was there to undo a leftover transform from the CSG path that shares the same mesh pool. It would have silently flattened every wireframe onto the origin, so it is gone and the wireframe path sets its own transform. The CSG path at line 297 already sets its own.

Three tests added to `tests/test_preview_shape_guards.gd`, since placement is now carried by the instance transform rather than baked into the vertices, and the existing visibility assertions would not notice a box drawn in the wrong place. Checked they fail: forcing the clip piece transform back to identity reports centre `(0, 0, 0)` where it wants `(0, -16, 0)` and scale `(1, 1, 1)` where it wants `(64, 32, 64)`.

I left the `_ensure_container()` fold alone. Carve, hollow and subtract are seven lines each differing only by node name, but clip also builds three mesh instances, so it is not the same function and folding three of four is not worth the indirection.

Full suite 2217 passing.