### PR TITLE
Call the owner for brush lookup and face keys

### DIFF
--- a/addons/hammerforge/dock.gd
+++ b/addons/hammerforge/dock.gd
@@ -1676,11 +1676,7 @@ func _get_selected_face_info() -> Dictionary:
 func _selected_face_has_displacement(info: Dictionary) -> bool:
 	if info.is_empty() or not level_root:
 		return false
-	var brush: Node3D = (
-		level_root.find_brush_by_id(info["brush_id"])
-		if level_root.has_method("find_brush_by_id")
-		else null
-	)
+	var brush: Node3D = level_root.find_brush_by_id(info["brush_id"])
 	if not brush:
 		return false
 	var fi: int = info["face_index"]

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -1537,10 +1537,6 @@ func _apply_face_selection() -> void:
 	brush_system._apply_face_selection()
 
 
-func _face_key(brush: DraftBrush) -> String:
-	return brush_system._face_key(brush)
-
-
 func _find_brush_by_key(key: String) -> DraftBrush:
 	return brush_system._find_brush_by_key(key)
 

--- a/addons/hammerforge/plugin_paint_input.gd
+++ b/addons/hammerforge/plugin_paint_input.gd
@@ -18,9 +18,7 @@ static func should_start_displacement(plugin: Object, event: InputEvent, root: N
 	var info: Dictionary = plugin.dock._get_selected_face_info()
 	if info.is_empty():
 		return false
-	var brush: Node3D = (
-		root.find_brush_by_id(info["brush_id"]) if root.has_method("find_brush_by_id") else null
-	)
+	var brush: Node3D = root.find_brush_by_id(info["brush_id"])
 	if not brush or not _is_visible_pick(root, brush):
 		return false
 	var face_index: int = info["face_index"]
@@ -79,11 +77,7 @@ static func do_displacement_stroke(
 		return
 	if plugin._disp_paint_brush_id == "" or plugin._disp_paint_face_idx < 0:
 		return
-	var brush: Node3D = (
-		root.find_brush_by_id(plugin._disp_paint_brush_id)
-		if root.has_method("find_brush_by_id")
-		else null
-	)
+	var brush: Node3D = root.find_brush_by_id(plugin._disp_paint_brush_id)
 	if not brush or not _is_visible_pick(root, brush):
 		return
 	var faces: Array = brush.faces

--- a/addons/hammerforge/plugin_selection_commands.gd
+++ b/addons/hammerforge/plugin_selection_commands.gd
@@ -19,9 +19,7 @@ const SIMILAR_SIZE_TOLERANCE := 0.2
 
 
 static func face_key_for(brush: DraftBrush) -> String:
-	if brush.brush_id != "":
-		return brush.brush_id
-	return str(brush.get_instance_id())
+	return HFBrushSystem.face_key(brush)
 
 
 static func apply_face_selection(plugin: Object, root: Node, face_sel: Dictionary) -> void:

--- a/addons/hammerforge/systems/hf_bevel_system.gd
+++ b/addons/hammerforge/systems/hf_bevel_system.gd
@@ -32,7 +32,7 @@ func bevel_edge(brush_id: String, edge: Array, segments: int = 2, radius: float 
 		return false
 	segments = clampi(segments, 1, 16)
 	radius = maxf(radius, 0.01)
-	var brush: Node3D = _find_brush(brush_id)
+	var brush: Node3D = root.find_brush_by_id(brush_id)
 	if not brush:
 		return false
 	var faces: Array = brush.faces
@@ -151,7 +151,7 @@ func inset_face(
 	brush_id: String, face_index: int, inset_distance: float = 2.0, height: float = 0.0
 ) -> bool:
 	inset_distance = maxf(inset_distance, 0.01)
-	var brush: Node3D = _find_brush(brush_id)
+	var brush: Node3D = root.find_brush_by_id(brush_id)
 	if not brush:
 		return false
 	var faces: Array = brush.faces
@@ -205,14 +205,6 @@ func inset_face(
 # ---------------------------------------------------------------------------
 # Internals
 # ---------------------------------------------------------------------------
-
-
-func _find_brush(brush_id: String) -> Node3D:
-	if not root:
-		return null
-	if root.has_method("find_brush_by_id"):
-		return root.find_brush_by_id(brush_id)
-	return null
 
 
 func _mark_brush_dirty(brush: Node3D) -> void:

--- a/addons/hammerforge/systems/hf_brush_system.gd
+++ b/addons/hammerforge/systems/hf_brush_system.gd
@@ -148,7 +148,7 @@ func delete_brush(brush: Node, free: bool = true) -> void:
 		removed_id = bid
 		if bid != "":
 			_brush_cache.erase(bid)
-		var key = _face_key(brush as DraftBrush)
+		var key = face_key(brush as DraftBrush)
 		if root.face_selection.has(key):
 			root.face_selection.erase(key)
 			_apply_face_selection()
@@ -1019,7 +1019,7 @@ func toggle_face_selection(
 		return
 	if not additive:
 		root.face_selection.clear()
-	var key = _face_key(brush)
+	var key = face_key(brush)
 	var indices: Array = root.face_selection.get(key, [])
 	var idx = indices.find(face_idx)
 	if idx >= 0 and toggle:
@@ -1083,16 +1083,18 @@ func _apply_face_selection() -> void:
 		if not (node is DraftBrush):
 			continue
 		var brush := node as DraftBrush
-		var key = _face_key(brush)
+		var key = face_key(brush)
 		var indices: Array = root.face_selection.get(key, [])
 		brush.set_selected_faces(PackedInt32Array(indices))
 
 
-func _face_key(brush: DraftBrush) -> String:
+## The key a brush is filed under in face_selection. Takes Node rather than
+## DraftBrush because selection filters see whatever the editor hands them.
+static func face_key(brush: Node) -> String:
 	if brush == null:
 		return ""
-	if brush.brush_id != "":
-		return brush.brush_id
+	if brush is DraftBrush and (brush as DraftBrush).brush_id != "":
+		return (brush as DraftBrush).brush_id
 	return str(brush.get_instance_id())
 
 

--- a/addons/hammerforge/systems/hf_displacement_system.gd
+++ b/addons/hammerforge/systems/hf_displacement_system.gd
@@ -31,7 +31,7 @@ func _init(p_root: Node3D = null) -> void:
 ## Create a displacement surface on the given face of a brush.
 ## The face must be a quad (4 vertices). Returns true on success.
 func create_displacement(brush_id: String, face_index: int, power: int = 3) -> bool:
-	var brush: Node3D = _find_brush(brush_id)
+	var brush: Node3D = root.find_brush_by_id(brush_id)
 	if not brush:
 		HFLog.warn("HFDisplacementSystem: brush not found: %s" % brush_id)
 		return false
@@ -57,7 +57,7 @@ func create_displacement(brush_id: String, face_index: int, power: int = 3) -> b
 
 ## Remove displacement from a face, reverting it to a flat quad.
 func destroy_displacement(brush_id: String, face_index: int) -> bool:
-	var brush: Node3D = _find_brush(brush_id)
+	var brush: Node3D = root.find_brush_by_id(brush_id)
 	if not brush:
 		return false
 	var faces: Array = brush.faces
@@ -73,7 +73,7 @@ func destroy_displacement(brush_id: String, face_index: int) -> bool:
 
 ## Check if a face has displacement data.
 func has_displacement(brush_id: String, face_index: int) -> bool:
-	var brush: Node3D = _find_brush(brush_id)
+	var brush: Node3D = root.find_brush_by_id(brush_id)
 	if not brush:
 		return false
 	var faces: Array = brush.faces
@@ -84,7 +84,7 @@ func has_displacement(brush_id: String, face_index: int) -> bool:
 
 ## Change the subdivision power of an existing displacement.
 func set_power(brush_id: String, face_index: int, power: int) -> bool:
-	var brush: Node3D = _find_brush(brush_id)
+	var brush: Node3D = root.find_brush_by_id(brush_id)
 	if not brush:
 		return false
 	var faces: Array = brush.faces
@@ -139,7 +139,7 @@ func paint(
 	strength: float,
 	mode: int = PaintMode.RAISE  # PaintMode enum
 ) -> bool:
-	var brush: Node3D = _find_brush(brush_id)
+	var brush: Node3D = root.find_brush_by_id(brush_id)
 	if not brush:
 		return false
 	var faces: Array = brush.faces
@@ -201,7 +201,7 @@ func paint(
 func apply_noise(
 	brush_id: String, face_index: int, noise: FastNoiseLite, scale: float = 1.0
 ) -> bool:
-	var brush: Node3D = _find_brush(brush_id)
+	var brush: Node3D = root.find_brush_by_id(brush_id)
 	if not brush:
 		return false
 	var faces: Array = brush.faces
@@ -217,7 +217,7 @@ func apply_noise(
 
 ## Smooth the entire displacement surface.
 func smooth_all(brush_id: String, face_index: int, strength: float = 0.5) -> bool:
-	var brush: Node3D = _find_brush(brush_id)
+	var brush: Node3D = root.find_brush_by_id(brush_id)
 	if not brush:
 		return false
 	var faces: Array = brush.faces
@@ -233,7 +233,7 @@ func smooth_all(brush_id: String, face_index: int, strength: float = 0.5) -> boo
 
 ## Set elevation scale for the displacement.
 func set_elevation(brush_id: String, face_index: int, elevation: float) -> bool:
-	var brush: Node3D = _find_brush(brush_id)
+	var brush: Node3D = root.find_brush_by_id(brush_id)
 	if not brush:
 		return false
 	var faces: Array = brush.faces
@@ -298,14 +298,6 @@ func sew_all(tolerance: float = 0.5) -> int:
 # ---------------------------------------------------------------------------
 # Internals
 # ---------------------------------------------------------------------------
-
-
-func _find_brush(brush_id: String) -> Node3D:
-	if not root:
-		return null
-	if root.has_method("find_brush_by_id"):
-		return root.find_brush_by_id(brush_id)
-	return null
 
 
 func _mark_brush_dirty(brush: Node3D) -> void:

--- a/addons/hammerforge/ui/hf_selection_filter.gd
+++ b/addons/hammerforge/ui/hf_selection_filter.gd
@@ -202,7 +202,7 @@ func _select_faces_by_normal(predicate: Callable) -> void:
 	var brushes := _get_all_brushes()
 	for brush in brushes:
 		var faces: Array = brush.get_faces() if brush.has_method("get_faces") else []
-		var key: String = _face_key(brush)
+		var key: String = HFBrushSystem.face_key(brush)
 		var basis: Basis = brush.global_transform.basis if brush is Node3D else Basis.IDENTITY
 		var indices: Array = []
 		for i in range(faces.size()):
@@ -228,7 +228,7 @@ func _filter_same_material() -> void:
 	var brushes := _get_all_brushes()
 	for brush in brushes:
 		var faces: Array = brush.get_faces() if brush.has_method("get_faces") else []
-		var key: String = _face_key(brush)
+		var key: String = HFBrushSystem.face_key(brush)
 		var indices: Array = []
 		for i in range(faces.size()):
 			var face = faces[i]
@@ -252,7 +252,7 @@ func _filter_similar_faces() -> void:
 	var brushes := _get_all_brushes()
 	for brush in brushes:
 		var faces: Array = brush.get_faces() if brush.has_method("get_faces") else []
-		var key: String = _face_key(brush)
+		var key: String = HFBrushSystem.face_key(brush)
 		var basis: Basis = brush.global_transform.basis if brush is Node3D else Basis.IDENTITY
 		var indices: Array = []
 		for i in range(faces.size()):
@@ -331,16 +331,6 @@ func _filter_structural() -> void:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-func _face_key(brush: Node) -> String:
-	if brush == null:
-		return ""
-	if brush is DraftBrush:
-		var b := brush as DraftBrush
-		if b.brush_id != "":
-			return b.brush_id
-	return str(brush.get_instance_id())
 
 
 func _get_selected_material_indices() -> Array:

--- a/addons/hammerforge/ui/hf_tutorial_wizard.gd
+++ b/addons/hammerforge/ui/hf_tutorial_wizard.gd
@@ -229,7 +229,7 @@ func _validate_bake_success(success) -> bool:
 
 
 func _validate_subtract(brush_id) -> bool:
-	if not _root or not _root.has_method("find_brush_by_id"):
+	if not _root:
 		return true
 	var brush = _root.find_brush_by_id(str(brush_id))
 	if not brush:

--- a/tests/test_plugin_selection_commands.gd
+++ b/tests/test_plugin_selection_commands.gd
@@ -210,6 +210,18 @@ func test_face_key_falls_back_to_instance_id():
 	assert_eq(HFPluginSelectionCommands.face_key_for(brush), str(brush.get_instance_id()))
 
 
+func test_face_key_is_null_safe_now_that_it_routes_through_the_owner():
+	# face_key_for had no null guard of its own. It shares HFBrushSystem's now.
+	assert_eq(HFPluginSelectionCommands.face_key_for(null), "")
+
+
+func test_face_key_agrees_with_the_brush_system():
+	var brush := DraftBrush.new()
+	brush.brush_id = "brush_9"
+	assert_eq(HFPluginSelectionCommands.face_key_for(brush), HFBrushSystem.face_key(brush))
+	brush.free()
+
+
 # ---------------------------------------------------------------------------
 # Select Similar routing
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #123.

**Brush lookup.** The bevel and displacement systems wrapped `root.find_brush_by_id` in a `has_method` guard, and the paint input did the same inline. `LevelRoot` always has that method, so the guard only hid a null root, which the callers already check. Ten call sites go straight to the owner and the wrappers are gone.

Two sites the issue missed, same defect, same fix: `dock.gd:1681` and `ui/hf_tutorial_wizard.gd:232`.

One site left alone: `HFVertexSystem._find_brush`. Its guard checks `root.brush_system`, not the method, and a runtime LevelRoot can legitimately be missing that system. It also falls back to scanning the selection list on a cache miss, which is deliberate. Removing that would be a behaviour change, not a cleanup.

**Face keys.** The issue overcounted this. Of the four I listed, `level_root._face_key` and `plugin._face_key_for` are one line delegates, not copies. The real duplication was three implementations that agreed on the answer: `HFBrushSystem._face_key`, `HFPluginSelectionCommands.face_key_for`, and `HFSelectionFilter._face_key`.

`HFBrushSystem.face_key` is static now and takes `Node`, which is the superset the selection filter needed, and the other two call it. `HFBrushSystem` is a global class name, so no new preloads and no dependency edge from the ui or plugin layers into systems.

`LevelRoot._face_key` is deleted. Nothing called it.

This fixes a real hole rather than only removing lines: `face_key_for` had no null guard and shares one now. Checked it bites by restoring the old body, which fails with "Invalid access to property or key 'brush_id' on a base object of type 'Nil'".

Full suite 2216 passing.