### PR TITLE
Distinguish a refused bake from a failed one

### DIFF
--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -27,6 +27,7 @@ const HFInputStateType = preload("input_state.gd")
 const HFEntitySystemType = preload("systems/hf_entity_system.gd")
 const HFBrushSystemType = preload("systems/hf_brush_system.gd")
 const HFBakeSystemType = preload("systems/hf_bake_system.gd")
+const BakeStatus = HFBakeSystemType.BakeStatus
 const HFPaintSystemType = preload("systems/hf_paint_system.gd")
 const HFFileSystemType = preload("systems/hf_file_system.gd")
 const HFPrototypeTextures = preload("hf_prototype_textures.gd")
@@ -1636,6 +1637,12 @@ func cancel_extrude() -> void:
 # ===========================================================================
 
 
+## Bake the level. Returns true only when geometry was produced.
+##
+## false is ambiguous on its own: the bake may have been refused because one was
+## already running (LevelRoot starts its own when a level loads), or it may have
+## genuinely failed. Call get_last_bake_status() immediately afterwards to tell
+## them apart, or wait for is_bake_in_flight() to clear before calling.
 func bake(
 	apply_cuts: bool = true,
 	hide_live: bool = false,
@@ -1668,6 +1675,14 @@ func is_bake_in_flight() -> bool:
 
 func was_last_bake_successful() -> bool:
 	return bake_system != null and bake_system._last_bake_success
+
+
+## Why the most recent bake call returned what it did, as a BakeStatus. Read it
+## immediately after the call: the next one overwrites it.
+func get_last_bake_status() -> int:
+	if bake_system == null:
+		return BakeStatus.NOT_RUN
+	return bake_system.get_last_bake_status()
 
 
 func estimate_bake_time(brush_ids: Array = []) -> Dictionary:

--- a/addons/hammerforge/systems/hf_bake_system.gd
+++ b/addons/hammerforge/systems/hf_bake_system.gd
@@ -17,9 +17,18 @@ const BAKED_PREVIEW_MODE_META := &"_hammerforge_bake_preview_mode"
 ## and generates unshaded wireframe, PROXY uses simplified box meshes.
 enum PreviewMode { FULL, WIREFRAME, PROXY }
 
+## Why the last bake call returned what it did.
+##
+## Every bake entry point returns a plain bool, and false alone is ambiguous:
+## a refused bake, a bake with nothing to do, and a bake that genuinely failed
+## all look identical. Callers that need the difference read
+## get_last_bake_status() immediately after the call.
+enum BakeStatus { NOT_RUN, SUCCESS, FAILED, BUSY, NOTHING_TO_DO }
+
 var root: Node3D
 var _last_dirty_brush_ids: Dictionary = {}  # brush_id -> true; captured at bake start
 var _last_bake_success: bool = false
+var _last_bake_status: int = BakeStatus.NOT_RUN
 var _bake_in_flight := false
 static var _wireframe_shader: Shader = null
 static var _wireframe_material: ShaderMaterial = null
@@ -287,12 +296,19 @@ func _total_bakeable_brush_count() -> int:
 # ---------------------------------------------------------------------------
 
 
+## Why the most recent bake call returned what it did. Read it immediately
+## after the call: it is overwritten by the next one.
+func get_last_bake_status() -> int:
+	return _last_bake_status
+
+
 func is_bake_in_flight() -> bool:
 	return _bake_in_flight
 
 
 func _try_begin_bake() -> bool:
 	if _bake_in_flight:
+		_last_bake_status = BakeStatus.BUSY
 		root.emit_signal("user_message", "A bake is already running", 1)
 		return false
 	_bake_in_flight = true
@@ -308,6 +324,7 @@ func bake_selected(
 		return false
 	await _bake_selected_impl(brush_nodes, collision_layer_mask, preview_mode)
 	_bake_in_flight = false
+	_last_bake_status = BakeStatus.SUCCESS if _last_bake_success else BakeStatus.FAILED
 	return _last_bake_success
 
 
@@ -380,11 +397,13 @@ func _bake_selected_impl(
 ## Missing dirty IDs represent deletions and therefore still require a bake.
 func bake_dirty(collision_layer_mask: int = 0, preview_mode: int = 0) -> bool:
 	if _bake_in_flight:
+		_last_bake_status = BakeStatus.BUSY
 		root.emit_signal("user_message", "A bake is already running", 1)
 		return false
 	var dirty_ids: Array = root._dirty_brush_ids.keys()
 	var full_reconcile_started: bool = root._full_reconcile_needed
 	if dirty_ids.is_empty() and not full_reconcile_started:
+		_last_bake_status = BakeStatus.NOTHING_TO_DO
 		root.emit_signal("user_message", "No changed brushes since last bake", 1)
 		return false
 	var dirty_snapshot: Dictionary = root._dirty_brush_ids.duplicate()
@@ -565,6 +584,7 @@ func bake(
 		return false
 	await _bake_impl(apply_cuts, hide_live, collision_layer_mask, preview_mode, force_csg)
 	_bake_in_flight = false
+	_last_bake_status = BakeStatus.SUCCESS if _last_bake_success else BakeStatus.FAILED
 	return _last_bake_success
 
 

--- a/tests/test_bake_system.gd
+++ b/tests/test_bake_system.gd
@@ -2498,3 +2498,53 @@ func test_collect_nonstructural_brushes_tolerates_incomplete_root():
 	var sys := HFBakeSystem.new(incomplete)
 	var brushes: Array = sys._collect_nonstructural_brushes()
 	assert_eq(brushes.size(), 0)
+
+
+# ---------------------------------------------------------------------------
+# Bake status
+#
+# Every bake entry point returns a plain bool. false alone cannot distinguish a
+# refused bake from a failed one, which is how a correctly-refused bake gets
+# misread as a broken bake pipeline.
+# ---------------------------------------------------------------------------
+
+
+func test_bake_status_starts_not_run():
+	assert_eq(bake_sys.get_last_bake_status(), HFBakeSystem.BakeStatus.NOT_RUN)
+
+
+func test_refused_bake_reports_busy_not_failure():
+	bake_sys._bake_in_flight = true
+	var ok: bool = await bake_sys.bake()
+	assert_false(ok, "A bake already in flight refuses the call")
+	assert_eq(
+		bake_sys.get_last_bake_status(),
+		HFBakeSystem.BakeStatus.BUSY,
+		"Refusal must be distinguishable from failure",
+	)
+
+
+func test_refused_selection_bake_reports_busy():
+	bake_sys._bake_in_flight = true
+	var ok: bool = await bake_sys.bake_selected([])
+	assert_false(ok)
+	assert_eq(bake_sys.get_last_bake_status(), HFBakeSystem.BakeStatus.BUSY)
+
+
+func test_bake_dirty_while_in_flight_reports_busy():
+	bake_sys._bake_in_flight = true
+	var ok: bool = await bake_sys.bake_dirty()
+	assert_false(ok)
+	assert_eq(bake_sys.get_last_bake_status(), HFBakeSystem.BakeStatus.BUSY)
+
+
+func test_bake_dirty_with_no_changes_reports_nothing_to_do():
+	root._dirty_brush_ids = {}
+	root._full_reconcile_needed = false
+	var ok: bool = await bake_sys.bake_dirty()
+	assert_false(ok, "Nothing to bake returns false")
+	assert_eq(
+		bake_sys.get_last_bake_status(),
+		HFBakeSystem.BakeStatus.NOTHING_TO_DO,
+		"Nothing to do must be distinguishable from failure",
+	)


### PR DESCRIPTION
Closes the API trap found while fixing #134.

## The problem

Every bake entry point returns a plain `bool`, and `false` alone was ambiguous:

| Call | `false` could mean |
|---|---|
| `bake()` | refused (one already running) **or** failed |
| `bake_selected()` | refused **or** failed |
| `bake_dirty()` | refused **or** nothing to do **or** failed |

The refusal was reported only through the `user_message` signal, which has no listener outside the editor. So a correctly-refused bake was indistinguishable from a broken bake pipeline.

That's not hypothetical — it's exactly the trap I fell into in #133. `LevelRoot` starts its own bake when a level loads, so any script calling `bake()` shortly after loading gets refused and sees `false`.

## The fix

`BakeStatus { NOT_RUN, SUCCESS, FAILED, BUSY, NOTHING_TO_DO }`, recorded at every entry point and readable via `get_last_bake_status()` on both the bake system and `LevelRoot`. `LevelRoot` re-exports the enum so callers don't need to preload the subsystem:

```gdscript
if not await level.bake():
    match level.get_last_bake_status():
        LevelRoot.BakeStatus.BUSY:
            pass  # a bake was already running; wait and retry
        LevelRoot.BakeStatus.FAILED:
            push_error("bake failed")
```

**Return types are unchanged**, so existing callers are unaffected. The status is set before each call returns and read immediately after, so there's no race with a concurrently running bake.

## Tests

Five new tests in `test_bake_system.gd` covering the initial state, refusal on all three entry points, and nothing-to-do. Full suite: **2241 tests, 0 failures** (7 pre-existing risky/pending, unrelated).