### PR TITLE
Centre the viewport overlays, and keep them centred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,11 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   (800, 46) at rest and (1136, **380**) the instant the palette opened. They now
   parent to the `Control` Godot passes to `_forward_3d_force_draw_over_viewport`
   — the viewport's own rect, which reserves nothing and positions nothing — with
-  placement in one table, `HFPluginOverlays.VIEWPORT_OVERLAY_ANCHORS`. That rect
+  placement in one table, `HFPluginOverlays.VIEWPORT_OVERLAY_ANCHORS`, centred
+  against the size each overlay reports and re-anchored when that size moves —
+  the contextual toolbar is 41px wide with nothing selected and 940px with a
+  brush selected, so anchoring it once while empty left it running off the side
+  of the viewport. That rect
   is also the space `event.position` is measured in, so `hf_quick_property`'s
   `position` and `hf_radial_menu`'s `PRESET_FULL_RECT` are no longer overwritten
   by the container on its next re-sort. Toolbar minimum is now (458, 46) and

--- a/addons/hammerforge/plugin.gd
+++ b/addons/hammerforge/plugin.gd
@@ -1232,6 +1232,7 @@ func _update_marquee_overlay(from: Vector2, to: Vector2, active: bool) -> void:
 ## remain correct under split views, editor scaling, and dock rearrangement.
 func _forward_3d_force_draw_over_viewport(viewport_control: Control) -> void:
 	HFPluginOverlays.adopt_viewport_overlay_host(self, viewport_control)
+	HFPluginOverlays.refresh_viewport_overlay_placement(self)
 	HFPluginOverlays.draw_marquee_overlay(self, viewport_control)
 
 

