### PR TITLE
Correct the test and line-count badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-1888%20passing-brightgreen" alt="1888 tests passing">
-  <img src="https://img.shields.io/badge/GDScript-44k%2B%20lines-blueviolet" alt="44k+ lines">
+  <img src="https://img.shields.io/badge/Tests-2234%20passing-brightgreen" alt="2234 tests passing">
+  <img src="https://img.shields.io/badge/GDScript-56k%2B%20lines-blueviolet" alt="56k+ lines">
 </p>
 
 <p align="center">


### PR DESCRIPTION
Both understated the project: the badges claimed **1888 tests** and **44k lines** against an actual **2241 tests** and **56,812 lines** in `addons/hammerforge`.

The figure is **2234**, not 2241, because that is how many actually pass — the other seven are pending/risky, not failing. A badge that rounds those into "passing" is the kind of small inaccuracy that makes a reader distrust everything else on the page.

Numbers from the last green CI run on `main` rather than counted by hand: Tests 2241, Passing 2234, Risky/Pending 7, Asserts 9316, across 126 scripts. Lines counted over `addons/hammerforge` only — the same basis the badge always used, since tests and tooling do not ship.