### PR TITLE
Give the path and polygon tools one raycast each

### DIFF
--- a/addons/hammerforge/hf_path_tool.gd
+++ b/addons/hammerforge/hf_path_tool.gd
@@ -163,7 +163,7 @@ func handle_input(event: InputEvent, camera: Camera3D, mouse_pos: Vector2) -> in
 	# Mouse motion
 	if event is InputEventMouseMotion:
 		if _phase == Phase.PLACING_WAYPOINTS:
-			_cursor_pos = _raycast_to_y_plane(camera, mouse_pos, _ground_y)
+			_cursor_pos = root.screen_ray_to_y_plane(camera, mouse_pos, _ground_y)
 			_cursor_pos = _snap(_cursor_pos)
 			_update_preview()
 
@@ -208,7 +208,7 @@ func get_shortcut_hud_lines() -> PackedStringArray:
 func _handle_click(camera: Camera3D, mouse_pos: Vector2) -> int:
 	match _phase:
 		Phase.IDLE:
-			var world_pos = _raycast_ground(camera, mouse_pos)
+			var world_pos = root._raycast(camera, mouse_pos).get("position")
 			if world_pos == null:
 				return EditorPlugin.AFTER_GUI_INPUT_PASS
 			var snapped: Vector3 = _snap(world_pos)
@@ -219,7 +219,7 @@ func _handle_click(camera: Camera3D, mouse_pos: Vector2) -> int:
 			return EditorPlugin.AFTER_GUI_INPUT_STOP
 
 		Phase.PLACING_WAYPOINTS:
-			var hit := _raycast_to_y_plane(camera, mouse_pos, _ground_y)
+			var hit: Vector3 = root.screen_ray_to_y_plane(camera, mouse_pos, _ground_y)
 			hit = _snap(hit)
 			_waypoints.append(hit)
 			_update_preview()
@@ -880,22 +880,6 @@ func _snap(pos: Vector3) -> Vector3:
 		var g: float = root.grid_snap
 		return Vector3(snappedf(pos.x, g), snappedf(pos.y, g), snappedf(pos.z, g))
 	return pos
-
-
-func _raycast_ground(camera: Camera3D, mouse_pos: Vector2) -> Variant:
-	if not root or not root.has_method("_raycast"):
-		return null
-	var hit: Dictionary = root._raycast(camera, mouse_pos)
-	return hit.get("position")
-
-
-func _raycast_to_y_plane(camera: Camera3D, mouse_pos: Vector2, y: float) -> Vector3:
-	var origin := camera.project_ray_origin(mouse_pos)
-	var dir := camera.project_ray_normal(mouse_pos)
-	if absf(dir.y) < 0.0001:
-		return Vector3(origin.x, y, origin.z)
-	var t := maxf((y - origin.y) / dir.y, 0.0)
-	return origin + dir * t
 
 
 func _ensure_mesh() -> void:

--- a/addons/hammerforge/hf_polygon_tool.gd
+++ b/addons/hammerforge/hf_polygon_tool.gd
@@ -98,7 +98,7 @@ func handle_input(event: InputEvent, camera: Camera3D, mouse_pos: Vector2) -> in
 			recover_lost_pointer_capture()
 			return EditorPlugin.AFTER_GUI_INPUT_STOP
 		if _phase == Phase.PLACING_VERTS:
-			_cursor_pos = _raycast_to_y_plane(camera, mouse_pos, _ground_y)
+			_cursor_pos = root.screen_ray_to_y_plane(camera, mouse_pos, _ground_y)
 			_cursor_pos = _snap(_cursor_pos)
 			_update_preview()
 		elif _phase == Phase.SETTING_HEIGHT:
@@ -164,7 +164,7 @@ func get_shortcut_hud_lines() -> PackedStringArray:
 func _handle_click(camera: Camera3D, mouse_pos: Vector2) -> int:
 	match _phase:
 		Phase.IDLE:
-			var world_pos := _raycast_ground(camera, mouse_pos)
+			var world_pos = root._raycast(camera, mouse_pos).get("position")
 			if world_pos == null:
 				return EditorPlugin.AFTER_GUI_INPUT_PASS
 			_ground_y = world_pos.y
@@ -176,7 +176,7 @@ func _handle_click(camera: Camera3D, mouse_pos: Vector2) -> int:
 			return EditorPlugin.AFTER_GUI_INPUT_STOP
 
 		Phase.PLACING_VERTS:
-			var hit := _raycast_to_y_plane(camera, mouse_pos, _ground_y)
+			var hit: Vector3 = root.screen_ray_to_y_plane(camera, mouse_pos, _ground_y)
 			hit = _snap(hit)
 			# Check auto-close
 			var threshold: float = get_setting("auto_close_threshold")
@@ -489,22 +489,6 @@ func _snap(pos: Vector3) -> Vector3:
 		var g: float = root.grid_snap
 		return Vector3(snappedf(pos.x, g), snappedf(pos.y, g), snappedf(pos.z, g))
 	return pos
