### PR TITLE
Add a second Search Console ownership proof

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -21,6 +21,14 @@
   {% endif %}
   {% set preview = config.site_url ~ "brand/png/social-preview.png" %}
 
+  {#
+    Second Search Console ownership proof, independent of
+    docs/googlef8407c6985aae961.html. Google re-checks whichever methods are
+    registered, so two of them means deleting one file cannot un-verify the
+    property and lose the indexing history with it.
+  #}
+  <meta name="google-site-verification" content="z8XeBvPGq6hzuC8M7io7XDFFRBNV0vzJQDLqJ_0LFoQ">
+
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="{{ config.site_name }}">
   <meta property="og:title" content="{{ page_title }}">


### PR DESCRIPTION
The HTML file is the only thing currently holding verification, and Google re-checks it periodically. Delete `docs/googlef8407c6985aae961.html` and the property un-verifies, taking the indexing history with it — and a file that looks like an unexplained stray is a plausible thing to delete, which is why `DEVELOPMENT.md` already needed a paragraph telling people not to.

A meta tag in `overrides/main.html` is a second, independent proof that nothing short of editing the theme override can remove. Confirmed present in the built home page.