### PR TITLE
Move the viewport overlays out of the 3D toolbar row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,18 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   8.0 to 7.5. The same chokepoint feeds hover and object picking, so during a
   drag those were latching onto the preview instead of real geometry too. The
   snap system already skipped the preview; picking now does the same.
+- **Viewport overlays were laid out as toolbar items.** The contextual toolbar,
+  the command palette and the cursor property popup were added to the 3D toolbar
+  row, which is a layout container, so it reserved each one's full minimum size
+  out of the space the viewport was going to get: the toolbar's minimum was
+  (800, 46) at rest and (1136, **380**) the instant the palette opened. They now
+  parent to the `Control` Godot passes to `_forward_3d_force_draw_over_viewport`
+  — the viewport's own rect, which reserves nothing and positions nothing — with
+  placement in one table, `HFPluginOverlays.VIEWPORT_OVERLAY_ANCHORS`. That rect
+  is also the space `event.position` is measured in, so `hf_quick_property`'s
+  `position` and `hf_radial_menu`'s `PRESET_FULL_RECT` are no longer overwritten
+  by the container on its next re-sort. Toolbar minimum is now (458, 46) and
+  stays there with every overlay open.
 - **`brush_changed` never fired.** The signal was declared on `LevelRoot` and
   emitted nowhere, while `HFSubtractPreview` connected to it, so the live
   subtract overlay listened to a signal that could not arrive and only refreshed

--- a/addons/hammerforge/plugin.gd
+++ b/addons/hammerforge/plugin.gd
@@ -43,6 +43,11 @@ var hf_selection: Array = []
 var _selection_gesture := HFSelectionGestureType.new()
 var _brush_change_tracker := HFBrushChangeTrackerType.new()
 var _brush_reconcile_queued := false
+## The Control Godot draws the 3D viewport overlay through, captured the first
+## time _forward_3d_force_draw_over_viewport runs. Viewport overlays are
+## parented here rather than into the toolbar row, which is a layout container
+## that reserved each of them a slot the width of its whole panel.
+var _viewport_overlay_host: Control = null
 var _marquee_overlay_origin := Vector2.ZERO
 var _marquee_overlay_current := Vector2.ZERO
 var _marquee_overlay_active := false
@@ -219,14 +224,14 @@ func _enter_tree():
 	_context_toolbar.tool_switch_requested.connect(_on_context_tool_switch)
 	_context_toolbar.material_quick_apply.connect(_on_context_material_apply)
 	_context_toolbar.hotkey_palette_requested.connect(_on_toggle_hotkey_palette)
-	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, _context_toolbar)
+	HFPluginOverlays.attach_viewport_overlay(self, _context_toolbar)
 	# Hotkey palette (command palette overlay)
 	_hotkey_palette = HFHotkeyPalette.new()
 	if base_control:
 		_hotkey_palette.theme = base_control.theme
 	_hotkey_palette.populate(_keymap)
 	_hotkey_palette.action_invoked.connect(_on_hotkey_palette_action)
-	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, _hotkey_palette)
+	HFPluginOverlays.attach_viewport_overlay(self, _hotkey_palette)
 	# Selection filter popover (Window-based — not a Control, so managed manually)
 	_selection_filter = HFSelectionFilter.new()
 	_selection_filter.filter_applied.connect(_on_selection_filter_applied)
@@ -245,7 +250,7 @@ func _enter_tree():
 	if base_control:
 		_quick_property.theme = base_control.theme
 	_quick_property.value_committed.connect(_on_quick_property_committed)
