### PR TITLE
Keep authored entity names and I/O wiring through save, bake, and runtime

### DIFF
--- a/addons/hammerforge/hf_io_runtime.gd
+++ b/addons/hammerforge/hf_io_runtime.gd
@@ -358,13 +358,22 @@ func _collect_connections(node: Node) -> void:
 				entry["_fired"] = false
 				_connections[id].append(entry)
 		# Reverse lookup: name -> [instance_id, ...]
-		if not _source_name_to_ids.has(source_name):
-			_source_name_to_ids[source_name] = []
-		var id_list: Array = _source_name_to_ids[source_name]
-		if id not in id_list:
-			id_list.append(id)
+		_index_source_name(source_name, id)
+		# Authors fire by the logical entity name, which can differ from the
+		# generated node name on baked triggers and meshes.
+		var meta_name := str(node.get_meta("entity_name", ""))
+		if meta_name != "" and meta_name != source_name:
+			_index_source_name(meta_name, id)
 	for child in node.get_children():
 		_collect_connections(child)
+
+
+func _index_source_name(key: String, id: int) -> void:
+	if not _source_name_to_ids.has(key):
+		_source_name_to_ids[key] = []
+	var id_list: Array = _source_name_to_ids[key]
+	if id not in id_list:
+		id_list.append(id)
 
 
 # ---------------------------------------------------------------------------

--- a/addons/hammerforge/systems/hf_bake_system.gd
+++ b/addons/hammerforge/systems/hf_bake_system.gd
@@ -1182,15 +1182,33 @@ func _append_nonstructural_brushes(container: Node3D, filter: Variant = null) ->
 		idx += 1
 
 
+## The authored name an entity is wired to. Brushes get a Godot generated node
+## name unless the author renamed them, so fall back to the node name only when
+## it is not one of those generated names.
+static func authored_entity_name(draft: Node) -> String:
+	if not draft:
+		return ""
+	var meta_name := str(draft.get_meta("entity_name", ""))
+	if meta_name != "":
+		return meta_name
+	var node_name := str(draft.name)
+	if node_name == "" or node_name.begins_with("@") or node_name == "DraftBrush":
+		return ""
+	return node_name
+
+
 func _append_detail_mesh(holder: Node3D, draft: DraftBrush, idx: int) -> void:
 	var mesh: Mesh = null
 	var source: Node3D = draft
 	if draft.mesh_instance and draft.mesh_instance.mesh:
 		mesh = draft.mesh_instance.mesh
 		source = draft.mesh_instance
+	var authored := authored_entity_name(draft)
 	var mi := MeshInstance3D.new()
-	mi.name = "FuncDetail_%d" % idx
+	mi.name = authored if authored != "" else "FuncDetail_%d" % idx
 	mi.mesh = mesh
+	if authored != "":
+		mi.set_meta("entity_name", authored)
 	holder.add_child(mi)
 	mi.transform = _source_transform_in_baked_container(source, holder.get_parent() as Node3D)
 	var body := StaticBody3D.new()
@@ -1201,6 +1219,7 @@ func _append_detail_mesh(holder: Node3D, draft: DraftBrush, idx: int) -> void:
 	body.collision_layer = layer
 	body.collision_mask = layer
 	holder.add_child(body)
+	body.transform = mi.transform
 	var col := CollisionShape3D.new()
 	col.shape = _shape_for_draft(draft, mesh)
 	col.transform = body.transform.affine_inverse() * mi.transform
@@ -1208,10 +1227,13 @@ func _append_detail_mesh(holder: Node3D, draft: DraftBrush, idx: int) -> void:
 
 
 func _append_trigger_volume(holder: Node3D, draft: DraftBrush, idx: int) -> void:
+	var authored := authored_entity_name(draft)
 	var area := Area3D.new()
-	area.name = "Trigger_%d" % idx
+	area.name = authored if authored != "" else "Trigger_%d" % idx
 	area.monitoring = true
 	area.monitorable = true
+	if authored != "":
+		area.set_meta("entity_name", authored)
 	var bec := str(draft.get_meta("brush_entity_class", ""))
 	if bec != "":
 		area.set_meta("brush_entity_class", bec)

--- a/addons/hammerforge/systems/hf_brush_system.gd
+++ b/addons/hammerforge/systems/hf_brush_system.gd
@@ -128,6 +128,12 @@ func create_brush_from_info(info: Dictionary) -> Node:
 		brush.set_meta("group_id", str(info["group_id"]))
 	if info.has("brush_entity_class") and str(info["brush_entity_class"]) != "":
 		brush.set_brush_entity_class(str(info["brush_entity_class"]))