--- a/addons/hammerforge/plugin_overlays.gd
+++ b/addons/hammerforge/plugin_overlays.gd
@@ -27,10 +27,10 @@ const VIEWPORT_OVERLAY_PROPERTIES := [
 ## around one, and now that neither is inside a layout container the geometry
 ## they set for themselves is no longer overwritten on the next re-sort.
 const VIEWPORT_OVERLAY_ANCHORS := {
-	"_context_toolbar": [Control.PRESET_CENTER_TOP, 8],
-	"_hotkey_palette": [Control.PRESET_CENTER, 0],
-	"_coach_marks": [Control.PRESET_CENTER_BOTTOM, 12],
-	"_operation_replay": [Control.PRESET_BOTTOM_LEFT, 12],
+	"_context_toolbar": ["top_center", 8.0],
+	"_hotkey_palette": ["center", 0.0],
+	"_coach_marks": ["bottom_center", 12.0],
+	"_operation_replay": ["bottom_left", 12.0],
 }
 
 
@@ -96,6 +96,11 @@ static func _rehome_viewport_overlay(control: Control, host: Control) -> void:
 	host.add_child(control)
 
 
+## The minimum size an overlay was last anchored against, so a change in it can
+## be noticed without polling every anchor every frame.
+const OVERLAY_PLACED_SIZE_META := &"hf_overlay_placed_size"
+
+
 ## Anchor an overlay inside the viewport. Anything not named in the table places
 ## itself, so leave it alone: overwriting a cursor-anchored popup with a corner
 ## preset is how it ends up in the wrong half of the screen.
@@ -105,10 +110,82 @@ static func place_viewport_overlay(plugin: Object, control: Control) -> void:
 	var property := _overlay_property_for(plugin, control)
 	if not VIEWPORT_OVERLAY_ANCHORS.has(property):
 		return
-	var placement: Array = VIEWPORT_OVERLAY_ANCHORS[property]
-	control.set_anchors_and_offsets_preset(
-		int(placement[0]), Control.PRESET_MODE_MINSIZE, int(placement[1])
-	)
+	_anchor_overlay(control, VIEWPORT_OVERLAY_ANCHORS[property])
+
+
+## Re-anchor any overlay whose minimum size has moved under it.
+##
+## `set_anchors_and_offsets_preset` bakes its offsets from the minimum size it
+## can see at the time, and neither anchored overlay is its final size when it is
+## first placed: the contextual toolbar grows and shrinks with what is selected,
+## and the palette finishes measuring its own rows after it is parented. Left
+## alone, the toolbar keeps the left edge it was centred on while empty and a
+## real selection grows it off the right side of the viewport.
+##
+## Anchors are fractions, so the host resizing is already handled; only a change
+## of minimum size needs re-baking, and comparing two Vector2s is cheap enough to
+## do on the draw hook.
+static func refresh_viewport_overlay_placement(plugin: Object) -> void:
+	if plugin == null:
+		return
+	var host = plugin._viewport_overlay_host
+	if host == null or not is_instance_valid(host):
+		return
+	for property in VIEWPORT_OVERLAY_ANCHORS:
+		var control = plugin.get(property)
+		if not (control is Control) or not is_instance_valid(control):
+			continue
+		if control.get_parent() != host:
+			continue
+		var minimum: Vector2 = control.get_combined_minimum_size()
+		if control.has_meta(OVERLAY_PLACED_SIZE_META):
+			if control.get_meta(OVERLAY_PLACED_SIZE_META) == minimum:
+				continue
+		_anchor_overlay(control, VIEWPORT_OVERLAY_ANCHORS[property])
+
+
+## Godot's own PRESET_CENTER_TOP puts the control's top-left corner on the
+## centre-top point rather than centring the control there — it leaves both
+## horizontal offsets at zero — so a 940px toolbar anchored that way starts at
+## the middle of the viewport and runs off the right of it. The anchors and
+## offsets are set out longhand instead, against the minimum size the overlay
+## reports now.
+static func _anchor_overlay(control: Control, placement: Array) -> void:
+	var minimum := control.get_combined_minimum_size()
+	var half := minimum * 0.5
+	var margin := float(placement[1])
+	match str(placement[0]):
+		"top_center":
+			_set_anchors(control, 0.5, 0.0, 0.5, 0.0)
+			_set_offsets(control, -half.x, margin, half.x, margin + minimum.y)
+		"center":
+			_set_anchors(control, 0.5, 0.5, 0.5, 0.5)
+			_set_offsets(control, -half.x, -half.y, half.x, half.y)
+		"bottom_center":
+			_set_anchors(control, 0.5, 1.0, 0.5, 1.0)
+			_set_offsets(control, -half.x, -margin - minimum.y, half.x, -margin)
+		"bottom_left":
+			_set_anchors(control, 0.0, 1.0, 0.0, 1.0)
+			_set_offsets(control, margin, -margin - minimum.y, margin + minimum.x, -margin)
+	control.set_meta(OVERLAY_PLACED_SIZE_META, minimum)
+
+
+static func _set_anchors(
+	control: Control, left: float, top: float, right: float, bottom: float
+) -> void:
+	control.anchor_left = left
+	control.anchor_top = top
+	control.anchor_right = right
+	control.anchor_bottom = bottom
+
+
+static func _set_offsets(
+	control: Control, left: float, top: float, right: float, bottom: float
+) -> void:
+	control.offset_left = left
+	control.offset_top = top
+	control.offset_right = right
+	control.offset_bottom = bottom
 
 
 static func _overlay_property_for(plugin: Object, control: Control) -> String:

--- a/tests/test_viewport_overlay_host.gd
+++ b/tests/test_viewport_overlay_host.gd
@@ -233,3 +233,51 @@ func test_self_positioning_overlays_are_left_alone() -> void:
 	plugin._quick_property.position = Vector2(123, 456)
 	Overlays.place_viewport_overlay(plugin, plugin._quick_property)
 	assert_eq(plugin._quick_property.position, Vector2(123, 456))
+
+
+# --- re-anchoring when the overlay's own size moves ----------------------
+
+
+func test_a_grown_overlay_is_recentred_rather_than_left_hanging_off_the_edge() -> void:
+	# `set_anchors_and_offsets_preset` bakes its offsets from the minimum size it
+	# can see at the time. The contextual toolbar is 41px wide with nothing
+	# selected and 940px with a brush selected, so the left edge it was centred
+	# on while empty put most of it past the right side of the viewport. Caught
+	# in the editor, not by the first round of these tests.
+	host.size = Vector2(1486, 820)
+	plugin._context_toolbar = _overlay("ContextToolbar")
+	plugin._context_toolbar.custom_minimum_size = Vector2(41, 36)
+	Overlays.attach_viewport_overlay(plugin, plugin._context_toolbar)
+	Overlays.adopt_viewport_overlay_host(plugin, host)
+
+	plugin._context_toolbar.custom_minimum_size = Vector2(940, 36)
+	Overlays.refresh_viewport_overlay_placement(plugin)
+
+	var rect: Rect2 = plugin._context_toolbar.get_rect()
+	assert_almost_eq(rect.position.x + rect.size.x * 0.5, host.size.x * 0.5, 1.0, "Still centred")
+	assert_gte(rect.position.x, 0.0, "Runs off the left of the viewport")
+	assert_lte(rect.position.x + rect.size.x, host.size.x, "Runs off the right of the viewport")
+
+
+func test_placement_is_not_rebaked_while_the_size_holds_still() -> void:
+	# The draw hook runs this every frame, so it has to be a cheap no-op in the
+	# common case rather than re-anchoring continuously.
+	host.size = Vector2(1486, 820)
+	plugin._hotkey_palette = _overlay("Palette")
+	Overlays.attach_viewport_overlay(plugin, plugin._hotkey_palette)
+	Overlays.adopt_viewport_overlay_host(plugin, host)
+	var before: Rect2 = plugin._hotkey_palette.get_rect()
+	plugin._hotkey_palette.position += Vector2(11, 13)
+	Overlays.refresh_viewport_overlay_placement(plugin)
+	assert_eq(
+		plugin._hotkey_palette.position,
+		before.position + Vector2(11, 13),
+		"An unchanged minimum size must not trigger a re-anchor"
+	)
+
+
+func test_refresh_is_safe_before_a_host_exists() -> void:
+	plugin._context_toolbar = _overlay("ContextToolbar")
+	Overlays.attach_viewport_overlay(plugin, plugin._context_toolbar)
+	Overlays.refresh_viewport_overlay_placement(plugin)
+	assert_same(plugin._context_toolbar.get_parent(), plugin.toolbar)


### PR DESCRIPTION
## Summary

Follow-up to #168. Moving the overlays onto the viewport was right; anchoring them there was wrong in two ways, and both were invisible until the editor drew them with a real selection.

**1. `PRESET_CENTER_TOP` does not centre anything.** It puts the control's top-left *corner* on the centre-top point. Measured directly rather than assumed — `set_anchors_and_offsets_preset(PRESET_CENTER_TOP, PRESET_MODE_MINSIZE, 8)` comes back with both horizontal offsets at `0.0`. So the contextual toolbar started at the middle of the viewport and grew rightward. Harmless at the 41px it measures with nothing selected; 176px off the right edge at the 940px it measures with a brush selected. The anchors and offsets are set out longhand now.

**2. The preset bakes offsets from the minimum size it can see at the time**, and neither anchored overlay is its final size when first placed — the toolbar changes width with the selection, and the palette finishes measuring its rows after it is parented. `refresh_viewport_overlay_placement` re-anchors when that minimum moves, driven from the draw hook that already adopts the host. Anchors are fractions so a resized viewport was already handled; only a change in the overlay's own size needs re-baking, and the check is a Vector2 comparison.

The CHANGELOG entry from #168 is amended rather than a new one added — that change is still unreleased, so this is describing its net behaviour, not a bug anyone saw.

## Before / After Behavior

Measured in the editor with a brush selected, viewport 1486x820 (host centre x = 743):

| | Before | After |
| --- | --- | --- |
| Context toolbar rect | `P(722, 8) S(940, 36)` — right edge at 1663, **177px past the viewport** | `P(273, 8) S(940, 36)` — fits |
| Context toolbar centre | 1192 | **743** |
| Palette centre | off by (+35, +133) | **dead centre** |

- **Before:** with a brush selected the contextual toolbar was clipped by the right edge of the viewport — its last button rendered as a bare "P". The command palette sat down-and-right of centre.
- **After:** the toolbar is centred at the top of the viewport with every button visible, clear of Godot's "Perspective" label and view gizmo; the palette is centred. Both re-centre themselves as their contents change.

**Why the existing tests did not catch it:** they asserted the overlays were anchored *somewhere distinct from the corner*, not that they were centred and inside the viewport. A test passing for the wrong reason. The new one grows the toolbar from 41px to 940px and asserts it stays centred and within the host; it fails against the old code.

**Still unverified, plainly:** click routing. The contextual toolbar and palette have `MOUSE_FILTER_STOP` and sit over the viewport, so clicks in their rects go to them rather than the 3D scene. I verified placement, not input — that needs a human clicking.

**Pre-existing, not touched here:** the palette's shortcut column is clipped ("Q", "Sh", "Ctr" rather than the full bindings). That is its own 320px `custom_minimum_size` and internal layout, unchanged by this work or by #168.

## Related Issue

Follow-up to #168, found by checking the result in the editor.

## Checks

- [x] `gdformat --check addons/hammerforge/ tests/` passes
- [x] `gdlint addons/hammerforge/` passes
- [x] `godot --headless -s res://addons/gut/gut_cmdln.gd --path .` passes — 2265 tests, 2258 passing, 0 failing (7 risky are pre-existing and unchanged). 3 new tests.
- [x] Verified in a real editor session, not only in tests — screenshots taken via `addons/hf_docshot`-style window-scoped capture
- [x] Docs updated together where behavior changed — the #168 entry in `[Unreleased]` amended
- [x] `git diff --check` is clean and relative Markdown links resolve
- [x] No MCP tokens, `user://` settings, verification logs, editor screenshots, or local client overrides committed
- [x] `addons/godot_mcp` left untouched
