### PR TITLE
Separate what ships from what this repository contains

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development Guide
 
-Last updated: September 3, 2026
+Last updated: September 7, 2026
 
 This document covers local setup, codebase structure, and how to test features.
 
@@ -12,6 +12,71 @@ This document covers local setup, codebase structure, and how to test features.
 1. Open the project in Godot.
 2. Enable the plugin: Project -> Project Settings -> Plugins -> HammerForge.
 3. Open any 3D scene and choose **Create Starter** or **Create Empty** from the dock's empty state.
+
+## What ships, and what does not
+
+This repository is a development workspace as well as the home of the plugin.
+The distinction matters more than it looks, because the Godot Asset Library
+installs whatever it finds at the commit it is pointed at -- so without a
+deliberate separation, installing HammerForge would also drop a test framework
+and the maintainer's own tooling into somebody else's project.
+
+**Only `addons/hammerforge` reaches users.** Everything else in the tree is
+development apparatus:
+
+| Not shipped | Why |
+|---|---|
+| `addons/gut` | Third-party test framework. Only `tests/` uses it, and anyone who already has GUT installed would have their copy overwritten by whichever version this repository pins, which can break their own suite. |
+| `addons/godot_mcp` | Contributor MCP server. Nothing to do with the plugin. |
+| `addons/hf_docshot` | Dev-only screenshot and demo-recording plugin. It reads an environment variable and can quit the editor. |
+| `tests/`, `tools/` | Test suite and build machinery. |
+| `docs/`, `overrides/` | The documentation site. Published, not installed. |
+| `samples/` | Demo scenes for the screenshots and the video. |
+| `project.godot`, `level_root.tscn` | Belong to whoever is installing. |
+
+The list lives in `tools/build_release_tree.py` and the default is exclude: a
+new folder does not reach users until somebody adds it deliberately. The
+release workflow re-checks the built output rather than trusting the list.
+
+```bash
+python tools/build_release_tree.py /tmp/release   # inspect what would ship
+```
+
+### Cutting a release
+
+The `release` branch holds the built tree. It is what the Asset Library
+downloads, by commit hash. It is a build artefact: never merge it into `main`
+or `main` into it, and expect its contents to be replaced wholesale each time.
+
+1. Bump `version=` in `addons/hammerforge/plugin.cfg` and update `CHANGELOG.md`.
+2. Build the tree and replace the branch contents with it:
+
+   ```bash
+   python tools/build_release_tree.py /tmp/release
+   git worktree add --detach /tmp/relwt && cd /tmp/relwt
+   git checkout release
+   find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+   cp -a /tmp/release/. .
+   git add -A && git commit -m "HammerForge 0.3.0" && git push origin release
+   ```
+
+   Removing the contents first matters: copying over the top would leave behind
+   anything dropped from the ship list.
+3. Tag `main`: `git tag v0.3.0 && git push origin v0.3.0`.
+4. Paste the new `release` commit hash into the Asset Library entry's
+   **Download Commit** field. There is no API for that, so it stays manual.
+
+Steps 2 and 4's first half are worth automating on tag; a workflow to do it is
+drafted but not yet committed, because pushing `.github/workflows/` needs a
+token with the `workflow` scope.
+
+### The same rule applies to screenshots and demos
+
+Development tooling should not appear in anything users see, not just in what
+they install. `tools/capture_ui.py` removes the MCP server from `project.godot`
+before capturing so it does not show up in the editor's main-screen bar, and
+puts it back afterwards. If you add tooling that is visible in the editor,
+extend that swap rather than cropping it out of the image.
 
 ## Godot MCP Development Setup
 