+	if info.has("entity_io_outputs"):
+		var outputs: Array = info.get("entity_io_outputs", [])
+		if not outputs.is_empty():
+			brush.set_meta("entity_io_outputs", outputs.duplicate(true))
+	if info.has("entity_name") and str(info["entity_name"]) != "":
+		brush.set_meta("entity_name", str(info["entity_name"]))
 	if root.has_method("tag_brush_dirty"):
 		root.tag_brush_dirty(str(brush_id))
 	if root.has_method("_emit_or_batch"):
@@ -322,6 +328,12 @@ func get_brush_info_from_node(brush: Node) -> Dictionary:
 	var bec: String = str(draft.get_meta("brush_entity_class", ""))
 	if bec != "":
 		info["brush_entity_class"] = bec
+	var outputs: Array = draft.get_meta("entity_io_outputs", [])
+	if not outputs.is_empty():
+		info["entity_io_outputs"] = outputs.duplicate(true)
+	var ename: String = str(draft.get_meta("entity_name", ""))
+	if ename != "":
+		info["entity_name"] = ename
 	return info
 
 

--- a/tests/test_bake_system.gd
+++ b/tests/test_bake_system.gd
@@ -2548,3 +2548,114 @@ func test_bake_dirty_with_no_changes_reports_nothing_to_do():
 		HFBakeSystem.BakeStatus.NOTHING_TO_DO,
 		"Nothing to do must be distinguishable from failure",
 	)
+
+
+# ===========================================================================
+# Nonstructural bake keeps authored names and places its collision body
+# (#140, #158)
+# ===========================================================================
+
+
+func _nonstructural_holder(container: Node3D) -> Node:
+	bake_sys._append_nonstructural_brushes(container)
+	return container.get_node_or_null("Nonstructural")
+
+
+func test_trigger_bake_keeps_authored_node_name():
+	var trigger := _make_brush(root.draft_brushes_node)
+	trigger.name = "door_sensor"
+	trigger.set_meta("brush_entity_class", "trigger_once")
+	var container := Node3D.new()
+	add_child_autoqfree(container)
+
+	var holder := _nonstructural_holder(container)
+	var area: Area3D = null
+	for child in holder.get_children():
+		if child is Area3D:
+			area = child
+			break
+	assert_not_null(area)
+	assert_eq(area.name, &"door_sensor", "Baked trigger keeps the authored node name")
+	assert_eq(str(area.get_meta("entity_name", "")), "door_sensor")
+
+
+func test_trigger_bake_prefers_entity_name_meta():
+	var trigger := _make_brush(root.draft_brushes_node)
+	trigger.name = "SomeBrush"
+	trigger.set_meta("entity_name", "secret_trigger")
+	trigger.set_meta("brush_entity_class", "trigger_multiple")
+	var container := Node3D.new()
+	add_child_autoqfree(container)
+
+	var holder := _nonstructural_holder(container)
+	var area: Area3D = null
+	for child in holder.get_children():
+		if child is Area3D:
+			area = child
+			break
+	assert_not_null(area)
+	assert_eq(str(area.get_meta("entity_name", "")), "secret_trigger")
+
+
+func test_trigger_bake_falls_back_to_indexed_name():
+	var trigger := _make_brush(root.draft_brushes_node)
+	trigger.name = "DraftBrush"
+	trigger.set_meta("brush_entity_class", "trigger_once")
+	var container := Node3D.new()
+	add_child_autoqfree(container)
+
+	var holder := _nonstructural_holder(container)
+	var area: Area3D = null
+	for child in holder.get_children():
+		if child is Area3D:
+			area = child
+			break
+	assert_not_null(area)
+	assert_eq(area.name, &"Trigger_0", "Generated brush names do not become entity names")
+	assert_false(area.has_meta("entity_name"))
+
+
+func test_func_detail_bake_keeps_authored_node_name():
+	var detail := _make_brush(root.draft_brushes_node)
+	detail.name = "crate_a"
+	detail.set_meta("brush_entity_class", "func_detail")
+	var container := Node3D.new()
+	add_child_autoqfree(container)
+
+	var holder := _nonstructural_holder(container)
+	var mi: MeshInstance3D = null
+	for child in holder.get_children():
+		if child is MeshInstance3D:
+			mi = child
+			break
+	assert_not_null(mi)
+	assert_eq(mi.name, &"crate_a")
+	assert_eq(str(mi.get_meta("entity_name", "")), "crate_a")
+
+
+func test_func_detail_collision_body_sits_at_the_brush():
+	var detail := _make_brush(root.draft_brushes_node, Vector3(10, 5, 20))
+	detail.set_meta("brush_entity_class", "func_detail")
+	var container := Node3D.new()
+	add_child_autoqfree(container)
+
+	var holder := _nonstructural_holder(container)
+	var mi: MeshInstance3D = null
+	var body: StaticBody3D = null
+	for child in holder.get_children():
+		if child is MeshInstance3D:
+			mi = child
+		elif child is StaticBody3D:
+			body = child
+	assert_not_null(mi)
+	assert_not_null(body)
+	assert_almost_eq(body.position.x, mi.position.x, 0.001)
+	assert_almost_eq(body.position.y, mi.position.y, 0.001)
+	assert_almost_eq(body.position.z, mi.position.z, 0.001)
+	var col := body.get_child(0) as CollisionShape3D
+	assert_not_null(col)
+	# The shape still lands where the mesh does, now relative to a placed body.
+	var shape_pos: Vector3 = (body.transform * col.transform).origin
+	assert_almost_eq(shape_pos.x, mi.position.x, 0.001)
+	assert_almost_eq(shape_pos.y, mi.position.y, 0.001)
+	assert_almost_eq(shape_pos.z, mi.position.z, 0.001)

