### PR TITLE
Re-verify Search Console under the account that owns the repository

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -83,7 +83,7 @@ before capturing so it does not show up in the editor's main-screen bar, and
 puts it back afterwards. If you add tooling that is visible in the editor,
 extend that swap rather than cropping it out of the image.
 
-### Do not delete docs/googlea10fdf23f3cd65ee.html
+### Do not delete docs/googlef8407c6985aae961.html
 
 It is the Google Search Console ownership proof for
 `https://saworbit.github.io/hammerforge/`. The filename is the token and the
@@ -93,6 +93,12 @@ verbatim.
 Google re-checks it periodically, so removing it un-verifies the property and
 loses the indexing reports with it. It looks exactly like the kind of
 unexplained stray a tidy-up deletes, which is why it is written down here.
+
+The property belongs to the personal Google account that owns the repository.
+An earlier file, `googlea10fdf23f3cd65ee.html`, was issued to a different
+account by mistake and has been removed; a verification token is per-account,
+so re-verifying under a different one means a new file rather than reusing the
+old.
 
 ## Godot MCP Development Setup
 

--- a/docs/googlea10fdf23f3cd65ee.html
+++ b/docs/googlea10fdf23f3cd65ee.html
@@ -1,1 +1,0 @@
-google-site-verification: googlea10fdf23f3cd65ee.html

--- a/docs/googlef8407c6985aae961.html
+++ b/docs/googlef8407c6985aae961.html
@@ -1,0 +1,1 @@
+google-site-verification: googlef8407c6985aae961.html


### PR DESCRIPTION
The first verification landed on the wrong Google account. A verification token is issued per account, so moving the property means a new file rather than reusing the old one.

- removes `docs/googlea10fdf23f3cd65ee.html`
- adds `docs/googlef8407c6985aae961.html`
- `DEVELOPMENT.md` updated to name the current file and record why there was a second

Nothing was exposed by the mistake: the property is a public documentation site, and the file contains only a Google-issued token served on that public site. The cost was that the search data would have lived in an account the repository owner does not control.

Removing the old file rather than leaving it means the property on the other account loses its proof at Google's next re-check.