-	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, _quick_property)
+	HFPluginOverlays.attach_viewport_overlay(self, _quick_property)
 	var selection = get_editor_interface().get_selection()
 	if selection:
 		if not selection.is_connected(
@@ -358,14 +363,14 @@ func _exit_tree():
 			_context_toolbar.tool_switch_requested.disconnect(_on_context_tool_switch)
 			_context_toolbar.material_quick_apply.disconnect(_on_context_material_apply)
 			_context_toolbar.hotkey_palette_requested.disconnect(_on_toggle_hotkey_palette)
-		remove_control_from_container(CONTAINER_SPATIAL_EDITOR_MENU, _context_toolbar)
+		HFPluginOverlays.detach_viewport_overlay(self, _context_toolbar)
 		if is_instance_valid(_context_toolbar):
 			_context_toolbar.queue_free()
 		_context_toolbar = null
 	if _hotkey_palette:
 		if is_instance_valid(_hotkey_palette):
 			_hotkey_palette.action_invoked.disconnect(_on_hotkey_palette_action)
-		remove_control_from_container(CONTAINER_SPATIAL_EDITOR_MENU, _hotkey_palette)
+		HFPluginOverlays.detach_viewport_overlay(self, _hotkey_palette)
 		if is_instance_valid(_hotkey_palette):
 			_hotkey_palette.queue_free()
 		_hotkey_palette = null
@@ -379,14 +384,14 @@ func _exit_tree():
 	if _coach_marks:
 		if is_instance_valid(_coach_marks):
 			_coach_marks.guide_dismissed.disconnect(_on_coach_mark_dismissed)
-		remove_control_from_container(CONTAINER_SPATIAL_EDITOR_MENU, _coach_marks)
+		HFPluginOverlays.detach_viewport_overlay(self, _coach_marks)
 		if is_instance_valid(_coach_marks):
 			_coach_marks.queue_free()
 		_coach_marks = null
 	if _operation_replay:
 		if is_instance_valid(_operation_replay):
 			_operation_replay.replay_requested.disconnect(_on_replay_requested)
-		remove_control_from_container(CONTAINER_SPATIAL_EDITOR_MENU, _operation_replay)
+		HFPluginOverlays.detach_viewport_overlay(self, _operation_replay)
 		if is_instance_valid(_operation_replay):
 			_operation_replay.queue_free()
 		_operation_replay = null
@@ -400,17 +405,20 @@ func _exit_tree():
 	if _radial_menu:
 		if is_instance_valid(_radial_menu):
 			_radial_menu.action_selected.disconnect(_on_radial_action)
-		remove_control_from_container(CONTAINER_SPATIAL_EDITOR_MENU, _radial_menu)
+		HFPluginOverlays.detach_viewport_overlay(self, _radial_menu)
 		if is_instance_valid(_radial_menu):
 			_radial_menu.queue_free()
 		_radial_menu = null
 	if _quick_property:
 		if is_instance_valid(_quick_property):
 			_quick_property.value_committed.disconnect(_on_quick_property_committed)
-		remove_control_from_container(CONTAINER_SPATIAL_EDITOR_MENU, _quick_property)
+		HFPluginOverlays.detach_viewport_overlay(self, _quick_property)
 		if is_instance_valid(_quick_property):
 			_quick_property.queue_free()
 		_quick_property = null
+	# Dropped last: detach_viewport_overlay reads it to know which of the two
+	# parents each overlay went onto.
+	_viewport_overlay_host = null
 	var selection = get_editor_interface().get_selection()
 	if (
 		selection
@@ -1223,6 +1231,7 @@ func _update_marquee_overlay(from: Vector2, to: Vector2, active: bool) -> void:
 ## Draw through Godot's real 3D overlay so viewport-local event coordinates
 ## remain correct under split views, editor scaling, and dock rearrangement.
 func _forward_3d_force_draw_over_viewport(viewport_control: Control) -> void:
+	HFPluginOverlays.adopt_viewport_overlay_host(self, viewport_control)
 	HFPluginOverlays.draw_marquee_overlay(self, viewport_control)
 
 

--- a/addons/hammerforge/plugin_overlays.gd
+++ b/addons/hammerforge/plugin_overlays.gd
@@ -9,6 +9,114 @@ const HFOperationReplay = preload("ui/hf_operation_replay.gd")
 const HFRadialMenu = preload("ui/hf_radial_menu.gd")
 const DraftBrush = preload("brush_instance.gd")
 
+## The overlays that belong over the 3D viewport rather than in the toolbar row.
+## Named by property so host adoption can re-home whichever of them exist.
+const VIEWPORT_OVERLAY_PROPERTIES := [
+	"_context_toolbar",
+	"_hotkey_palette",
+	"_quick_property",
+	"_coach_marks",
+	"_operation_replay",
+	"_radial_menu",
+]
+
+## Where each overlay sits once it is over the viewport. Anchors rather than
+## positions: the host is the viewport's own rect, so these follow it as the
+## window is resized or the docks are dragged. Two are deliberately absent —
+## the quick property puts itself at the cursor and the radial menu draws itself
+## around one, and now that neither is inside a layout container the geometry
+## they set for themselves is no longer overwritten on the next re-sort.
+const VIEWPORT_OVERLAY_ANCHORS := {
+	"_context_toolbar": [Control.PRESET_CENTER_TOP, 8],
+	"_hotkey_palette": [Control.PRESET_CENTER, 0],
+	"_coach_marks": [Control.PRESET_CENTER_BOTTOM, 12],
+	"_operation_replay": [Control.PRESET_BOTTOM_LEFT, 12],
+}
+
+
+## Park a viewport overlay on the Control the 3D viewport draws through.
+##
+## CONTAINER_SPATIAL_EDITOR_MENU is a layout container: it reserves every child's
+## full minimum size in the toolbar row, and the 3D viewport gets whatever height
+## is left under that row. A 320x380 command palette parked there takes the row
+## to 380px tall and squeezes the viewport it is supposed to float over; the
+## contextual toolbar and the cursor popup do the same to its width. None of them
+## are toolbar items — only the shortcut HUD and the status strip are.
+##
+## The viewport's draw-over Control is a plain Control, so it positions nothing
+## and reserves nothing, and it is the space `event.position` from
+## _forward_3d_gui_input is measured in — so the positions these overlays already
+## set for themselves finally land where they say. The toolbar stays the fallback
+## for the frames before the 3D editor has drawn once and handed us that Control.
+static func attach_viewport_overlay(plugin: Object, control: Control) -> void:
+	if plugin == null or control == null:
+		return
+	var host = plugin._viewport_overlay_host
+	if host != null and is_instance_valid(host):
+		host.add_child(control)
+		place_viewport_overlay(plugin, control)
+		return
+	plugin.add_control_to_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_MENU, control)
+
+
+## Take the overlay off whichever of the two parents it landed on.
+static func detach_viewport_overlay(plugin: Object, control: Control) -> void:
+	if plugin == null or control == null or not is_instance_valid(control):
+		return
+	var host = plugin._viewport_overlay_host
+	if host != null and is_instance_valid(host) and control.get_parent() == host:
+		host.remove_child(control)
+		return
+	plugin.remove_control_from_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_MENU, control)
+
+
+## Godot hands the draw-over Control to every viewport of a split layout on every
+## draw. Keep the first live one: adopting each call in turn would drag the
+## overlays between viewports every frame.
+static func adopt_viewport_overlay_host(plugin: Object, host: Control) -> void:
+	if plugin == null or host == null or not is_instance_valid(host):
+		return
+	var current = plugin._viewport_overlay_host
+	if current != null and is_instance_valid(current) and current.is_inside_tree():
+		return
+	plugin._viewport_overlay_host = host
+	for property in VIEWPORT_OVERLAY_PROPERTIES:
+		var control = plugin.get(property)
+		if control is Control and is_instance_valid(control):
+			_rehome_viewport_overlay(control, host)
+			place_viewport_overlay(plugin, control)
+
+
+static func _rehome_viewport_overlay(control: Control, host: Control) -> void:
+	var parent := control.get_parent()
+	if parent == host:
+		return
+	if parent != null:
+		parent.remove_child(control)
+	host.add_child(control)
+
+
+## Anchor an overlay inside the viewport. Anything not named in the table places
+## itself, so leave it alone: overwriting a cursor-anchored popup with a corner
+## preset is how it ends up in the wrong half of the screen.
+static func place_viewport_overlay(plugin: Object, control: Control) -> void:
+	if plugin == null or control == null or not is_instance_valid(control):
+		return
+	var property := _overlay_property_for(plugin, control)
+	if not VIEWPORT_OVERLAY_ANCHORS.has(property):
+		return
+	var placement: Array = VIEWPORT_OVERLAY_ANCHORS[property]
+	control.set_anchors_and_offsets_preset(
+		int(placement[0]), Control.PRESET_MODE_MINSIZE, int(placement[1])
+	)
+
+
+static func _overlay_property_for(plugin: Object, control: Control) -> String:
+	for property in VIEWPORT_OVERLAY_PROPERTIES:
+		if plugin.get(property) == control:
+			return property
+	return ""
+
 
 static func install_power_user_overlays(plugin: Object) -> void:
 	if plugin == null:
@@ -19,17 +127,13 @@ static func install_power_user_overlays(plugin: Object) -> void:
 			plugin._coach_marks.theme = plugin.base_control.theme
 		plugin._coach_marks.set_user_prefs(plugin._user_prefs)
 		plugin._coach_marks.guide_dismissed.connect(plugin._on_coach_mark_dismissed)
-		plugin.add_control_to_container(
-			EditorPlugin.CONTAINER_SPATIAL_EDITOR_MENU, plugin._coach_marks
-		)
+		attach_viewport_overlay(plugin, plugin._coach_marks)
 	if plugin._operation_replay == null:
 		plugin._operation_replay = HFOperationReplay.new()
 		if plugin.base_control:
 			plugin._operation_replay.theme = plugin.base_control.theme
 		plugin._operation_replay.replay_requested.connect(plugin._on_replay_requested)
-		plugin.add_control_to_container(
-			EditorPlugin.CONTAINER_SPATIAL_EDITOR_MENU, plugin._operation_replay
-		)
+		attach_viewport_overlay(plugin, plugin._operation_replay)
 		if plugin.dock:
 			plugin.dock.set_operation_replay(plugin._operation_replay)
 	if plugin._radial_menu == null:
@@ -37,9 +141,7 @@ static func install_power_user_overlays(plugin: Object) -> void:
 		if plugin.base_control:
 			plugin._radial_menu.theme = plugin.base_control.theme
 		plugin._radial_menu.action_selected.connect(plugin._on_radial_action)
