### PR TITLE
Wrap the contextual toolbar instead of overflowing the viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   explains it. It reads the Console's own evaluation, so the two cannot disagree.
 
 ### Fixed
+- **The contextual toolbar ran off both sides of the viewport when it did not
+  fit.** With a brush selected it measures 940px unwrapped, and the 3D viewport
+  is narrower than that as soon as a dock is open — centring something wider
+  than what it is centred in just hangs it off both ends, with the controls at
+  each end unreachable. Its sections wrap now, and placement caps an overlay to
+  the viewport it floats over. Measured at a 709px viewport: laid out at 693px
+  across four rows, with every button inside the viewport instead of 115px of
+  toolbar hanging off each side. A toolbar that fits still keeps its own width
+  rather than stretching to fill.
 - **Every keybinding in the command palette was clipped to its first character
   or two** — `Ctrl+Shift+Enter` rendered as `Ctr`, `Shift+P` as `Sh`. The binding
   label was anchored with `PRESET_CENTER_RIGHT`, which puts a control's top-left

--- a/addons/hammerforge/plugin_overlays.gd
+++ b/addons/hammerforge/plugin_overlays.gd
@@ -151,9 +151,9 @@ static func refresh_viewport_overlay_placement(plugin: Object) -> void:
 ## offsets are set out longhand instead, against the minimum size the overlay
 ## reports now.
 static func _anchor_overlay(control: Control, placement: Array) -> void:
-	var minimum := control.get_combined_minimum_size()
-	var half := minimum * 0.5
 	var margin := float(placement[1])
+	var minimum := _overlay_size(control, margin)
+	var half := minimum * 0.5
 	match str(placement[0]):
 		"top_center":
 			_set_anchors(control, 0.5, 0.0, 0.5, 0.0)
@@ -167,7 +167,29 @@ static func _anchor_overlay(control: Control, placement: Array) -> void:
 		"bottom_left":
 			_set_anchors(control, 0.0, 1.0, 0.0, 1.0)
 			_set_offsets(control, margin, -margin - minimum.y, margin + minimum.x, -margin)