--- a/tests/test_brush_info_roundtrip.gd
+++ b/tests/test_brush_info_roundtrip.gd
@@ -303,3 +303,90 @@ func test_move_to_ceiling_nonexistent_id_noop():
 	# Should not crash
 	sys.move_brushes_to_ceiling(["nonexistent"])
 	assert_true(true, "Nonexistent ID should not crash")
+
+
+# ===========================================================================
+# Entity I/O wiring survives capture/restore (#149)
+# ===========================================================================
+
+
+func test_round_trip_preserves_entity_io_outputs_and_name():
+	var b = sys.create_brush_from_info({"shape": root.BrushShape.BOX, "size": Vector3(8, 8, 8)})
+	b.set_meta("brush_entity_class", "trigger_once")
+	b.set_meta("entity_name", "entry_trigger")
+	(
+		b
+		. set_meta(
+			"entity_io_outputs",
+			[
+				{
+					"output_name": "OnTrigger",
+					"target_name": "door1",
+					"input_name": "Open",
+					"parameter": "",
+					"delay": 0.5,
+					"fire_once": true,
+				}
+			]
+		)
+	)
+
+	var info = sys.get_brush_info_from_node(b)
+	sys.delete_brush(b)
+
+	info["brush_id"] = "io_restored"
+	var restored = sys.create_brush_from_info(info)
+
+	assert_not_null(restored)
+	assert_eq(str(restored.get_meta("entity_name", "")), "entry_trigger")
+	var outputs: Array = restored.get_meta("entity_io_outputs", [])
+	assert_eq(outputs.size(), 1, "Output connection should survive the round trip")
+	assert_eq(str(outputs[0].get("target_name", "")), "door1")
+	assert_eq(str(outputs[0].get("input_name", "")), "Open")
+	assert_almost_eq(float(outputs[0].get("delay", 0.0)), 0.5, 0.001)
+	assert_true(bool(outputs[0].get("fire_once", false)))
+
+
+func test_round_trip_copies_outputs_instead_of_sharing_them():
+	var b = sys.create_brush_from_info({"shape": root.BrushShape.BOX, "size": Vector3(8, 8, 8)})
+	b.set_meta(
+		"entity_io_outputs",
+		[{"output_name": "OnTrigger", "target_name": "door1", "input_name": "Open"}]
+	)
+
+	var info = sys.get_brush_info_from_node(b)
+	info["brush_id"] = "io_copy"
+	var restored = sys.create_brush_from_info(info)
+
+	var restored_outputs: Array = restored.get_meta("entity_io_outputs", [])
+	restored_outputs[0]["target_name"] = "door2"
+	var original_outputs: Array = b.get_meta("entity_io_outputs", [])
+	assert_eq(
+		str(original_outputs[0].get("target_name", "")),
+		"door1",
+		"Restored brush must not share output dictionaries with the source",
+	)
+
+
+func test_duplicate_info_keeps_entity_wiring():
+	var b = sys.create_brush_from_info({"shape": root.BrushShape.BOX, "size": Vector3(8, 8, 8)})
+	b.set_meta("entity_name", "entry_trigger")
+	b.set_meta(
+		"entity_io_outputs",
+		[{"output_name": "OnTrigger", "target_name": "door1", "input_name": "Open"}]
+	)
+
+	var dup_info = sys.build_duplicate_info(b, Vector3(4, 0, 0))
+	var dup = sys.create_brush_from_info(dup_info)
+
+	assert_eq(str(dup.get_meta("entity_name", "")), "entry_trigger")
+	assert_eq((dup.get_meta("entity_io_outputs", []) as Array).size(), 1)
+
+
+func test_round_trip_without_entity_wiring_sets_no_meta():
+	var b = sys.create_brush_from_info({"shape": root.BrushShape.BOX, "size": Vector3(8, 8, 8)})
+	var info = sys.get_brush_info_from_node(b)
+	assert_false(info.has("entity_io_outputs"))
+	assert_false(info.has("entity_name"))
+	var restored = sys.create_brush_from_info(info)
+	assert_false(restored.has_meta("entity_name"), "Plain brushes stay free of entity metadata")