-
-
-func _raycast_ground(camera: Camera3D, mouse_pos: Vector2) -> Variant:
-	if not root or not root.has_method("_raycast"):
-		return null
-	var hit: Dictionary = root._raycast(camera, mouse_pos)
-	return hit.get("position")
-
-
-func _raycast_to_y_plane(camera: Camera3D, mouse_pos: Vector2, y: float) -> Vector3:
-	var origin := camera.project_ray_origin(mouse_pos)
-	var dir := camera.project_ray_normal(mouse_pos)
-	if absf(dir.y) < 0.0001:
-		return Vector3(origin.x, y, origin.z)
-	var t := maxf((y - origin.y) / dir.y, 0.0)
-	return origin + dir * t
 
 
 func _ensure_mesh() -> void:

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -2761,6 +2761,19 @@ static func construction_plane_intersection(from: Vector3, to: Vector3) -> Varia
 	return Plane(Vector3.UP, 0.0).intersects_segment(from, to)
 
 
+## Where a screen ray meets the horizontal plane at `y`. Unlike a plane
+## intersection this always answers: a ray parallel to the plane drops straight
+## down from the camera, and the hit is clamped in front of it. Viewport tools
+## place points with this, so a null would leave the cursor with nowhere to go.
+static func screen_ray_to_y_plane(camera: Camera3D, mouse_pos: Vector2, y: float) -> Vector3:
+	var origin := camera.project_ray_origin(mouse_pos)
+	var dir := camera.project_ray_normal(mouse_pos)
+	if absf(dir.y) < 0.0001:
+		return Vector3(origin.x, y, origin.z)
+	var t := maxf((y - origin.y) / dir.y, 0.0)
+	return origin + dir * t
+
+
 func _entity_pick_distance(entity: Node3D, ray_origin: Vector3, ray_dir: Vector3) -> float:
 	if not _is_pick_visible(entity):
 		return -1.0

--- a/tests/test_path_tool.gd
+++ b/tests/test_path_tool.gd
@@ -10,6 +10,7 @@ class PlacementRoot:
 	var raycast_result: Dictionary = {}
 	var snap_calls := 0
 	var raycast_calls := 0
+	var y_plane_calls := 0
 
 	func _snap_point(point: Vector3, _exclude_ids: Array = []) -> Vector3:
 		snap_calls += 1
@@ -19,19 +20,51 @@ class PlacementRoot:
 		raycast_calls += 1
 		return raycast_result
 
+	func screen_ray_to_y_plane(_camera: Camera3D, _mouse_pos: Vector2, y: float) -> Vector3:
+		y_plane_calls += 1
+		return Vector3(0, y, 0)
+
 
 func test_placement_uses_level_root_snap_and_raycast():
+	# The tool has no raycast of its own any more. A click has to reach
+	# LevelRoot for picking, and LevelRoot for snapping.
 	var tool = HFPathTool.new()
 	var root := PlacementRoot.new()
 	var camera := Camera3D.new()
 	tool.root = root
 	root.raycast_result = {"position": Vector3(3, 7, 9)}
 	assert_eq(tool._snap(Vector3(3, 7, 9)), Vector3(4, 8, 8))
-	assert_eq(tool._raycast_ground(camera, Vector2(20, 30)), Vector3(3, 7, 9))
-	assert_eq(root.snap_calls, 1, "LevelRoot owns the snap settings")
+	assert_eq(tool._handle_click(camera, Vector2(20, 30)), EditorPlugin.AFTER_GUI_INPUT_STOP)
 	assert_eq(root.raycast_calls, 1, "LevelRoot owns visual and physics picking")
+	assert_eq(tool._waypoints.size(), 1, "The picked point becomes the first point")
+	assert_eq(tool._waypoints[0], Vector3(4, 8, 8), "and it is snapped by LevelRoot")
+	root.free()
+	camera.free()
+
+
+func test_a_raycast_miss_places_nothing():
+	var tool = HFPathTool.new()
+	var root := PlacementRoot.new()
+	var camera := Camera3D.new()
+	tool.root = root
 	root.raycast_result = {}
-	assert_null(tool._raycast_ground(camera, Vector2.ZERO), "a shared raycast miss stays a miss")
+	assert_eq(tool._handle_click(camera, Vector2.ZERO), EditorPlugin.AFTER_GUI_INPUT_PASS)
+	assert_eq(root.raycast_calls, 1, "a shared raycast miss stays a miss")
+	assert_eq(tool._waypoints.size(), 0, "and nothing is placed")
+	root.free()
+	camera.free()
+
+
+func test_later_points_come_off_the_shared_y_plane_projection():
+	var tool = HFPathTool.new()
+	var root := PlacementRoot.new()
+	var camera := Camera3D.new()
+	tool.root = root
+	root.raycast_result = {"position": Vector3(3, 7, 9)}
+	tool._handle_click(camera, Vector2(20, 30))
+	tool._handle_click(camera, Vector2(40, 50))
+	assert_eq(root.raycast_calls, 1, "Only the first point is picked against geometry")
+	assert_eq(root.y_plane_calls, 1, "The rest come off LevelRoot's y plane projection")
 	root.free()
 	camera.free()
 