-	control.set_meta(OVERLAY_PLACED_SIZE_META, minimum)
+	control.set_meta(OVERLAY_PLACED_SIZE_META, control.get_combined_minimum_size())
+
+
+## What the overlay should be laid out at, never wider or taller than the
+## viewport it floats over. An overlay bigger than the viewport cannot be centred
+## into it: centring just hangs it off both sides, with the buttons at each end
+## unreachable. The contextual toolbar measures 940px with a brush selected and
+## the viewport is narrower than that with a dock open, so it is capped here and
+## wraps to a second row inside the cap.
+##
+## `natural_row_width()` is asked for rather than the combined minimum, because a
+## wrapping container reports only its widest child and would otherwise cap
+## itself to a single button.
+static func _overlay_size(control: Control, margin: float) -> Vector2:
+	var minimum := control.get_combined_minimum_size()
+	if control.has_method("natural_row_width"):
+		minimum.x = maxf(minimum.x, float(control.call("natural_row_width")))
+	var area := control.get_parent_area_size()
+	if area.x > 0.0:
+		minimum.x = minf(minimum.x, maxf(0.0, area.x - margin * 2.0))
+	if area.y > 0.0:
+		minimum.y = minf(minimum.y, maxf(0.0, area.y - margin * 2.0))
+	return minimum
 
 
 static func _set_anchors(

--- a/addons/hammerforge/ui/hf_context_toolbar.gd
+++ b/addons/hammerforge/ui/hf_context_toolbar.gd
@@ -90,6 +90,44 @@ func _build_content() -> void:
 	_build_vertex_section()
 
 
+## The width this toolbar would need laid out as one row.
+##
+## The sections wrap now, and an HFlowContainer reports only its widest child as
+## a minimum width — so nothing in the tree can answer "how wide is the content
+## really", which is exactly what the placement code needs in order to choose
+## between the natural width and the width of the viewport.
+func natural_row_width() -> float:
+	var total := 0.0
+	var panel_style := get_theme_stylebox("panel")
+	if panel_style:
+		total += panel_style.get_margin(SIDE_LEFT) + panel_style.get_margin(SIDE_RIGHT)
+	if _content == null:
+		return total
+	var shown := 0
+	for child in _content.get_children():
+		var c := child as Control
+		if c == null or not c.visible:
+			continue
+		shown += 1
+		total += _unwrapped_width(c)
+	return total + maxf(0.0, float(shown - 1)) * float(_content.get_theme_constant("separation"))
+
+
+static func _unwrapped_width(control: Control) -> float:
+	if not (control is FlowContainer):
+		return control.get_combined_minimum_size().x
+	var total := 0.0
+	var shown := 0
+	for child in control.get_children():
+		var c := child as Control
+		if c == null or not c.visible:
+			continue
+		shown += 1
+		total += c.get_combined_minimum_size().x
+	var gap := float(control.get_theme_constant("h_separation"))
+	return total + maxf(0.0, float(shown - 1)) * gap
+
+
 func _build_auto_hint_bar() -> void:
 	_auto_hint_bar = PanelContainer.new()
 	var hint_style = StyleBoxFlat.new()
@@ -128,8 +166,13 @@ func _build_auto_hint_bar() -> void:
 
 
 func _build_brush_section() -> void:
-	var section = HBoxContainer.new()
-	section.add_theme_constant_override("separation", 2)
+	var section = HFlowContainer.new()
+	# Wraps to a second row rather than running off the sides of the viewport.
+	# The brush section alone measures 940px, and the viewport is narrower than
+	# that as soon as a dock is open.
+	section.add_theme_constant_override("h_separation", 2)
+	section.add_theme_constant_override("v_separation", 2)
+	section.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	section.visible = false
 	_content.add_child(section)
 	_sections[Context.BRUSH_SELECTED] = section
@@ -178,8 +221,13 @@ func _build_brush_section() -> void:
 
 
 func _build_face_section() -> void:
-	var section = HBoxContainer.new()
-	section.add_theme_constant_override("separation", 2)
+	var section = HFlowContainer.new()
+	# Wraps to a second row rather than running off the sides of the viewport.
+	# The brush section alone measures 940px, and the viewport is narrower than
+	# that as soon as a dock is open.
+	section.add_theme_constant_override("h_separation", 2)
+	section.add_theme_constant_override("v_separation", 2)
+	section.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	section.visible = false
 	_content.add_child(section)
 	_sections[Context.FACE_SELECTED] = section
@@ -213,8 +261,13 @@ func _build_face_section() -> void:
 
 
 func _build_entity_section() -> void:
-	var section = HBoxContainer.new()
-	section.add_theme_constant_override("separation", 2)
+	var section = HFlowContainer.new()
+	# Wraps to a second row rather than running off the sides of the viewport.
+	# The brush section alone measures 940px, and the viewport is narrower than
+	# that as soon as a dock is open.
+	section.add_theme_constant_override("h_separation", 2)
+	section.add_theme_constant_override("v_separation", 2)
+	section.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	section.visible = false
 	_content.add_child(section)
 	_sections[Context.ENTITY_SELECTED] = section
@@ -256,8 +309,13 @@ func _build_entity_section() -> void:
 
 
 func _build_draw_section() -> void:
-	var section = HBoxContainer.new()
-	section.add_theme_constant_override("separation", 2)
+	var section = HFlowContainer.new()
+	# Wraps to a second row rather than running off the sides of the viewport.
+	# The brush section alone measures 940px, and the viewport is narrower than
+	# that as soon as a dock is open.
+	section.add_theme_constant_override("h_separation", 2)
+	section.add_theme_constant_override("v_separation", 2)
+	section.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	section.visible = false
 	_content.add_child(section)
 	_sections[Context.DRAW_IDLE] = section
@@ -302,8 +360,13 @@ func _build_draw_section() -> void:
 
 
 func _build_drag_section() -> void:
-	var section = HBoxContainer.new()
-	section.add_theme_constant_override("separation", 2)
+	var section = HFlowContainer.new()
+	# Wraps to a second row rather than running off the sides of the viewport.
+	# The brush section alone measures 940px, and the viewport is narrower than
+	# that as soon as a dock is open.
+	section.add_theme_constant_override("h_separation", 2)
+	section.add_theme_constant_override("v_separation", 2)
+	section.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	section.visible = false
 	_content.add_child(section)
 	_sections[Context.DRAGGING] = section
@@ -330,8 +393,13 @@ func _build_drag_section() -> void:
 
 
 func _build_vertex_section() -> void:
-	var section = HBoxContainer.new()
-	section.add_theme_constant_override("separation", 2)
+	var section = HFlowContainer.new()
+	# Wraps to a second row rather than running off the sides of the viewport.
+	# The brush section alone measures 940px, and the viewport is narrower than
+	# that as soon as a dock is open.
+	section.add_theme_constant_override("h_separation", 2)
+	section.add_theme_constant_override("v_separation", 2)
+	section.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	section.visible = false
 	_content.add_child(section)
 	_sections[Context.VERTEX_EDIT] = section

--- a/tests/test_context_toolbar.gd
+++ b/tests/test_context_toolbar.gd
@@ -452,3 +452,32 @@ func test_viewport_menu_context_matches_selection_state():
 	assert_true(menu.is_item_disabled(0))
 	menu.hide()
 	menu.free()
+
+
+# --- the row wraps rather than running off the viewport -------------------
+
+
+func test_sections_wrap_instead_of_overflowing():
+	# An HBoxContainer section runs off the sides of the viewport once the
+	# buttons no longer fit. Measured before this: 940px of brush tools with the
+	# viewport at 975px, and narrower than that with a dock open.
+	for ctx_key in toolbar._sections:
+		var section: Control = toolbar._sections[ctx_key]
+		assert_true(
+			section is FlowContainer,
+			"Section %s cannot wrap, so it overflows instead" % str(ctx_key)
+		)
+		assert_eq(section.size_flags_horizontal, Control.SIZE_EXPAND_FILL)
+
+
+func test_natural_row_width_reports_the_unwrapped_content():
+	# A wrapping container reports only its widest child as a minimum, so the
+	# placement code cannot ask it how wide the content really is.
+	toolbar.update_state({"has_root": true, "brush_count": 1, "tool": 1})
+	var natural: float = toolbar.natural_row_width()
+	assert_gt(natural, 0.0)
+	assert_gt(
+		natural,
+		toolbar.get_combined_minimum_size().x,
+		"A wrapped row's minimum is one button wide; the natural width is the whole row"
+	)

--- a/tests/test_viewport_overlay_host.gd
+++ b/tests/test_viewport_overlay_host.gd
@@ -281,3 +281,76 @@ func test_refresh_is_safe_before_a_host_exists() -> void:
 	Overlays.attach_viewport_overlay(plugin, plugin._context_toolbar)
 	Overlays.refresh_viewport_overlay_placement(plugin)
 	assert_same(plugin._context_toolbar.get_parent(), plugin.toolbar)
+
+
+# --- an overlay wider than the viewport ----------------------------------
+
+
+## A panel whose width comes from wrappable content, like the real contextual
+## toolbar: a control pinned by `custom_minimum_size` cannot be capped, because
+## Godot will not lay a control out smaller than its own minimum.
+func _wrappable_overlay(name: String, buttons: int, button_width: float) -> Control:
+	var panel := PanelContainer.new()
+	panel.name = name
+	var flow := HFlowContainer.new()
+	flow.add_theme_constant_override("h_separation", 0)
+	flow.add_theme_constant_override("v_separation", 0)
+	flow.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	panel.add_child(flow)
+	for i in range(buttons):
+		var b := Button.new()
+		b.custom_minimum_size = Vector2(button_width, 30)
+		flow.add_child(b)
+	return panel
+
+
+func test_an_overlay_wider_than_the_viewport_is_capped_to_it() -> void:
+	# Centring cannot help something wider than what it is centred in: it just
+	# hangs off both sides with the controls at each end unreachable. Measured in
+	# the editor before this: a 940px toolbar in a 975px viewport, which a single
+	# open dock is enough to push over.
+	host.size = Vector2(600, 400)
+	plugin._context_toolbar = _wrappable_overlay("ContextToolbar", 10, 94.0)
+	Overlays.attach_viewport_overlay(plugin, plugin._context_toolbar)
+	Overlays.adopt_viewport_overlay_host(plugin, host)
+
+	var rect: Rect2 = plugin._context_toolbar.get_rect()
+	assert_lte(rect.size.x, host.size.x, "Wider than the viewport it floats over")
+	assert_gte(rect.position.x, 0.0, "Hangs off the left")
+	assert_lte(rect.position.x + rect.size.x, host.size.x, "Hangs off the right")
+
+
+func test_a_capped_overlay_wraps_rather_than_losing_its_controls() -> void:
+	host.size = Vector2(600, 400)
+	plugin._context_toolbar = _wrappable_overlay("ContextToolbar", 10, 94.0)
+	Overlays.attach_viewport_overlay(plugin, plugin._context_toolbar)
+	Overlays.adopt_viewport_overlay_host(plugin, host)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var flow: Control = plugin._context_toolbar.get_child(0)
+	var rows := {}
+	for b in flow.get_children():
+		rows[(b as Control).position.y] = true
+	assert_gt(rows.size(), 1, "940px of buttons in a 600px viewport has to take more than one row")
+	for b in flow.get_children():
+		var r: Rect2 = (b as Control).get_global_rect()
+		assert_lte(
+			r.position.x + r.size.x,
+			host.get_global_rect().position.x + host.size.x + 0.01,
+			"A button ended up outside the viewport"
+		)
+
+
+func test_an_overlay_that_fits_keeps_its_natural_width() -> void:
+	# The cap must not shrink a toolbar that had room, or every selection would
+	# get a full-width bar instead of a compact one.
+	host.size = Vector2(1486, 820)
+	plugin._context_toolbar = _overlay("ContextToolbar")
+	plugin._context_toolbar.custom_minimum_size = Vector2(420, 36)
+	Overlays.attach_viewport_overlay(plugin, plugin._context_toolbar)
+	Overlays.adopt_viewport_overlay_host(plugin, host)
+
+	var rect: Rect2 = plugin._context_toolbar.get_rect()
+	assert_almost_eq(rect.size.x, 420.0, 0.01, "Kept its own width")
+	assert_almost_eq(rect.position.x + rect.size.x * 0.5, 743.0, 1.0, "Still centred")


### PR DESCRIPTION
## Summary

With a brush selected the contextual toolbar measures **940px** laid out as one row, and the 3D viewport is narrower than that as soon as a dock is open. Centring something wider than what it is centred in does not help — it hangs off both ends, and the controls at each end cannot be clicked at all.

Two changes:

1. **The sections wrap.** They were `HBoxContainer`s, which cannot; they are `HFlowContainer`s now, with `SIZE_EXPAND_FILL` so they take the width the row gives them.
2. **Placement caps an overlay to the viewport it floats over**, which is what gives the wrap a width to work against.

The cap needs a width the container cannot supply. A wrapping container reports only its *widest child* as a minimum, so asking it directly would cap the toolbar to a single button. `natural_row_width()` sums the visible content as it would sit unwrapped, and placement takes the larger of the two.

Found while verifying #169 in the editor — the toolbar measured 940px in a 975px viewport, within 35px of overflowing, and a 70px probe button was enough to push it over.

## Before / After Behavior

Measured in the editor at a deliberately narrowed window, viewport **709px** wide against **940px** of content:

| | Before | After |
| --- | --- | --- |
| Toolbar laid out at | 940px — 115px hanging off **each** side | **693px**, inside the viewport |
| Rows | 1 | **4** |
| Buttons outside the viewport | the ends of the row, unreachable | **0** |

- **Before:** narrow the editor or open a dock, and the ends of the contextual toolbar — `Extrude`/`Ext▲` on one side, `Preview`/`Bake▷` on the other — sat outside the viewport with no way to reach them.
- **After:** the row wraps and every control stays inside. A toolbar that fits is untouched and keeps its own width rather than stretching to fill, so the compact centred look is unchanged in the common case.

**Known limitation, plainly:** the cap cannot shrink a control pinned by `custom_minimum_size` — Godot will not lay a control out below its own minimum. It works for the toolbar because its width comes from wrappable content. The command palette is pinned at 320x380, so on a viewport shorter than 380px it would still overflow vertically; that is not a size any real editor window produces, and I have not changed it.

## Related Issue

Follow-up to #169, found by measuring in the editor rather than by a report.

## Checks

- [x] `gdformat --check addons/hammerforge/ tests/` passes
- [x] `gdlint addons/hammerforge/` passes
- [x] `godot --headless -s res://addons/gut/gut_cmdln.gd --path .` passes — 2274 tests, 2267 passing, 0 failing (7 risky are pre-existing and unchanged). 5 new tests.
- [x] Verified in a real editor session at a narrowed window, not only in tests
- [x] Docs updated together where behavior changed — `[Unreleased]` / Fixed in CHANGELOG
- [x] `git diff --check` is clean and relative Markdown links resolve
- [x] No MCP tokens, `user://` settings, verification logs, editor screenshots, or local client overrides committed
- [x] `addons/godot_mcp` left untouched

## Note on the tests

My first version of the cap test used a panel pinned with `custom_minimum_size` as the fixture. It failed — correctly, because that models a control which genuinely cannot be capped, and it would have sent me looking for a bug in working code. The fixture now builds a panel whose width comes from wrappable content, which is what the real toolbar is.
