### PR TITLE
Give every docs page its own description, and mark the site up as software

### DIFF
--- a/docs/HammerForge_Data_Portability.md
+++ b/docs/HammerForge_Data_Portability.md
@@ -1,3 +1,7 @@
+---
+description: "Moving level data in and out of HammerForge safely: the .hflevel save format, version fields, UV migration and region streaming files."
+---
+
 # HammerForge Data Portability
 
 Last updated: September 2, 2026

--- a/docs/HammerForge_Design_Constraints.md
+++ b/docs/HammerForge_Design_Constraints.md
@@ -1,3 +1,7 @@
+---
+description: "What HammerForge optimises for, stated plainly: draft brush previews rather than live CSG, cuts staged until applied, geometry made at bake time."
+---
+
 # HammerForge Design Constraints
 
 Last updated: September 3, 2026

--- a/docs/HammerForge_Editor_Smoke_Checklist.md
+++ b/docs/HammerForge_Editor_Smoke_Checklist.md
@@ -1,3 +1,7 @@
+---
+description: "Manual smoke checklist for verifying a HammerForge build inside the Godot editor before release."
+---
+
 # HammerForge Editor Smoke Checklist
 
 Last updated: September 2, 2026

--- a/docs/HammerForge_FloorPaint_Greyboxing.md
+++ b/docs/HammerForge_FloorPaint_Greyboxing.md
@@ -1,3 +1,7 @@
+---
+description: "Grid-based floor painting and greyboxing in HammerForge: heightmaps, multi-material blending, auto-connectors and foliage scatter."
+---
+
 # HammerForge Floor Paint Greyboxing
 
 Last updated: March 27, 2026

--- a/docs/HammerForge_Install_Upgrade.md
+++ b/docs/HammerForge_Install_Upgrade.md
@@ -1,3 +1,7 @@
+---
+description: "Install HammerForge into a Godot 4.7+ project, enable the plugin, and upgrade an existing install without losing level data."
+---
+
 # HammerForge Install + Upgrade
 
 Last updated: August 22, 2026

--- a/docs/HammerForge_MVP_GUIDE.md
+++ b/docs/HammerForge_MVP_GUIDE.md
@@ -1,3 +1,7 @@
+---
+description: "The shortest path from an empty Godot scene to a playable blockout: draw brushes, cut openings, paint surfaces, bake and test."
+---
+
 # HammerForge MVP Guide
 
 Last updated: September 3, 2026

--- a/docs/HammerForge_Prototype_Textures.md
+++ b/docs/HammerForge_Prototype_Textures.md
@@ -1,3 +1,7 @@
+---
+description: "150 built-in prototype textures for greyboxing in Godot: 15 patterns across 10 colours, drawn as SVGs so they stay sharp at any resolution."
+---
+
 # HammerForge Prototype Textures
 
 Last updated: March 28, 2026

--- a/docs/HammerForge_Texture_Materials.md
+++ b/docs/HammerForge_Texture_Materials.md
@@ -1,3 +1,7 @@
+---
+description: "HammerForge's per-face material system: a shared material palette, UV projection and editing tools, and the surface paint workflow."
+---
+
 # HammerForge Texture and Materials
 
 Last updated: April 5, 2026

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -1,3 +1,7 @@
+---
+description: "Day-to-day reference for building levels with HammerForge: the dock, viewport tools, entities, I/O connections and the runtime API."
+---
+
 # HammerForge User Guide
 
 Last updated: September 5, 2026

--- a/docs/brand/BRAND.md
+++ b/docs/brand/BRAND.md
@@ -1,3 +1,7 @@
+---
+description: "HammerForge brand identity: logo lockups and marks, the colour palette, and how the assets should be used."
+---
+
 # HammerForge — brand identity
 
 `saworbit/hammerforge` · a brush-based level editor for Godot 4.7+

--- a/docs/demos/README.md
+++ b/docs/demos/README.md
@@ -1,3 +1,7 @@
+---
+description: "How HammerForge's screenshots and demo video are generated, and the harness that records the editor being driven by a real mouse."
+---
+
 # Demo Media
 
 Last updated: September 7, 2026

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,3 +1,7 @@
+---
+description: "Complete feature and reference material for HammerForge: brush drawing, pending cuts, floor paint, entities, baking, collision and the Console."
+---
+
 # Features and Reference
 
 The complete feature and reference material for HammerForge. For a quick

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+description: "Brush-based level editor for Godot 4.7+. Draw rooms, carve doorways, paint terrain and bake to optimised meshes without leaving the Godot editor."
+---
+
 ![HammerForge](brand/svg/hammerforge-lockup-light.svg#only-light){ width="460" }
 ![HammerForge](brand/svg/hammerforge-lockup-dark.svg#only-dark){ width="460" }
 

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -34,4 +34,30 @@
   <meta name="twitter:title" content="{{ page_title }}">
   <meta name="twitter:description" content="{{ page_desc }}">
   <meta name="twitter:image" content="{{ preview }}">
+
+  {#
+    Structured data, home page only. Tells a search engine this is a free
+    developer tool rather than an article, which is what decides whether it can
+    appear as software rather than as a page of text.
+  #}
+  {% if page and page.is_homepage %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "{{ config.site_name }}",
+      "description": "{{ config.site_description }}",
+      "applicationCategory": "DeveloperApplication",
+      "applicationSubCategory": "Level editor",
+      "operatingSystem": "Windows, macOS, Linux",
+      "url": "{{ config.site_url }}",
+      "image": "{{ preview }}",
+      "codeRepository": "{{ config.repo_url }}",
+      "programmingLanguage": "GDScript",
+      "license": "https://opensource.org/licenses/MIT",
+      "isAccessibleForFree": true,
+      "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+    }
+  </script>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
All thirteen docs pages inherited `site_description`, so a search engine saw thirteen pages claiming to be the same thing, with nothing to tell them apart in a result listing. Each now carries its own, written from what the page actually covers. The `og:` and `twitter:` tags derive from the same value, so link previews improve too.

The home page also gains `SoftwareApplication` structured data. Without it the site is a page of text; with it, a search engine can tell it is a free developer tool, what it is written in, and where the source lives.

## A trap worth knowing about

An unquoted YAML scalar cannot contain `": "`, and **MkDocs drops the whole front matter block without a word when it does — even under `--strict`**. Nine of these descriptions have a colon in them, and the first attempt silently kept the site default on every page except the home page (which has no colon, so it worked and looked like proof the approach was fine). The values are quoted for that reason.

## Verified in the built output

- All 13 pages emit distinct `<meta name="description">` and `og:description`.
- The JSON-LD parses, and is present on the home page only.
