### PR TITLE
Deploy the docs when the theme override changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      # The theme override is part of the site: it carries the link-preview
+      # metadata, the structured data and the Search Console proof. Leaving it
+      # out meant a change to it built locally, merged cleanly, and never
+      # deployed -- with nothing anywhere reporting a failure.
+      - "overrides/**"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
`overrides/` was missing from the docs workflow's `paths` filter, so a change to `overrides/main.html` alone never triggered a deploy. It built locally, passed review and merged cleanly — and the site kept serving the previous template, with nothing reporting a failure anywhere.

That template is not decoration. It carries the link-preview metadata, the `SoftwareApplication` structured data, and now a Search Console ownership proof. A silent no-op on any of those is the kind of thing you find weeks later.

Caught because the verification meta tag added in #161 never appeared on the live home page despite a green build.