-		plugin.add_control_to_container(
-			EditorPlugin.CONTAINER_SPATIAL_EDITOR_MENU, plugin._radial_menu
-		)
+		attach_viewport_overlay(plugin, plugin._radial_menu)
 
 
 static func teardown_power_user_overlays(plugin: Object) -> void:
@@ -48,18 +150,14 @@ static func teardown_power_user_overlays(plugin: Object) -> void:
 	if plugin._coach_marks:
 		if is_instance_valid(plugin._coach_marks):
 			plugin._coach_marks.guide_dismissed.disconnect(plugin._on_coach_mark_dismissed)
-		plugin.remove_control_from_container(
-			EditorPlugin.CONTAINER_SPATIAL_EDITOR_MENU, plugin._coach_marks
-		)
+		detach_viewport_overlay(plugin, plugin._coach_marks)
 		if is_instance_valid(plugin._coach_marks):
 			plugin._coach_marks.queue_free()
 		plugin._coach_marks = null
 	if plugin._operation_replay:
 		if is_instance_valid(plugin._operation_replay):
 			plugin._operation_replay.replay_requested.disconnect(plugin._on_replay_requested)
-		plugin.remove_control_from_container(
-			EditorPlugin.CONTAINER_SPATIAL_EDITOR_MENU, plugin._operation_replay
-		)
+		detach_viewport_overlay(plugin, plugin._operation_replay)
 		if is_instance_valid(plugin._operation_replay):
 			plugin._operation_replay.queue_free()
 		plugin._operation_replay = null
@@ -68,9 +166,7 @@ static func teardown_power_user_overlays(plugin: Object) -> void:
 	if plugin._radial_menu:
 		if is_instance_valid(plugin._radial_menu):
 			plugin._radial_menu.action_selected.disconnect(plugin._on_radial_action)
-		plugin.remove_control_from_container(
-			EditorPlugin.CONTAINER_SPATIAL_EDITOR_MENU, plugin._radial_menu
-		)
+		detach_viewport_overlay(plugin, plugin._radial_menu)
 		if is_instance_valid(plugin._radial_menu):
 			plugin._radial_menu.queue_free()
 		plugin._radial_menu = null

