### PR TITLE
Link the demo clip on YouTube

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@
 
 <p align="center">
   <em>Drag a cut brush through the wall, apply it, then Test Level and walk up to the hole.<br>
-  <a href="https://saworbit.github.io/hammerforge/#see-it-in-motion">Watch the full 55-second clip</a> — it starts from an empty grid and builds the room first.</em>
+  <a href="https://saworbit.github.io/hammerforge/#see-it-in-motion">Watch the full 55-second clip</a>
+  or <a href="https://youtu.be/Nilou2q8SjE">on YouTube</a> — it starts from an empty grid and builds the room first.</em>
 </p>
 
 > **Fair warning:** This is a solo hobby project in early alpha. I built it to support another project and it grew from there. It's buggy, rough around the edges, and a bit directionless. If any of this looks useful to you, I'd genuinely appreciate help testing and filing issues. Contributions welcome -- just know you're signing up for an adventure, not a polished product.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,8 @@ nothing is sped up, cut together, or mocked up.
   <a href="demos/carve_a_doorway.mp4">Download it instead</a> (MP4, 55 seconds, no audio).
 </video>
 
+Also on [YouTube](https://youtu.be/Nilou2q8SjE), with chapters.
+
 ## How it works
 
 | Step | | |


### PR DESCRIPTION
The clip is published at https://youtu.be/Nilou2q8SjE, on a HammerForge brand channel rather than a personal one so it can be handed over later without moving the video.

The site keeps its own embed as the canonical copy — it needs no third party to play and it carries the poster frame. YouTube is offered alongside it, because that is where people search for "godot level editor", and because the Asset Library accepts a YouTube link as its only moving preview.