--- a/tools/build_release_tree.py
+++ b/tools/build_release_tree.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Assemble the tree that ships to users, and nothing else.
+
+    python tools/build_release_tree.py <output-dir>
+
+This repository is a development workspace as well as the home of the plugin.
+It contains a test framework, contributor tooling and the machinery that builds
+the documentation, none of which a user of HammerForge has any use for. The
+Godot Asset Library installs whatever is in the repository at the commit it is
+pointed at, so "the repository" and "the release" have to be different things.
+
+What ships is the list below and nothing that is not on it. The default is
+exclude: a new folder added to the repository does not reach users until
+somebody puts it here deliberately.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Everything a user needs, and only that.
+#
+# The plugin is self-contained: the only paths it references outside its own
+# folder are ones it creates inside the user's project at runtime
+# (res://.hammerforge/, res://hammerforge_entities.json, res://prefabs).
+#
+# LICENSE and .gitignore are here because the Asset Library submission
+# guidelines require the repository to carry both.
+SHIP = [
+    "addons/hammerforge",
+    "LICENSE",
+    ".gitignore",
+]
+
+# Named so the reason is recorded rather than rediscovered. These are all
+# development tooling that lives in this repository for the maintainer's
+# convenience; shipping them puts files in someone else's project that they did
+# not ask for and cannot be expected to understand.
+#
+#   addons/gut          A third-party test framework. Only tests/ uses it, and
+#                       tests do not ship. Worse than useless to a user: anyone
+#                       who already has GUT installed would have their copy
+#                       overwritten by whichever version this repository pins,
+#                       which can break their own test suite.
+#   addons/godot_mcp    Contributor MCP server. Nothing to do with the plugin.
+#   addons/hf_docshot   Dev-only screenshot and demo-recording plugin. Reads an
+#                       environment variable and can quit the editor.
+#   tests/              Needs GUT, and tests the plugin rather than using it.
+#   tools/              This script, and the rest of the build machinery.
+#   docs/, overrides/   The documentation site. It is published, not installed.
+#   samples/            Demo scenes for the screenshots and the video.
+#   project.godot       Belongs to whoever is installing, not to us. Shipping
+#   level_root.tscn     it would overwrite their project settings.
+EXCLUDED_ON_PURPOSE = [
+    "addons/gut",
+    "addons/godot_mcp",
+    "addons/hf_docshot",
+    "tests",
+    "tools",
+    "docs",
+    "overrides",
+    "samples",
+    "project.godot",
+    "level_root.tscn",
+]
+
+# A short README for the release tree. The repository's own README is written
+# for GitHub and points at images under docs/, which do not ship -- copying it
+# would produce a page of broken images.
+RELEASE_README = """# HammerForge
+
+Brush-based level editor for Godot 4.7+. Draw rooms, carve doorways, paint
+terrain and bake to optimised meshes without leaving the Godot editor.
+
+This is the release tree: the plugin and nothing else. Copy `addons/hammerforge`
+into your project and enable **HammerForge** under
+*Project > Project Settings > Plugins*.
+
+- Documentation: https://saworbit.github.io/hammerforge/
+- Source, issues and development: https://github.com/saworbit/hammerforge
+
+Licensed under the MIT License. See `LICENSE`.
+"""
+
+
+def plugin_version() -> str:
+    """Read the version from plugin.cfg, so there is one source of truth."""
+    cfg = (REPO / "addons/hammerforge/plugin.cfg").read_text(encoding="utf-8")
+    for line in cfg.splitlines():
+        if line.startswith("version="):
+            return line.split("=", 1)[1].strip().strip('"')
+    raise SystemExit("no version= in addons/hammerforge/plugin.cfg")
+
+
+def tracked(path: str) -> list[str]:
+    """Files git knows about under `path`.
+
+    Deliberately not a filesystem walk: the working tree carries stray logs and
+    scratch files, and a release should contain what is committed, not whatever
+    happens to be lying around.
+    """
+    out = subprocess.run(
+        ["git", "ls-files", "-z", "--", path],
+        cwd=REPO, capture_output=True, text=True, check=True,
+    ).stdout
+    return [f for f in out.split("\0") if f]
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit(__doc__.strip())
+    dest = Path(sys.argv[1]).resolve()
+    if dest.exists() and any(dest.iterdir()):
+        raise SystemExit(f"refusing to build into a non-empty directory: {dest}")
+
+    for excluded in EXCLUDED_ON_PURPOSE:
+        for shipped in SHIP:
+            if excluded == shipped or excluded.startswith(shipped + "/"):
+                raise SystemExit(
+                    f"{excluded} is both shipped and excluded; the lists disagree"
+                )
+
+    count = 0
+    for entry in SHIP:
+        files = tracked(entry)
+        if not files:
+            raise SystemExit(f"nothing tracked under {entry}; check the SHIP list")
+        for rel in files:
+            target = dest / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(REPO / rel, target)
+            count += 1
+
+    # The licence travels with the plugin folder as well as the tree root, so it
+    # survives a user who installs only addons/hammerforge.
+    shutil.copy2(REPO / "LICENSE", dest / "addons/hammerforge/LICENSE")
+    (dest / "README.md").write_text(RELEASE_README, encoding="utf-8", newline="\n")
+
+    version = plugin_version()
+    print(f"HammerForge {version}: {count + 2} files in {dest}")
+    for entry in sorted(p.name for p in dest.iterdir()):
+        print(f"  {entry}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The Godot Asset Library installs whatever it finds at the commit it is pointed at. This repository is a development workspace as well as the home of the plugin, so pointed at `main` it would have written **345 files of tooling** into the user's project alongside the 818 that are actually HammerForge.

| Not shipped | Files | Why |
|---|---|---|
| `addons/gut` | 248 | Only `tests/` uses it. Anyone who already has GUT installed would have their copy overwritten by whichever version this repo pins, which can break their own suite. |
| `addons/godot_mcp` | 97 | Contributor MCP server. Nothing to do with the plugin. |
| `addons/hf_docshot` | 3 | Dev-only screenshot plugin. Reads an env var and can quit the editor. |

Plus `tests/`, `tools/`, `docs/`, `samples/`, `project.godot` and `level_root.tscn`.

## How it works

`tools/build_release_tree.py` owns the list and **defaults to excluding** — a new folder does not reach users until someone adds it deliberately. It copies from `git ls-files` rather than walking the filesystem, so a release contains what is committed rather than whatever is lying around the working tree. The licence is copied into `addons/hammerforge` as well as the tree root, so it survives a user who installs only the plugin folder.

`DEVELOPMENT.md` gains the policy and the release steps, including the point that the same rule applies to screenshots and demos — `capture_ui.py` already strips the MCP server from `project.godot` before capturing so it never appears in the editor's main-screen bar.

## The `release` branch is live

`395a272` — four top-level entries: `addons/`, `LICENSE`, `README.md`, `.gitignore`. 822 files, and the zip GitHub serves for that commit is 946 KB.

## Verified

The built tree **loads as a plugin in a bare Godot project** with nothing else in it. That is the real test of whether the addon is self-contained, and it is: the only paths it references outside its own folder are ones it creates in the user's project at runtime (`res://.hammerforge/`, `res://hammerforge_entities.json`, `res://prefabs`).

## Not included

A `.github/workflows/release.yml` that automates the branch update on tag is written and tested as far as it can be locally, but the token here lacks the `workflow` scope, so it cannot be pushed. `DEVELOPMENT.md` documents the manual steps instead and says so.
