### PR TITLE
Stop the command palette clipping its own keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   explains it. It reads the Console's own evaluation, so the two cannot disagree.
 
 ### Fixed
+- **Every keybinding in the command palette was clipped to its first character
+  or two** — `Ctrl+Shift+Enter` rendered as `Ctr`, `Shift+P` as `Sh`. The binding
+  label was anchored with `PRESET_CENTER_RIGHT`, which puts a control's top-left
+  *corner* on that point rather than aligning its right edge to it, so each label
+  began at the row's right edge and ran past it for the scroll container to clip.
+  Only the single-key bindings looked right, and then only just: `Q` overflowed
+  its 300px row by one pixel. The label now stretches the row with its text
+  right-aligned and an 8px inset, so it holds that inset at any palette width.
 - **The 3D toolbar resized itself, and the viewport moved with it.**
   `CONTAINER_SPATIAL_EDITOR_MENU` is a plain `HBoxContainer` and the 3D viewport
   gets whatever height is left under it. Every control Godot puts in that row is

--- a/addons/hammerforge/ui/hf_hotkey_palette.gd
+++ b/addons/hammerforge/ui/hf_hotkey_palette.gd
@@ -44,6 +44,10 @@ func _build_style() -> void:
 	custom_minimum_size = Vector2(320, 380)
 
 
+## Gap between a row's binding text and the right edge of the row.
+const BIND_INSET := 8.0
+
+
 func _build_ui() -> void:
 	var vbox = VBoxContainer.new()
 	vbox.add_theme_constant_override("separation", 6)
