### PR TITLE
Stop shipping the capture plugin enabled

### DIFF
--- a/addons/hf_docshot/hf_docshot.gd
+++ b/addons/hf_docshot/hf_docshot.gd
@@ -6,8 +6,14 @@ extends EditorPlugin
 ## viewport that owns the editor base control. This is what makes UI screenshots
 ## regenerable instead of hand-grabbed.
 ##
-## Inert unless the HF_DOCSHOT environment variable is "1", so leaving the plugin
-## enabled costs nothing during normal editing.
+## Deliberately NOT enabled in project.godot. tools/capture_ui.py enables it for
+## the duration of a capture run and removes it again afterwards. An
+## EditorPlugin that reads an environment variable and can call
+## get_tree().quit() should not load in a contributor's normal session, where a
+## stray HF_DOCSHOT=1 would close their editor mid-work.
+##
+## The HF_DOCSHOT check below is a second gate, for anyone who enables the
+## plugin by hand.
 ##
 ## Usage:
 ##   HF_DOCSHOT=1 godot --editor --path .

--- a/docs/demos/README.md
+++ b/docs/demos/README.md
@@ -39,11 +39,15 @@ drives the editor's own 3D camera, cycles the dock tabs, switches main screens,
 and writes the images before quitting.
 
 ```bash
-HF_DOCSHOT=1 godot --editor --path .
+python tools/capture_ui.py
 ```
 
-The plugin is inert unless `HF_DOCSHOT=1`, so leaving it enabled costs nothing
-during normal editing.
+The plugin is **not** enabled in `project.godot`. The wrapper enables it for the
+duration of the run and removes it again, because an `EditorPlugin` that reads
+an environment variable and can call `get_tree().quit()` should not load during
+normal editing -- a stray `HF_DOCSHOT=1` would otherwise close your editor
+mid-work. The env var remains as a second gate for anyone enabling the plugin
+by hand.
 
 ### Composing the shot
 
@@ -99,6 +103,15 @@ showcase must be opened late or it loses the active tab; opening a level hands
 the main screen back to the HammerForge plugin, so each screen is re-selected
 immediately before its own capture; and `F`-to-frame never reaches the viewport,
 so the editor camera is positioned directly.
+
+## Captures are not byte-stable
+
+Re-running a capture with no changes still produces slightly different PNGs.
+The Console header carries a live `Checked HH:MM:SS` timestamp, and antialiasing
+around dock text varies with layout timing, so a few kilobytes shift each run.
+
+Only commit regenerated images when something actually changed. `git restore
+docs/images/` discards a no-op run.
 
 ## Not covered by the stills
 

--- a/project.godot
+++ b/project.godot
@@ -21,7 +21,7 @@ MCPRuntimeProbe="*uid://bsg12huaf1u5i"
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/hammerforge/plugin.cfg", "res://addons/godot_mcp/plugin.cfg", "res://addons/hf_docshot/plugin.cfg")
+enabled=PackedStringArray("res://addons/hammerforge/plugin.cfg", "res://addons/godot_mcp/plugin.cfg")
 
 [physics]
 

--- a/tools/capture_ui.py
+++ b/tools/capture_ui.py
@@ -75,12 +75,26 @@ def prepare() -> None:
         if src.exists():
             shutil.copy2(src, BACKUP_DIR / rel.name)
 
+    import re
+
     proj = REPO / "project.godot"
     text = proj.read_text(encoding="utf-8")
     text = text.replace(', "res://addons/godot_mcp/plugin.cfg"', "")
     text = "\n".join(
         l for l in text.split("\n") if not l.startswith("MCPRuntimeProbe=")
     )
+    # Enable the capture plugin for this run only. It is deliberately not
+    # shipped enabled: an EditorPlugin that reads an environment variable and
+    # can call get_tree().quit() should not load during a contributor's normal
+    # session, where a stray HF_DOCSHOT=1 would close their editor mid-work.
+    text, enabled_count = re.subn(
+        r'(?m)^(enabled=PackedStringArray\((?!.*hf_docshot).*?)\)$',
+        r'\1, "res://addons/hf_docshot/plugin.cfg")',
+        text,
+        count=1,
+    )
+    if enabled_count != 1:
+        raise SystemExit("could not enable hf_docshot in project.godot")
     proj.write_text(text, encoding="utf-8", newline="\n")
 
     layout = REPO / ".godot/editor/editor_layout.cfg"


### PR DESCRIPTION
Item 3 from the review pass.

## The problem

`hf_docshot` was listed in `project.godot`'s enabled plugins. It reads `HF_DOCSHOT` from the environment and, on the capture path, calls `get_tree().quit()`.

A contributor who happened to have `HF_DOCSHOT=1` set for any reason would open the project, silently run a capture that overwrote `docs/images/`, and have their editor close on them. Unlikely, but an env var alone should not be able to do that.

## The fix

The plugin is no longer enabled by default. `tools/capture_ui.py` adds it to the enabled list for the duration of a run and removes it again — inside the swap it already performs and already restores crash-safely, so this adds no new machinery and no new failure mode.

Verified round trip:

```
before : PackedStringArray("...hammerforge...", "...godot_mcp...")
during : PackedStringArray("...hammerforge...", "...hf_docshot...")
after  : PackedStringArray("...hammerforge...", "...godot_mcp...")   # byte-identical to before
```

Then end to end: **11 images captured**, `project.godot` restored, tree clean.

The environment variable stays as a second gate for anyone enabling the plugin by hand.

## Also

Documents that captures are not byte-stable — the Console header carries a live `Checked HH:MM:SS` timestamp and dock antialiasing shifts with layout timing, so a no-op run still rewrites a few KB. Only commit regenerated images when something actually changed.