### PR TITLE
Dress the docs site in the HammerForge brand

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
-# HammerForge
+![HammerForge](brand/svg/hammerforge-lockup-light.svg#only-light){ width="460" }
+![HammerForge](brand/svg/hammerforge-lockup-dark.svg#only-dark){ width="460" }
 
-**Brush-based level editor for Godot 4.7+**
+# Brush-based level editor for Godot 4.7+
 
 Draw rooms, carve doors, paint terrain, and bake to optimized meshes — all
 inside the Godot editor.

--- a/docs/stylesheets/brand.css
+++ b/docs/stylesheets/brand.css
@@ -1,0 +1,43 @@
+/* HammerForge brand palette. See docs/brand/BRAND.md.
+ *
+ * Red is the only accent, and it is not decorative: it is the colour the
+ * viewport already uses to outline subtract brushes. Godot blue is absent by
+ * design -- an addon wearing the engine's colour reads as first-party. */
+:root {
+  --hf-red: #e03131;
+  --hf-ink: #14171c;
+  --hf-paper: #f2f4f7;
+  --hf-slate: #79818f;
+}
+
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color: var(--hf-red);
+  --md-primary-fg-color--light: #e85d5d;
+  --md-primary-fg-color--dark: #b82626;
+  --md-primary-bg-color: var(--hf-paper);
+  --md-accent-fg-color: var(--hf-red);
+  --md-typeset-a-color: #c22a2a;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: var(--hf-ink);
+  --md-primary-fg-color--light: #2a2f38;
+  --md-primary-fg-color--dark: #0d1015;
+  --md-primary-bg-color: var(--hf-paper);
+  --md-accent-fg-color: var(--hf-red);
+  --md-typeset-a-color: #ff6b6b;
+  --md-default-bg-color: var(--hf-ink);
+}
+
+/* Slate is for annotation and rules, with no accent role. */
+.md-typeset hr {
+  border-bottom-color: var(--hf-slate);
+  opacity: 0.35;
+}
+
+/* Screenshots carry their own frame badly against a flat page; a hairline and
+ * soft corners stop them bleeding into the background in either theme. */
+.md-typeset img[src*="/images/"] {
+  border-radius: 6px;
+  border: 1px solid rgba(121, 129, 143, 0.35);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,18 +12,20 @@ exclude_docs: |
 
 theme:
   name: material
+  logo: brand/svg/hammerforge-mark-dark.svg
+  favicon: brand/svg/favicon.svg
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: red
-      accent: red
+      primary: custom
+      accent: custom
       toggle:
         icon: material/weather-night
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: red
-      accent: red
+      primary: custom
+      accent: custom
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode
@@ -34,6 +36,9 @@ theme:
     - navigation.top
     - content.code.copy
     - search.suggest
+
+extra_css:
+  - stylesheets/brand.css
 
 markdown_extensions:
   - admonition
@@ -65,4 +70,5 @@ nav:
   - Reference:
       - Design Constraints: HammerForge_Design_Constraints.md
       - Editor Smoke Checklist: HammerForge_Editor_Smoke_Checklist.md
+      - Brand: brand/BRAND.md
       - Regenerating Screenshots: demos/README.md


### PR DESCRIPTION
The site was running Material's stock red with no logo and no favicon — a generic MkDocs build rather than the project it documents.

## Palette

From `docs/brand/BRAND.md`, applied via `docs/stylesheets/brand.css`:

| Token | Hex | Role |
|---|---|---|
| Red | `#E03131` | The only accent |
| Ink | `#14171C` | Dark ground |
| Paper | `#F2F4F7` | Light ground |
| Slate | `#79818F` | Rules, no accent role |

Godot blue stays absent, per the brand notes — an addon wearing the engine's colour reads as first-party.

## Logo variant

The header uses the **paper** mark, not the ink one. Material's header is always the primary colour — brand red in light, Ink in dark — so both are dark grounds and `hammerforge-mark-light.svg` (ink on red) would be close to invisible. Verified in the browser: header computes to `rgb(224, 49, 49)` with the paper mark on it.

## Also

- Home page leads with the lockup, switching variant by colour scheme.
- `BRAND.md` joins the nav under Reference. It was being built but left unreachable.
- Screenshots get a hairline border so they stop bleeding into the page in either theme.