--- a/tests/test_io_runtime.gd
+++ b/tests/test_io_runtime.gd
@@ -730,3 +730,52 @@ func test_prune_overlapping_roots_disjoint():
 	var roots: Array[Node] = [a, b]
 	var pruned: Array[Node] = HFIORuntime._prune_overlapping_roots(roots)
 	assert_eq(pruned.size(), 2, "disjoint roots should both survive")
+
+
+# ===========================================================================
+# Firing by authored entity name (#151)
+# ===========================================================================
+
+
+func test_fire_resolves_source_by_entity_name_meta():
+	var button := _make_entity(scene_root, "Area3D_Baked_1")
+	button.set_meta("entity_name", "secret_button")
+	var door := _make_target_entity(scene_root, "Door1")
+	_add_connection(button, "OnPressed", "Door1", "Open")
+	_wire_dispatcher()
+
+	dispatcher.fire("secret_button", "OnPressed")
+	assert_eq(door.received_calls.size(), 1, "fire() should resolve the authored entity name")
+
+
+func test_fire_still_resolves_source_by_node_name():
+	var button := _make_entity(scene_root, "Area3D_Baked_1")
+	button.set_meta("entity_name", "secret_button")
+	var door := _make_target_entity(scene_root, "Door1")
+	_add_connection(button, "OnPressed", "Door1", "Open")
+	_wire_dispatcher()
+
+	dispatcher.fire("Area3D_Baked_1", "OnPressed")
+	assert_eq(door.received_calls.size(), 1, "Node name lookup must keep working")
+
+
+func test_fire_by_both_names_does_not_double_dispatch():
+	var button := _make_entity(scene_root, "Trigger_0")
+	button.set_meta("entity_name", "secret_button")
+	var door := _make_target_entity(scene_root, "Door1")
+	_add_connection(button, "OnPressed", "Door1", "Open")
+	_wire_dispatcher()
+
+	dispatcher.fire("secret_button", "OnPressed")
+	assert_eq(door.received_calls.size(), 1, "One alias fires the source exactly once")
+
+
+func test_fire_ignores_empty_entity_name_meta():
+	var button := _make_entity(scene_root, "Button1")
+	button.set_meta("entity_name", "")
+	var door := _make_target_entity(scene_root, "Door1")
+	_add_connection(button, "OnPressed", "Door1", "Open")
+	_wire_dispatcher()
+
+	dispatcher.fire("", "OnPressed")
+	assert_eq(door.received_calls.size(), 0, "An empty alias must not become a lookup key")


### PR DESCRIPTION
One root cause: the authored name of a brush entity, and its output connections, did not survive the pipeline.

- `HFBrushSystem.get_brush_info_from_node()` now captures `entity_io_outputs` and `entity_name`, and `create_brush_from_info()` restores them. Outputs are deep copied so a restored or duplicated brush does not share dictionaries with its source.
- `HFBakeSystem._append_trigger_volume()` and `_append_detail_mesh()` use the authored name for the baked node and always set `entity_name` on it. Generated names like `@DraftBrush@3` are not treated as authored, so those still fall back to `Trigger_N` and `FuncDetail_N`.
- `_append_detail_mesh()` sets the `StaticBody3D` transform instead of leaving it at the origin.
- `HFIORuntime._collect_connections()` indexes sources under `entity_name` as well as the node name, so `fire()` works with either.

13 new tests. All fail without the corresponding fix.

Fixes #149
Fixes #140
Fixes #158
Fixes #151