--- a/tests/test_viewport_overlay_host.gd
+++ b/tests/test_viewport_overlay_host.gd
@@ -1,0 +1,235 @@
+extends GutTest
+## Viewport overlays belong over the 3D viewport, not in the toolbar row.
+##
+## CONTAINER_SPATIAL_EDITOR_MENU is a plain HBoxContainer and the 3D viewport
+## gets whatever height is left under it, so every child reserves its full
+## minimum size out of the viewport's space. Measured with the overlays parked
+## there: the toolbar's minimum went from (800, 46) to (1136, 380) the moment the
+## command palette opened. Only the shortcut HUD and the status strip are
+## genuinely toolbar items; the rest float over the viewport and are parented to
+## the Control Godot draws that viewport's overlays through.
+
+const Overlays = preload("res://addons/hammerforge/plugin_overlays.gd")
+
+
+class FakePlugin:
+	extends RefCounted
+
+	var _viewport_overlay_host: Control = null
+	var _context_toolbar: Control = null
+	var _hotkey_palette: Control = null
+	var _quick_property: Control = null
+	var _coach_marks: Control = null
+	var _operation_replay: Control = null
+	var _radial_menu: Control = null
+	## Stands in for the 3D toolbar row, which is an HBoxContainer.
+	var toolbar := HBoxContainer.new()
+	var added_to_toolbar: Array = []
+	var removed_from_toolbar: Array = []
+
+	func add_control_to_container(_container: int, control: Control) -> void:
+		added_to_toolbar.append(control)
+		toolbar.add_child(control)
+
+	func remove_control_from_container(_container: int, control: Control) -> void:
+		removed_from_toolbar.append(control)
+		if control.get_parent() == toolbar:
+			toolbar.remove_child(control)
+
+
+var plugin: FakePlugin
+var host: Control
+
+
+func before_each() -> void:
+	plugin = FakePlugin.new()
+	add_child_autoqfree(plugin.toolbar)
+	host = Control.new()
+	host.name = "ViewportOverlayHost"
+	add_child_autoqfree(host)
+
+
+func after_each() -> void:
+	plugin = null
+	host = null
+
+
+func _overlay(name: String) -> Control:
+	var c := PanelContainer.new()
+	c.name = name
+	c.custom_minimum_size = Vector2(320, 380)
+	return c
+
+
+# --- attach --------------------------------------------------------------
+
+
+func test_overlay_goes_to_the_viewport_host_when_there_is_one() -> void:
+	plugin._viewport_overlay_host = host
+	var overlay := _overlay("Palette")
+	Overlays.attach_viewport_overlay(plugin, overlay)
+	assert_same(overlay.get_parent(), host)
+	assert_eq(plugin.added_to_toolbar, [], "The toolbar never sees it")
+
+
+func test_overlay_falls_back_to_the_toolbar_before_the_viewport_has_drawn() -> void:
+	# Overlays are built in _enter_tree, before the 3D editor has handed us its
+	# draw-over Control. They have to live somewhere until it does.
+	var overlay := _overlay("Palette")
+	Overlays.attach_viewport_overlay(plugin, overlay)
+	assert_same(overlay.get_parent(), plugin.toolbar)
+	assert_eq(plugin.added_to_toolbar, [overlay])
+
+
+# --- adoption ------------------------------------------------------------
+
+
+func test_adopting_the_host_moves_parked_overlays_off_the_toolbar() -> void:
+	plugin._context_toolbar = _overlay("ContextToolbar")
+	plugin._hotkey_palette = _overlay("Palette")
+	plugin._quick_property = _overlay("QuickProperty")
+	for c in [plugin._context_toolbar, plugin._hotkey_palette, plugin._quick_property]:
+		Overlays.attach_viewport_overlay(plugin, c)
+	assert_eq(plugin.toolbar.get_child_count(), 3, "Parked, as expected, before adoption")
+
+	Overlays.adopt_viewport_overlay_host(plugin, host)
+
+	assert_eq(plugin.toolbar.get_child_count(), 0, "The toolbar row reserves nothing for them")
+	for c in [plugin._context_toolbar, plugin._hotkey_palette, plugin._quick_property]:
+		assert_same(c.get_parent(), host)
+
+
+func test_adoption_keeps_the_first_live_host() -> void:
+	# Godot calls the draw-over hook once per viewport in a split layout, every
+	# frame. Re-homing on each call would drag the overlays between viewports.
+	plugin._hotkey_palette = _overlay("Palette")
+	Overlays.attach_viewport_overlay(plugin, plugin._hotkey_palette)
+	Overlays.adopt_viewport_overlay_host(plugin, host)
+
+	var second := Control.new()
+	add_child_autoqfree(second)
+	Overlays.adopt_viewport_overlay_host(plugin, second)
+
+	assert_same(plugin._viewport_overlay_host, host)
+	assert_same(plugin._hotkey_palette.get_parent(), host)
+
+
+func test_adoption_replaces_a_host_that_left_the_tree() -> void:
+	plugin._hotkey_palette = _overlay("Palette")
+	Overlays.attach_viewport_overlay(plugin, plugin._hotkey_palette)
+	Overlays.adopt_viewport_overlay_host(plugin, host)
+	remove_child(host)
+
+	var second := Control.new()
+	add_child_autoqfree(second)
+	Overlays.adopt_viewport_overlay_host(plugin, second)
+
+	assert_same(plugin._viewport_overlay_host, second)
+	assert_same(plugin._hotkey_palette.get_parent(), second)
+	host.free()
+
+
+func test_adoption_is_safe_with_no_overlays_built_yet() -> void:
+	Overlays.adopt_viewport_overlay_host(plugin, host)
+	assert_same(plugin._viewport_overlay_host, host)
+
+
+# --- detach --------------------------------------------------------------
+
+
+func test_detach_takes_the_overlay_off_the_host() -> void:
+	plugin._viewport_overlay_host = host
+	var overlay := _overlay("Palette")
+	Overlays.attach_viewport_overlay(plugin, overlay)
+	Overlays.detach_viewport_overlay(plugin, overlay)
+	assert_null(overlay.get_parent())
+	assert_eq(plugin.removed_from_toolbar, [], "It was never in the toolbar")
+	overlay.free()
+
+
+func test_detach_takes_a_parked_overlay_off_the_toolbar() -> void:
+	var overlay := _overlay("Palette")
+	Overlays.attach_viewport_overlay(plugin, overlay)
+	Overlays.detach_viewport_overlay(plugin, overlay)
+	assert_null(overlay.get_parent())
+	assert_eq(plugin.removed_from_toolbar, [overlay])
+	overlay.free()
+
+
+# --- the toolbar row keeps only what belongs in it ------------------------
+
+
+func test_only_the_hud_and_the_status_strip_are_added_to_the_toolbar() -> void:
+	var source := FileAccess.get_file_as_string("res://addons/hammerforge/plugin.gd")
+	for overlay in Overlays.VIEWPORT_OVERLAY_PROPERTIES:
+		assert_false(
+			source.contains(
+				"add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, %s)" % overlay
+			),
+			(
+				"%s floats over the viewport; in the toolbar row it reserves its whole panel out of the viewport's height"
+				% overlay
+			)
+		)
+	assert_true(
+		source.contains("add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, hud)"),
+		"The shortcut HUD really is a toolbar item",
+	)
+
+
+func test_power_user_overlays_go_to_the_viewport_too() -> void:
+	var source := FileAccess.get_file_as_string("res://addons/hammerforge/plugin_overlays.gd")
+	for overlay in ["_coach_marks", "_operation_replay", "_radial_menu"]:
+		assert_true(
+			source.contains("attach_viewport_overlay(plugin, plugin.%s)" % overlay),
+			"%s is an overlay, not a toolbar item" % overlay,
+		)
+
+
+# --- placement -----------------------------------------------------------
+
+
+func test_overlays_are_anchored_rather_than_piled_in_the_corner() -> void:
+	# Straight off the toolbar they all land at the host's origin, on top of each
+	# other and on top of Godot's own viewport labels.
+	host.size = Vector2(1000, 600)
+	plugin._context_toolbar = _overlay("ContextToolbar")
+	plugin._hotkey_palette = _overlay("Palette")
+	plugin._coach_marks = _overlay("CoachMarks")
+	plugin._operation_replay = _overlay("Replay")
+	for c in [
+		plugin._context_toolbar,
+		plugin._hotkey_palette,
+		plugin._coach_marks,
+		plugin._operation_replay
+	]:
+		Overlays.attach_viewport_overlay(plugin, c)
+	Overlays.adopt_viewport_overlay_host(plugin, host)
+
+	var origins := {}
+	for c in host.get_children():
+		origins[c.name] = (c as Control).position
+	for name in origins:
+		assert_ne(origins[name], Vector2.ZERO, "%s was left at the corner" % name)
+	assert_eq(origins.values().size(), 4)
+	for name in origins:
+		for other in origins:
+			if name != other:
+				assert_ne(origins[name], origins[other], "%s and %s share a spot" % [name, other])
+
+
+func test_self_positioning_overlays_are_left_alone() -> void:
+	# The quick property puts itself at the cursor and the radial menu draws
+	# around one. A corner preset applied over the top is how an overlay ends up
+	# in the wrong half of the screen.
+	plugin._viewport_overlay_host = host
+	for property in ["_quick_property", "_radial_menu"]:
+		assert_false(
+			Overlays.VIEWPORT_OVERLAY_ANCHORS.has(property),
+			"%s places itself from event.position" % property
+		)
+	plugin._quick_property = _overlay("QuickProperty")
+	Overlays.attach_viewport_overlay(plugin, plugin._quick_property)
+	plugin._quick_property.position = Vector2(123, 456)
+	Overlays.place_viewport_overlay(plugin, plugin._quick_property)
+	assert_eq(plugin._quick_property.position, Vector2(123, 456))