--- a/tests/test_polygon_tool.gd
+++ b/tests/test_polygon_tool.gd
@@ -10,6 +10,7 @@ class PlacementRoot:
 	var raycast_result: Dictionary = {}
 	var snap_calls := 0
 	var raycast_calls := 0
+	var y_plane_calls := 0
 
 	func _snap_point(point: Vector3, _exclude_ids: Array = []) -> Vector3:
 		snap_calls += 1
@@ -19,19 +20,51 @@ class PlacementRoot:
 		raycast_calls += 1
 		return raycast_result
 
+	func screen_ray_to_y_plane(_camera: Camera3D, _mouse_pos: Vector2, y: float) -> Vector3:
+		y_plane_calls += 1
+		return Vector3(0, y, 0)
+
 
 func test_placement_uses_level_root_snap_and_raycast():
+	# The tool has no raycast of its own any more. A click has to reach
+	# LevelRoot for picking, and LevelRoot for snapping.
 	var tool = HFPolygonTool.new()
 	var root := PlacementRoot.new()
 	var camera := Camera3D.new()
 	tool.root = root
 	root.raycast_result = {"position": Vector3(3, 7, 9)}
 	assert_eq(tool._snap(Vector3(3, 7, 9)), Vector3(4, 8, 8))
-	assert_eq(tool._raycast_ground(camera, Vector2(20, 30)), Vector3(3, 7, 9))
-	assert_eq(root.snap_calls, 1, "LevelRoot owns the snap settings")
+	assert_eq(tool._handle_click(camera, Vector2(20, 30)), EditorPlugin.AFTER_GUI_INPUT_STOP)
 	assert_eq(root.raycast_calls, 1, "LevelRoot owns visual and physics picking")
+	assert_eq(tool._polygon_points.size(), 1, "The picked point becomes the first point")
+	assert_eq(tool._polygon_points[0], Vector3(4, 8, 8), "and it is snapped by LevelRoot")
+	root.free()
+	camera.free()
+
+
+func test_a_raycast_miss_places_nothing():
+	var tool = HFPolygonTool.new()
+	var root := PlacementRoot.new()
+	var camera := Camera3D.new()
+	tool.root = root
 	root.raycast_result = {}
-	assert_null(tool._raycast_ground(camera, Vector2.ZERO), "a shared raycast miss stays a miss")
+	assert_eq(tool._handle_click(camera, Vector2.ZERO), EditorPlugin.AFTER_GUI_INPUT_PASS)
+	assert_eq(root.raycast_calls, 1, "a shared raycast miss stays a miss")
+	assert_eq(tool._polygon_points.size(), 0, "and nothing is placed")
+	root.free()
+	camera.free()
+
+
+func test_later_points_come_off_the_shared_y_plane_projection():
+	var tool = HFPolygonTool.new()
+	var root := PlacementRoot.new()
+	var camera := Camera3D.new()
+	tool.root = root
+	root.raycast_result = {"position": Vector3(3, 7, 9)}
+	tool._handle_click(camera, Vector2(20, 30))
+	tool._handle_click(camera, Vector2(40, 50))
+	assert_eq(root.raycast_calls, 1, "Only the first point is picked against geometry")
+	assert_eq(root.y_plane_calls, 1, "The rest come off LevelRoot's y plane projection")
 	root.free()
 	camera.free()
 


### PR DESCRIPTION
Fixes #124.

`_raycast_ground` was a wrapper around `root._raycast` guarded by `has_method`. That is the leftover duck typing the earlier removal pass took out of `plugin.gd` and `dock.gd`. `LevelRoot` always has `_raycast`, so the guard only hid a null root. Both call sites go straight to `root._raycast` now.

`_raycast_to_y_plane` needed different treatment than the issue assumed. There was no shared equivalent to fold it onto. `construction_plane_intersection` is fixed at y zero, and `HFVertexSystem._screen_ray_plane_intersection` returns null on a parallel ray and does not clamp the hit in front of the camera, so neither could stand in without changing what the tools do at both edges. It moves to `LevelRoot` as `screen_ray_to_y_plane`, beside `construction_plane_intersection`, with its behaviour unchanged.

The two tests that called `tool._raycast_ground` were asserting through the wrapper I deleted. They now drive `_handle_click` instead, which is the real path, and check three things the wrapper test could not: the picked point becomes the first point and is snapped by LevelRoot, a raycast miss places nothing, and only the first click is picked against geometry while later ones come off the y plane projection.

I left `_ensure_mesh` duplicated. It differs only by the preview node name, but the shared form needs a factory that builds a MeshInstance3D with its material and ImmediateMesh, and neither `HFOutlineUtil` nor `LevelRoot` is the right home for one. Fifteen lines is not worth a new module.

Full suite 2218 passing.