### PR TITLE
Upload the MkDocs output from .site, not site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,9 @@ jobs:
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5
         with:
-          path: site
+          # Must track site_dir in mkdocs.yml, which is .site so Godot does not
+          # scan the built site and report UID collisions against docs/.
+          path: .site
 
   deploy:
     needs: build


### PR DESCRIPTION
Follow-up to #136.

Moving the MkDocs output to `.site` stopped Godot scanning the built site (it was reporting a UID collision for every image against its copy in `docs/`), but the Pages workflow still uploaded `site/`.

The build step passed and `upload-pages-artifact` then failed with nothing to upload, so the docs deploy has been broken since that change. The live site is still serving the previous successful deploy.

One line: `path: site` → `path: .site`, with a comment noting it must track `site_dir`.