--- a/tests/test_viewport_overlay_host.gd.uid
+++ b/tests/test_viewport_overlay_host.gd.uid
@@ -1,0 +1,1 @@
+uid://xkrxa43wlk2d


### PR DESCRIPTION
## Summary

Three of the five controls HammerForge added to `CONTAINER_SPATIAL_EDITOR_MENU` are not toolbar items: a floating contextual toolbar, a command palette and a cursor property popup. That row is a layout container, so it reserved each one's full minimum size out of the space the 3D viewport was going to get.

Measured in a real editor session (`godot --editor --headless`), not inferred:

| | Toolbar minimum |
| --- | --- |
| At rest | `(800, 46)` — 752px of it HammerForge's |
| Command palette open | `(1136, `**`380`**`)` |

A command palette resizing the toolbar to eight times its height. And because our controls are added last, they are the ones pushed off the right edge on narrower windows.

They now parent to the `Control` Godot passes to `_forward_3d_force_draw_over_viewport` — a plain Control at the viewport's exact rect, which reserves nothing and positions nothing. Worth noting this is *not* `EditorInterface.get_editor_viewport_3d(0)`, which returns the SubViewport, a different node; I checked rather than assumed.

This is the move the marquee already made, pinned by `test_marquee_draws_in_the_native_3d_viewport_overlay` — *"A viewport marquee must not be laid out or clipped by the spatial toolbar."*

