### PR TITLE
Emit brush_changed when a brush is tagged dirty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   explains it. It reads the Console's own evaluation, so the two cannot disagree.
 
 ### Fixed
+- **`brush_changed` never fired.** The signal was declared on `LevelRoot` and
+  emitted nowhere, while `HFSubtractPreview` connected to it, so the live
+  subtract overlay listened to a signal that could not arrive and only refreshed
+  when a brush was added or removed. `tag_brush_dirty()` emits it now, which is
+  the one call every transform, material, UV, paint and vertex mutation already
+  makes. It fires on every tag rather than only the first, because the dirty set
+  is not cleared until a bake and a preview following a drag needs each step.
+  The preview connects only while enabled and `show_subtract_preview` defaults
+  off, so nothing is emitted into an empty room by default.
 - **Box faces exported to `.map` carried another face's texture and UV settings**
   ([#113](https://github.com/saworbit/hammerforge/issues/113)): `MapIO._box_to_map_lines`
   walked its plane table with the same counter it used to index `brush.faces`, but the

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -277,7 +277,7 @@ addons/hammerforge/
 The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs on push and PR to `main`:
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
-- **GUT unit + integration tests** -- 2,226 tests across 126 test scripts (2,219 passing plus seven intentional no-assert safety tests; 9,279 assertions; verified locally September 6, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 2,230 tests across 126 test scripts (2,223 passing plus seven intentional no-assert safety tests; 9,285 assertions; verified locally September 6, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -513,6 +513,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 38 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified locally on September 6, 2026): **2,226 tests** across **126 scripts** (**2,219 passing** plus seven intentional no-assert safety tests; **9,279 assertions**).
+Full suite (verified locally on September 6, 2026): **2,230 tests** across **126 scripts** (**2,223 passing** plus seven intentional no-assert safety tests; **9,285 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Shortcuts marked with **\*** are rebindable via `user://hammerforge_keymap.json`
 
 ## Testing
 
-The verified Godot 4.7 suite on September 6, 2026 contains **2,226 tests across 126 scripts**: **2,219 passing tests**, seven intentional no-assert safety tests, and **9,279 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 6, 2026 contains **2,230 tests across 126 scripts**: **2,223 passing tests**, seven intentional no-assert safety tests, and **9,285 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -458,7 +458,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 2,226 tests across 126 scripts, including the large brush, bake, paint, vertex, baker, brush-instance, and map-I/O systems. Remaining work is concentrated in failure semantics and scale-sensitive paths rather than wholly untested systems:
+The current suite covers 2,230 tests across 126 scripts, including the large brush, bake, paint, vertex, baker, brush-instance, and map-I/O systems. Remaining work is concentrated in failure semantics and scale-sensitive paths rather than wholly untested systems:
 - crash-safe destination replacement and truthful manual-save completion ([#33](https://github.com/saworbit/hammerforge/issues/33), [#51](https://github.com/saworbit/hammerforge/issues/51));
 - quoted `.map` property round-trips ([#32](https://github.com/saworbit/hammerforge/issues/32));
 - non-blocking threaded merge/finalization ([#35](https://github.com/saworbit/hammerforge/issues/35));

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -251,6 +251,12 @@ var _full_reconcile_needed := false
 ## Mark a specific brush as needing reconciliation.
 func tag_brush_dirty(brush_id: String) -> void:
 	_dirty_brush_ids[brush_id] = true
+	# This is the one call every transform, material, UV, paint and vertex
+	# mutation already makes, so it is where brush_changed belongs. Emit on
+	# every tag rather than only the first: the dirty set is not cleared until
+	# a bake, and a listener watching a drag needs each step, not just the one
+	# that happened to arrive first.
+	brush_changed.emit(brush_id)
 
 
 ## Mark a specific paint chunk as needing reconciliation.

--- a/tests/test_dirty_tags.gd
+++ b/tests/test_dirty_tags.gd
@@ -27,6 +27,7 @@ var _full_reconcile_needed := false
 
 func tag_brush_dirty(brush_id: String) -> void:
 	_dirty_brush_ids[brush_id] = true
+	brush_changed.emit(brush_id)
 
 func tag_paint_dirty(chunk_coord: Vector2i) -> void:
 	if not _dirty_paint_chunks.has(chunk_coord):
@@ -126,6 +127,40 @@ func test_tag_brush_dirty_dedup():
 	root.tag_brush_dirty("brush_1")
 	var tags = root.consume_dirty_tags()
 	assert_eq(tags["brush_ids"].size(), 1, "Duplicate tag should not add twice")
+
+
+## The shim above stands in for LevelRoot everywhere else in this file. These
+## two build the real one, because a signal the shim emits proves nothing about
+## whether production does.
+func _real_level_root() -> Node3D:
+	var level_root = LevelRootType.new()
+	level_root.name = "RealLevelRoot"
+	return level_root
+
+
+func test_tag_brush_dirty_emits_brush_changed():
+	# brush_changed was declared and never emitted. HFSubtractPreview connects
+	# to it, so the preview listened to a signal that could not fire.
+	var level_root := _real_level_root()
+	var seen: Array = []
+	level_root.brush_changed.connect(func(brush_id: String): seen.append(brush_id))
+	level_root.tag_brush_dirty("b1")
+	assert_eq(seen, ["b1"], "Tagging a brush dirty announces that brush changed")
+	level_root.free()
+
+
+func test_repeat_tags_keep_announcing():
+	# The dirty set is not cleared until a bake, so a drag tags the same id on
+	# every step. Announcing only the first would freeze a live preview.
+	var level_root := _real_level_root()
+	var seen: Array = []
+	level_root.brush_changed.connect(func(brush_id: String): seen.append(brush_id))
+	level_root.tag_brush_dirty("b1")
+	level_root.tag_brush_dirty("b1")
+	level_root.tag_brush_dirty("b2")
+	assert_eq(seen, ["b1", "b1", "b2"], "Every tag is announced, not just new ids")
+	assert_eq(level_root._dirty_brush_ids.size(), 2, "The dirty set still dedupes")
+	level_root.free()
 
 
 func test_tag_paint_dirty():

--- a/tests/test_subtract_preview.gd
+++ b/tests/test_subtract_preview.gd
@@ -165,3 +165,51 @@ func test_destroy_when_never_enabled():
 	preview.destroy()
 	assert_false(preview.is_enabled(), "Should remain disabled")
 	assert_eq(preview._mesh_pool.size(), 0, "Pool should be empty")
+
+
+# -- brush_changed wiring --------------------------------------------------------
+
+
+func _signal_root() -> Node3D:
+	var script := GDScript.new()
+	script.source_code = """
+extends Node3D
+
+signal brush_added(brush_id: String)
+signal brush_removed(brush_id: String)
+signal brush_changed(brush_id: String)
+
+var draft_brushes_node: Node3D
+"""
+	script.reload()
+	var root := Node3D.new()
+	root.set_script(script)
+	var draft := Node3D.new()
+	draft.name = "DraftBrushes"
+	root.add_child(draft)
+	root.draft_brushes_node = draft
+	add_child_autofree(root)
+	return root
+
+
+func test_enabled_preview_rebuilds_when_a_brush_changes():
+	var root := _signal_root()
+	var preview = HFSubtractPreview.new(root)
+	preview.set_enabled(true)
+	# Clear the update set_enabled itself asked for.
+	preview.process(1.0)
+	assert_false(preview._needs_rebuild, "Starting state is settled")
+	root.brush_changed.emit("b1")
+	assert_true(preview._needs_rebuild, "A changed brush must schedule a rebuild")
+	preview.destroy()
+
+
+func test_disabled_preview_ignores_a_changed_brush():
+	var root := _signal_root()
+	var preview = HFSubtractPreview.new(root)
+	preview.set_enabled(true)
+	preview.set_enabled(false)
+	preview.process(1.0)
+	root.brush_changed.emit("b1")
+	assert_false(preview._needs_rebuild, "A disabled preview stays disconnected")
+	preview.destroy()


### PR DESCRIPTION
Follows the gap I flagged on #129.

`brush_changed` was declared at `level_root.gd:161` and emitted nowhere. `HFSubtractPreview` connects to it at lines 121 and 130, so the live subtract overlay was listening to a signal that could not arrive. In practice it only refreshed when a brush was added or removed: moving, resizing, retexturing or vertex editing a brush left the overlay showing the old cut. `HammerForge_SPEC.md:28` and `docs/HammerForge_MVP_GUIDE.md:90` both documented it as working.

**Where it emits.** `tag_brush_dirty()`. That is the one call every transform, material, UV, paint and vertex mutation already makes, and `DEVELOPMENT.md` already names it as the contract for exactly those cases, so all 22 call sites are covered without touching any of them.

**Why on every tag, not just the first.** The dirty set is not cleared until a bake, so during a drag the same id is tagged on every step. Emitting only when the id was new would announce the first frame and then go silent, which is worse than not firing at all.

**Why this is cheap.** The preview connects in `set_enabled(true)` and disconnects in `set_enabled(false)`, and `show_subtract_preview` defaults to `false`. With no one connected the emit costs almost nothing. When it is on, the listener is `request_update()`, which sets a flag and resets a 0.15s debounce.

I left the unused `_emit_or_batch` path alone. It has no production caller, and `_flush_batched_signals` coalesces these three signals into `selection_changed` rather than re-emitting them, so routing through it would mean the preview stops hearing `brush_changed` inside a batch. Emitting directly matches how `brush_added` and `brush_removed` already work.

**One thing the tests turned up.** The root shim in `tests/test_dirty_tags.gd` reimplements `tag_brush_dirty`, so a test written there would have asserted on the shim and passed with production untouched. The shim now emits as well, and the two tests that matter build a real `LevelRoot`. Checked they fail without the fix: both report an empty array where they want the announced ids.

Test counts in README, DEVELOPMENT, SPEC and ROADMAP move to 2,230 across 126 scripts, since this adds four.