### PR TITLE
Stop the toolbar jolting the viewport, and the drag preview flickering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,34 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   explains it. It reads the Console's own evaluation, so the two cannot disagree.
 
 ### Fixed
+- **The 3D toolbar resized itself, and the viewport moved with it.**
+  `CONTAINER_SPATIAL_EDITOR_MENU` is a plain `HBoxContainer` and the 3D viewport
+  gets whatever height is left under it. Every control Godot puts in that row is
+  a fixed 29px; the shortcut HUD was the tallest child, so the row's height was
+  the HUD's height — and the HUD renegotiated it on every mode change and every
+  mode hint. Measured in the editor: 46px with a one-line hint, 49px with none,
+  63px with the two-line draw hint, and hints appear and expire on a timer, so
+  the viewport slid under the cursor with nobody touching anything. The three
+  labels ran at three different font sizes, `MODE_HINTS["draw_idle"]` carried a
+  newline that quietly made the row two lines, and the row had no height floor.
+  One `ROW_FONT_SIZE` for every label, `_pin_row_height()` measuring a single
+  line from the theme, and `_show_hint` collapsing newlines. Now 46.0px in every
+  mode and hint state. The status strip had the same fault sideways — its
+  summary rewrites on a two-second poll, swinging 76px to 155px and dragging
+  everything to its right along the row — and is now a fixed width with the
+  numbers still on its tooltip.
+- **One side of a box flickered while you dragged it.** The preview brush is
+  parented under `draft_brushes_node` for the whole drag and stands a full grid
+  step tall, and draft brushes carry no physics body, so `_raycast` always falls
+  through to `pick_face_from_ray` for the placement ray. The preview was not
+  excluded there, so a drag heading *away* from the camera met the preview's own
+  roof before the construction plane: the hit sits nearer the eye, the box pulls
+  back off the cursor, the next ray misses it and the box springs out again.
+  Drag towards the camera and nothing is in the way, which is why it only bit
+  sometimes. Pinned by a test in which a still cursor moved the box's Z edge from
+  8.0 to 7.5. The same chokepoint feeds hover and object picking, so during a
+  drag those were latching onto the preview instead of real geometry too. The
+  snap system already skipped the preview; picking now does the same.
 - **`brush_changed` never fired.** The signal was declared on `LevelRoot` and
   emitted nowhere, while `HFSubtractPreview` connected to it, so the live
   subtract overlay listened to a signal that could not arrive and only refreshed

--- a/addons/hammerforge/shortcut_hud.gd
+++ b/addons/hammerforge/shortcut_hud.gd
@@ -14,6 +14,13 @@ extends Control
 ## that actually changes — the active hint, or the primary action for the
 ## current tool — and keeps the full list one hover away.
 const HUD_WIDTH := 260.0
+## Every label in the row is drawn at this size, so the row is the same height
+## whichever of them is showing. CONTAINER_SPATIAL_EDITOR_MENU is a plain
+## HBoxContainer and the 3D viewport gets whatever height is left under it, so a
+## HUD that renegotiated its height with each mode or hint slid the viewport
+## under the cursor mid-edit. Godot's own controls in that bar are a fixed 29px
+## and never move; this one holds still the same way.
+const ROW_FONT_SIZE := 12
 
 var _last_context := {}
 var _user_prefs = null  # HFUserPrefs — untyped to avoid preload