It also fixes a latent bug. That Control's rect **is** the space `event.position` from `_forward_3d_gui_input` is measured in, so `hf_quick_property`'s `position` and `hf_radial_menu`'s `PRESET_FULL_RECT` are no longer overwritten by the container on its next re-sort. They worked before only because it rarely re-sorted.

Split out of #167 on request, and rebased onto `main` now that #167 has merged — the two
CHANGELOG entries sit side by side and there is nothing left to resolve. The branch is a
clean fast-forward from `6f47e4a`.

## Before / After Behavior

- **Before:**
  - Toolbar minimum width 800px at rest, 752px of it HammerForge's.
  - Opening the command palette took the toolbar's minimum to `(1136, 380)`, squeezing the viewport it is supposed to float over.
  - `hf_quick_property` and `hf_radial_menu` set geometry the container would overwrite on its next re-sort.

- **After:**
  - Toolbar minimum `(458, 46)` at rest, and unchanged with every overlay open — only the shortcut HUD and status strip remain in the row, which is what they are.
  - Overlays sit over the viewport, in the coordinate space their code already claimed to be using.
  - Verified in the editor with all overlays shown at once: context toolbar at `(334, 8)` — top-centre of a 709px-wide viewport; palette at `(230, 132.5)` — dead centre.

**Known limitations, plainly:**
- The contextual toolbar and palette have `MOUSE_FILTER_STOP` and now sit *over* the viewport, so clicks in their rects go to them rather than the 3D scene. That is what a floating toolbar should do, but it is new behaviour and worth a look before merge.
- Placement (`VIEWPORT_OVERLAY_ANCHORS`) is a first pass — context toolbar top-centre, palette centred, coach marks bottom-centre, replay bottom-left — chosen so they do not land stacked in the viewport's corner. Verified in the editor for the first two; the power-user overlays are off in my config, so their anchors are covered by unit tests only.
- Only the first live viewport host is adopted, so in a split-viewport layout the overlays stay on the viewport that drew first. Godot calls the draw-over hook once per viewport per frame, so adopting each call would drag them between viewports.

## Related Issue

None — found while measuring the toolbar resizing reported in #167.

## Checks

- [x] `gdformat --check addons/hammerforge/ tests/` passes
- [x] `gdlint addons/hammerforge/` passes
- [x] `godot --headless -s res://addons/gut/gut_cmdln.gd --path .` passes — re-run after the rebase, so this is #167's merged code plus this change: 2262 tests, 2255 passing, 0 failing (7 risky are pre-existing and unchanged). 12 new tests in `tests/test_viewport_overlay_host.gd`.
- [x] Docs updated together where behavior changed — `[Unreleased]` / Fixed in CHANGELOG
- [x] `git diff --check` is clean and relative Markdown links resolve
- [x] No MCP tokens, `user://` settings, verification logs, editor screenshots, or local client overrides committed
- [x] `addons/godot_mcp` left untouched