@@ -158,8 +162,21 @@ func _create_entry(
 	bind_lbl.text = binding
 	bind_lbl.add_theme_font_size_override("font_size", 11)
 	bind_lbl.add_theme_color_override("font_color", HFThemeUtils.muted_text())
-	bind_lbl.set_anchors_preset(Control.PRESET_CENTER_RIGHT)
-	bind_lbl.position.x = -8
+	# Stretched across the row with the text right-aligned, rather than anchored
+	# to the centre-right point: Godot's PRESET_CENTER_RIGHT puts the label's
+	# top-left corner there, so every binding started at the row's right edge and
+	# ran off it, leaving the scroll container to clip all but the first
+	# character or two — "Ctrl+K" showed as "Ctr".
+	bind_lbl.anchor_left = 0.0
+	bind_lbl.anchor_top = 0.0
+	bind_lbl.anchor_right = 1.0
+	bind_lbl.anchor_bottom = 1.0
+	bind_lbl.offset_left = 0.0
+	bind_lbl.offset_top = 0.0
+	bind_lbl.offset_right = -BIND_INSET
+	bind_lbl.offset_bottom = 0.0
+	bind_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	bind_lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
 	bind_lbl.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	btn.add_child(bind_lbl)
 

--- a/tests/test_hotkey_palette.gd
+++ b/tests/test_hotkey_palette.gd
@@ -290,3 +290,71 @@ func _entry_for(action: String):
 		if entry["action"] == action:
 			return entry
 	return null
+
+
+# ===========================================================================
+# Row layout
+#
+# The binding used to be anchored with PRESET_CENTER_RIGHT, which puts a
+# control's top-left corner on that point rather than aligning its right edge
+# to it. Every binding therefore began at the row's right edge and ran past it,
+# and the scroll container clipped all but the first character or two: "Ctrl+K"
+# rendered as "Ctr". Caught by looking at the editor, not by these tests.
+# ===========================================================================
+
+
+func _binding_label(btn: Button) -> Label:
+	for child in btn.get_children():
+		if child is Label:
+			return child
+	return null
+
+
+func test_binding_label_stays_inside_its_row():
+	# Rows sit at their own minimum width until the palette gets a real layout
+	# pass, and a binding trivially "fits" a row narrower than itself. Give each
+	# row the width it has in the palette and measure against that.
+	for entry in palette._entries:
+		var btn: Button = entry["button"]
+		btn.size = Vector2(300, 26)
+		var bind := _binding_label(btn)
+		assert_not_null(bind, "Every row carries its binding")
+		assert_lte(
+			bind.position.x + bind.size.x,
+			btn.size.x,
+			"Binding '%s' runs off the right of its row and gets clipped" % entry["binding"]
+		)
+		assert_gte(bind.position.x, 0.0, "Binding '%s' starts left of its row" % entry["binding"])
+
+
+func test_binding_label_follows_a_row_that_changes_width():
+	var btn: Button = palette._entries[0]["button"]
+	var bind := _binding_label(btn)
+	for width in [200.0, 320.0, 640.0]:
+		btn.size = Vector2(width, 26)
+		assert_almost_eq(
+			bind.position.x + bind.size.x,
+			width - HFHotkeyPalette.BIND_INSET,
+			0.01,
+			"The binding should hold its inset from the right edge at width %s" % width
+		)
+
+
+func test_binding_label_is_right_aligned_with_an_inset():
+	var entry = palette._entries[0]
+	var btn: Button = entry["button"]
+	var bind: Label = null
+	for child in btn.get_children():
+		if child is Label:
+			bind = child
+			break
+	assert_eq(bind.horizontal_alignment, HORIZONTAL_ALIGNMENT_RIGHT)
+	assert_eq(bind.anchor_right, 1.0, "Follows the row's right edge as the palette resizes")
+	assert_almost_eq(bind.offset_right, -HFHotkeyPalette.BIND_INSET, 0.01)
+
+
+func test_binding_label_does_not_swallow_the_row_click():
+	for entry in palette._entries:
+		for child in entry["button"].get_children():
+			if child is Label:
+				assert_eq(child.mouse_filter, Control.MOUSE_FILTER_IGNORE)


### PR DESCRIPTION
## Summary

Every keybinding in the command palette was clipped to its first character or two — `Ctrl+Shift+Enter` rendered as `Ctr`, `Shift+P` as `Sh`. The single-key bindings looked correct and were not: `Q` overflowed its 300px row by exactly one pixel.

The cause is the same misreading of the layout API as the overlay anchoring in #169: `PRESET_CENTER_RIGHT` puts a control's top-left **corner** on the centre-right point rather than aligning its right edge to it. Each binding label therefore began at the row's right edge and ran past it, leaving the scroll container to clip the remainder.

The label now spans the row with its text right-aligned and an 8px inset, so it holds that inset at whatever width the palette is given rather than depending on its text having been measured first.

This predates the overlay work — it was only ever visible once #168 and #169 put the palette somewhere you could actually read it.

## Before / After Behavior

- **Before:** `Toggle Add / Cut  Q` · `Toggle Paint Mode  Sh` · `Quick Play  Ctr` · `Validate Level  Ctr` — bindings unreadable, so the palette could not teach a shortcut, which is most of its job.
- **After:** `Q` · `Shift+P` · `Ctrl+Enter` · `Ctrl+Shift+Enter` — all complete, right-aligned, and holding their inset as the palette resizes.

Measured against the old code, all 43 labels overflowed their row; the worst ran to 377px on a 300px row.

## Related Issue

Found while verifying #169 in the editor. Reported there as pre-existing and left alone at the time.

## Checks

- [x] `gdformat --check addons/hammerforge/ tests/` passes
- [x] `gdlint addons/hammerforge/` passes
- [x] `godot --headless -s res://addons/gut/gut_cmdln.gd --path .` passes — 2269 tests, 2262 passing, 0 failing (7 risky are pre-existing and unchanged). 4 new tests.
- [x] New tests confirmed to fail against the old code before being trusted — 43 labels, every one overflowing
- [x] Verified in a real editor session as well, not only in tests
- [x] Docs updated together where behavior changed — `[Unreleased]` / Fixed in CHANGELOG
- [x] `git diff --check` is clean and relative Markdown links resolve
- [x] No MCP tokens, `user://` settings, verification logs, editor screenshots, or local client overrides committed
- [x] `addons/godot_mcp` left untouched

## Note on the tests

They assert against a row of known width rather than a laid-out palette. Rows sit at their own minimum width until the palette gets a real layout pass, and a binding trivially "fits" a row narrower than itself — an assertion that would have passed against the bug. Learned from #169, where the first round of tests passed for exactly that kind of wrong reason.