@@ -27,11 +34,10 @@ var _grid_flash_tween: Tween
 var _last_grid_snap := -1.0
 
 const MODE_HINTS := {
-	"draw_idle":
-	(
-		"Click to place corner \u2192 drag to set size \u2192 release for height\n"
-		+ "Empty scene? Use Manage > Create Floor for a stable draw surface"
-	),
+	# One line. The row is one line high, and the toolbar takes its height from
+	# this HUD, so a second line here moves the whole 3D viewport down. The rest
+	# of the advice is on the tooltip with the full shortcut list.
+	"draw_idle": "Click to place corner → drag to set size → release for height",
 	"select": "Click to select; drag empty space for a box; drag widgets to edit",
 	"extrude_up_idle": "Click a face to start extruding upward",
 	"extrude_down_idle": "Click a face to start extruding downward",
@@ -80,9 +86,24 @@ func _setup_row() -> void:
 	margin.add_child(_row)
 	margin.remove_child(label)
 	_row.add_child(label)
+	label.add_theme_font_size_override("font_size", ROW_FONT_SIZE)
 	label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	label.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 	label.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+	_pin_row_height()
+
+
+## One line, measured from the theme rather than from whatever text happens to
+## be in the row. Without a floor the row still collapses when every label in it
+## is hidden, and the toolbar shrinks with it.
+func _pin_row_height() -> void:
+	if _row == null or label == null:
+		return
+	var font := label.get_theme_font("font")
+	var line := float(ROW_FONT_SIZE)
+	if font:
+		line = font.get_height(ROW_FONT_SIZE)
+	_row.custom_minimum_size.y = line
 
 
 func set_user_prefs(prefs) -> void:
@@ -94,7 +115,7 @@ func _setup_hint_label() -> void:
 		return
 	_hint_label = Label.new()
 	_hint_label.name = "HintLabel"
-	_hint_label.add_theme_font_size_override("font_size", 11)
+	_hint_label.add_theme_font_size_override("font_size", ROW_FONT_SIZE)
 	_hint_label.add_theme_color_override("font_color", Color(0.8, 0.9, 1.0, 0.7))
 	_hint_label.visible = false
 	_hint_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -110,7 +131,7 @@ func _setup_grid_label() -> void:
 		return
 	_grid_label = Label.new()
 	_grid_label.name = "GridLabel"
-	_grid_label.add_theme_font_size_override("font_size", 12)
+	_grid_label.add_theme_font_size_override("font_size", ROW_FONT_SIZE)
 	_grid_label.add_theme_color_override("font_color", Color(0.7, 0.85, 1.0, 0.8))
 	_grid_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	_grid_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -239,7 +260,9 @@ func _compute_hint_key(ctx: Dictionary) -> String:
 func _show_hint(text: String) -> void:
 	# The hint replaces the shortcut line rather than stacking under it: the row
 	# is one line high, and while a hint is up it is the more useful of the two.
-	_hint_label.text = text
+	# A newline here would quietly make the row two lines high and grow the whole
+	# toolbar by a line. Anything past the first sentence belongs on the tooltip.
+	_hint_label.text = " ".join(text.split("\n", false))
 	_hint_label.modulate = Color(1, 1, 1, 1)
 	_hint_label.visible = true
 	if label:

--- a/addons/hammerforge/systems/hf_brush_system.gd
+++ b/addons/hammerforge/systems/hf_brush_system.gd
@@ -978,12 +978,24 @@ func pick_face(camera: Camera3D, mouse_pos: Vector2) -> Dictionary:
 
 
 ## Ray-based face picker that applies the same visibility rules as object picks.
+##
+## The in-progress drag preview is deliberately not a target. It is parented
+## under draft_brushes_node the moment a drag starts and stands a full grid step
+## tall, and draft brushes carry no physics body, so `_raycast` reaches this
+## fallback for every placement ray. Left in, a drag heading away from the
+## camera meets the preview's own roof before the construction plane: the hit
+## sits nearer the eye, the box pulls back off the cursor, the next ray misses
+## it and the box springs out again — one edge twitching for as long as the
+## mouse moves. The snap system excludes it for the same reason.
 func pick_face_from_ray(ray_origin: Vector3, ray_direction: Vector3) -> Dictionary:
 	if ray_direction.is_zero_approx():
 		return {}
 	var ray_dir := ray_direction.normalized()
+	var preview = root.preview_brush
 	var brushes: Array = []
 	for node in root._iter_pick_nodes():
+		if node == preview:
+			continue
 		if (
 			node is DraftBrush
 			and is_brush_node(node)

--- a/addons/hammerforge/ui/hf_status_strip.gd
+++ b/addons/hammerforge/ui/hf_status_strip.gd
@@ -15,6 +15,12 @@ const HFStatusLampType = preload("hf_status_lamp.gd")
 ## Slower than the Console's own beat. Nothing here is read closely, and unlike
 ## the Console's poll this one runs whether or not the Console is open.
 const POLL_SECONDS := 2.0
+## The summary rewrites itself every poll — "All good" one moment, "3 problems,
+## 2 to review" the next — and the 3D viewport toolbar is a plain HBoxContainer,
+## so a label that sizes to its text drags everything to its right along the bar
+## while you build. Wide enough for the ordinary summaries, fixed so the bar
+## holds still; anything longer trims, and the tooltip carries the numbers.
+const LABEL_WIDTH := 150.0
 
 signal console_requested
 
@@ -41,6 +47,9 @@ func _init() -> void:
 	_button.focus_mode = Control.FOCUS_NONE
 	_button.text = "HammerForge"
 	_button.add_theme_font_size_override("font_size", 11)
+	_button.custom_minimum_size = Vector2(LABEL_WIDTH, 0.0)
+	_button.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
+	_button.clip_text = true
 	_button.pressed.connect(func(): console_requested.emit())
 	add_child(_button)
 

--- a/tests/test_console_panel.gd
+++ b/tests/test_console_panel.gd
@@ -610,3 +610,24 @@ func test_strip_tooltip_breaks_the_summary_down():
 	add_child_autofree(strip)
 	strip.set_source(panel)
 	assert_string_contains(strip._button.tooltip_text, "Click to open the Console")
+
+
+func test_strip_keeps_one_width_whatever_the_summary_says():
+	# The strip sits in the 3D viewport toolbar, which is a plain HBoxContainer.
+	# A label that sized to its text moved everything to its right along the bar
+	# every time the summary changed — and it changes on a two-second poll while
+	# you build. Measured before this was pinned: 76px for "All good", 155px for
+	# "3 problems, 2 to review".
+	var strip = HFStatusStripType.new()
+	add_child_autofree(strip)
+	var widths := {}
+	for text in ["All good", "Nothing to check yet", "3 problems, 2 to review", ""]:
+		strip._button.text = text
+		widths[text] = strip.get_combined_minimum_size().x
+	var first: float = widths.values()[0]
+	for text in widths:
+		assert_eq(
+			widths[text],
+			first,
+			"Summary '%s' resized the strip and shifted the toolbar. Widths: %s" % [text, widths]
+		)

--- a/tests/test_drag_preview_self_pick.gd
+++ b/tests/test_drag_preview_self_pick.gd
@@ -1,0 +1,120 @@
+extends GutTest
+## The in-progress preview brush must never be a pick target.
+##
+## `update_drag` places the drag point with `root._raycast`, which falls back to
+## `pick_face_from_ray` when nothing has a physics body — and draft brushes never
+## do. The preview brush is parented under `draft_brushes_node` the moment a drag
+## starts and stands a full grid step tall, so a ray aimed near the corner the
+## user is dragging hits the preview's own top face instead of the construction
+## plane. The hit sits closer to the camera, the box shrinks away from the
+## cursor, the next ray misses it, and the box grows back: one edge oscillating
+## every frame the mouse moves. The snap system already excludes the preview for
+## the same reason; picking did not.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+const DraftBrush = preload("res://addons/hammerforge/brush_instance.gd")
+
+var root: LevelRoot
+var camera: Camera3D
+
+
+func before_each() -> void:
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.commit_freeze = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	camera = Camera3D.new()
+	add_child_autoqfree(camera)
+	# A raised, tilted view is the ordinary building camera, and it is the angle
+	# that gives a preview's top face any screen area to steal the ray with.
+	camera.global_position = Vector3(0, 12, 12)
+	camera.look_at(Vector3.ZERO, Vector3.UP)
+
+
+func after_each() -> void:
+	root = null
+	camera = null
+
+
+func _preview_box(center: Vector3, size: Vector3) -> DraftBrush:
+	var brush := DraftBrush.new()
+	brush.name = "PreviewBrush"
+	brush.shape = LevelRootType.BrushShape.BOX
+	brush.size = size
+	root.draft_brushes_node.add_child(brush)
+	brush.global_position = center
+	root.preview_brush = brush
+	return brush
+
+
+# --- the pick chokepoint -------------------------------------------------
+
+
+func test_face_pick_ignores_the_preview_brush() -> void:
+	var preview := _preview_box(Vector3(0, 1, 0), Vector3(4, 2, 4))
+	assert_not_null(preview)
+	var hit := root.brush_system.pick_face_from_ray(Vector3(0, 8, 0), Vector3(0, -1, 0))
+	assert_true(
+		hit.is_empty(), "A ray straight down the preview's top face must not pick the preview"
+	)
+
+
+func test_face_pick_still_sees_a_committed_brush_behind_the_preview() -> void:
+	var real := (
+		(
+			root
+			. create_brush_from_info(
+				{
+					"shape": LevelRootType.BrushShape.BOX,
+					"size": Vector3(4, 2, 4),
+					"center": Vector3(0, -3, 0),
+					"operation": CSGShape3D.OPERATION_UNION,
+					"brush_id": "committed",
+				}
+			)
+		)
+		as DraftBrush
+	)
+	_preview_box(Vector3(0, 1, 0), Vector3(4, 2, 4))
+	var hit := root.brush_system.pick_face_from_ray(Vector3(0, 8, 0), Vector3(0, -1, 0))
+	assert_same(hit.get("brush"), real, "Excluding the preview must not hide real geometry")
+
+
+func test_raycast_falls_through_the_preview_to_the_construction_plane() -> void:
+	_preview_box(Vector3(0, 1, 0), Vector3(4, 2, 4))
+	var hit := root._raycast(camera, _screen_point_for(Vector3(0, 0, 0)))
+	assert_false(hit.is_empty())
+	var pos: Vector3 = hit.get("position", Vector3.ONE * 999.0)
+	assert_almost_eq(pos.y, 0.0, 0.001, "The drag point belongs on the plane, not on the preview")
+
+
+func _screen_point_for(world: Vector3) -> Vector2:
+	return camera.unproject_position(world)
+
+
+# --- the symptom the user sees -------------------------------------------
+
+
+func test_repeated_drag_updates_at_one_position_do_not_oscillate() -> void:
+	# Dragging *away* from the camera is what puts the growing box between the
+	# eye and the corner under the cursor, so the ray meets the preview's roof
+	# before it ever reaches the construction plane. Drag towards the camera and
+	# nothing is in the way — which is why this only bites sometimes.
+	root.grid_snap = 0.5
+	var drag = root.drag_system
+	var near_corner := _screen_point_for(Vector3(4, 0, 4))
+	assert_true(
+		drag.begin_drag(camera, near_corner, CSGShape3D.OPERATION_UNION, Vector3(2, 2, 2), 0),
+		"The drag has to start for the rest of this to mean anything"
+	)
+	var far_corner := _screen_point_for(Vector3(-4, 0, -4))
+	var sizes: Array = []
+	for i in range(6):
+		drag.update_drag(camera, far_corner)
+		sizes.append(root.preview_brush.size)
+	gut.p("observed preview sizes: %s" % str(sizes))
+	for i in range(1, sizes.size()):
+		assert_eq(
+			sizes[i], sizes[0], "A still cursor must give one answer. Sizes seen: %s" % str(sizes)
+		)

--- a/tests/test_drag_preview_self_pick.gd.uid
+++ b/tests/test_drag_preview_self_pick.gd.uid
@@ -1,0 +1,1 @@
+uid://dh2rbn5gq2qry

--- a/tests/test_shortcut_hud_layout.gd
+++ b/tests/test_shortcut_hud_layout.gd
@@ -122,3 +122,84 @@ func test_fractional_grid_snaps_render_as_numbers():
 	for pair in [[0.125, "Grid: 0.125"], [0.5, "Grid: 0.5"], [2.5, "Grid: 2.5"]]:
 		hud.update_grid_snap(pair[0])
 		assert_eq(hud._grid_label.text, pair[1])
+
+
+# --- a constant height, because the toolbar is what sizes the viewport ---
+#
+# CONTAINER_SPATIAL_EDITOR_MENU is a plain HBoxContainer inside a PanelContainer,
+# and the 3D viewport gets whatever height is left under it. Every other child in
+# that bar — Godot's own transform, view and snap controls — is 29px tall and
+# stays there. The HUD is the tallest thing in the bar, so the bar's height is
+# the HUD's height, and the HUD renegotiating it mid-edit slid the viewport under
+# the cursor. Measured before this was pinned: 46px with a one-line hint, 49px
+# with none, 63px with the two-line draw hint.
+
+
+func _hud_heights_across_contexts() -> Dictionary:
+	var hud := _hud()
+	var seen := {}
+	var contexts := {
+		"draw idle": {"tool": 0, "mode": 0},
+		"select": {"tool": 1, "mode": 0},
+		"drag base": {"tool": 0, "mode": 1},
+		"drag height": {"tool": 0, "mode": 2},
+		"extrude up": {"tool": 2, "mode": 0},
+		"extrude active": {"tool": 2, "mode": 4},
+		"vertex edit": {"tool": 0, "mode": 5},
+		"floor paint": {"tool": 0, "mode": 0, "paint_mode": true},
+		"surface paint": {"tool": 0, "mode": 0, "paint_mode": true, "paint_target": 1},
+		"external tool": {"tool": 0, "mode": 0, "external_tool_name": "Measure"},
+	}
+	for tag in contexts:
+		hud.update_context(contexts[tag])
+		seen[tag] = hud.get_combined_minimum_size().y
+	return seen
+
+
+func test_hud_height_is_the_same_in_every_mode():
+	var seen := _hud_heights_across_contexts()
+	var heights := seen.values()
+	for tag in seen:
+		assert_eq(
+			seen[tag],
+			heights[0],
+			"Mode '%s' resized the toolbar and moved the viewport. Heights: %s" % [tag, str(seen)]
+		)
+
+
+func test_hud_height_is_the_same_with_and_without_a_hint():
+	var hud := _hud()
+	hud.update_context({"tool": 1, "mode": 0})
+	hud._hide_hint()
+	var without: float = hud.get_combined_minimum_size().y
+	for key in ShortcutHUD.MODE_HINTS:
+		hud._show_hint(ShortcutHUD.MODE_HINTS[key])
+		assert_eq(
+			hud.get_combined_minimum_size().y,
+			without,
+			(
+				"Hint '%s' resized the toolbar. A hint appears and expires on a timer, so this moves the viewport twice on its own."
+				% key
+			)
+		)
+
+
+func test_no_mode_hint_wraps_to_a_second_line():
+	# The row is one line high by design; a newline in the data quietly made it
+	# two and grew the whole toolbar by a line.
+	for key in ShortcutHUD.MODE_HINTS:
+		assert_false(
+			str(ShortcutHUD.MODE_HINTS[key]).contains("\n"),
+			"Hint '%s' carries a newline; the second line has to live on the tooltip" % key
+		)
+
+
+func test_a_long_hint_does_not_grow_the_row():
+	var hud := _hud()
+	hud.update_context({"tool": 1, "mode": 0})
+	hud._hide_hint()
+	var without: float = hud.get_combined_minimum_size().y
+	hud._show_hint(
+		"a hint far longer than the two hundred and sixty pixels the row is given, on and on"
+	)
+	assert_eq(hud.get_combined_minimum_size().y, without, "Long text ellipsizes, it does not wrap")


### PR DESCRIPTION
## Summary

The two problems reported from use, both traced to a root cause before anything was changed. One commit each, one test file each. Every number below was measured in a real editor session (`godot --editor --headless`), not inferred.

**1. The top ribbon jolted the viewport when its text changed.** `CONTAINER_SPATIAL_EDITOR_MENU` is a plain `HBoxContainer` and the 3D viewport gets whatever height is left under it. Everything Godot puts in that row is a fixed 29px; the shortcut HUD was the tallest child, so the row's height *was* the HUD's height — and the HUD renegotiated it constantly. Three causes: the three labels ran at three different font sizes, `MODE_HINTS["draw_idle"]` carried a newline that quietly made the row two lines, and the row had no height floor. Hints appear and expire on a timer, so the viewport moved twice with nobody touching anything.

The status strip had the same fault sideways: its summary rewrites on a two-second poll while you build, sliding everything to its right along the row.

**2. One side of a box flickered during a drag.** The preview brush is parented under `draft_brushes_node` for the whole drag and stands a full grid step tall, and draft brushes carry no physics body — so `_raycast` always falls through to `pick_face_from_ray`, which did not exclude it. A drag heading *away* from the camera met the preview's own roof before the construction plane: the hit sits nearer the eye, the box pulls back off the cursor, the next ray misses it and the box springs out again. Drag towards the camera and nothing is in the way, which is why it only bit sometimes and would not reproduce on demand.

The snap system already skipped the preview for exactly this reason; picking now does the same.

The overlay/toolbar-overflow work that was originally in this PR has been split out to #168 on request. The two are independent — different files, different tests, no shared commits — though both add an entry to `[Unreleased]` / Fixed, so whichever merges second will want a one-line CHANGELOG conflict resolved.

## Before / After Behavior

- **Before:**
  - Toolbar height swung 46 / 49 / 63px with mode and hint text, moving the 3D viewport under the cursor.
  - Status strip swung 76px to 155px on a two-second poll, dragging everything to its right along the row while you built.
  - Dragging a box away from the camera: `_raycast` returned `y=2.0` (the preview's own roof) instead of `y=0.0`, and a second update with the cursor held still moved the box's Z edge from 8.0 to 7.5. The same chokepoint feeds hover and object picking, so during a drag those were latching onto the preview instead of real geometry too.

- **After:**
  - Toolbar height a constant **46.0px** in every mode and hint state, re-measured in the editor.
  - Status strip a fixed width, with the numbers still on its tooltip.
  - `_raycast` returns the construction plane; the box holds at 8.0 across repeated updates.

**Known limitation, plainly:** the advice dropped from the two-line draw hint ("Empty scene? Use Manage > Create Floor…") is not lost — it was already on the HUD's tooltip with the full shortcut list — but the hint line itself is now shorter.

## Related Issue

None — both reported directly from use.

## Checks

- [x] `gdformat --check addons/hammerforge/ tests/` passes
- [x] `gdlint addons/hammerforge/` passes
- [x] `godot --headless -s res://addons/gut/gut_cmdln.gd --path .` passes on this branch alone — 2250 tests, 2243 passing, 0 failing (7 risky are pre-existing and unchanged). 9 new tests across `tests/test_drag_preview_self_pick.gd`, `tests/test_shortcut_hud_layout.gd` and `tests/test_console_panel.gd`.
- [x] Docs updated together where behavior changed — `[Unreleased]` / Fixed in CHANGELOG
- [x] `git diff --check` is clean and relative Markdown links resolve
- [x] No MCP tokens, `user://` settings, verification logs, editor screenshots, or local client overrides committed
- [x] `addons/godot_mcp` left untouched
