### PR TITLE
Fix map plane winding and refuse malformed map imports

### DIFF
--- a/addons/hammerforge/dock_file_handler.gd
+++ b/addons/hammerforge/dock_file_handler.gd
@@ -151,8 +151,15 @@ static func on_map_import_selected(dock: Object, path: String) -> void:
 	if not dock.level_root:
 		dock._set_status("No LevelRoot for .map import", true)
 		return
+	var check: Dictionary = dock.level_root.validate_map(path)
+	if not bool(check.get("ok", false)):
+		var reason := str(check.get("error", "unreadable file"))
+		dock._set_status("Failed to import .map: %s" % reason, true)
+		dock.show_toast("Failed to import .map", 2)
+		return
 	dock._commit_full_state_action("Import .map", "import_map", [path])
 	dock._set_status("Imported .map", false, 3.0)
+	dock.show_toast("Imported .map", 0)
 
 
 static func on_map_export_selected(dock: Object, path: String) -> void:

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -1890,6 +1890,10 @@ func load_hflevel(path: String = "") -> bool:
 	return ok
 
 
+func validate_map(path: String) -> Dictionary:
+	return file_system.validate_map(path)
+
+
 func import_map(path: String) -> int:
 	return file_system.import_map(path)
 

--- a/addons/hammerforge/map_io.gd
+++ b/addons/hammerforge/map_io.gd
@@ -30,13 +30,16 @@ static func load_map(path: String) -> Dictionary:
 static func parse_map_text(text: String) -> Dictionary:
 	var lines = text.replace("\r", "").split("\n")
 	var entities: Array = []
+	var errors: Array[String] = []
 	var current_entity: Dictionary = {}
 	var current_brush: Dictionary = {}
 	var in_entity = false
 	var in_brush = false
 	var face_re = RegEx.new()
 	face_re.compile("\\(([^\\)]+)\\)")
+	var line_no = 0
 	for raw_line in lines:
+		line_no += 1
 		var line = raw_line.strip_edges()
 		if line == "" or line.begins_with("//"):
 			continue
@@ -54,6 +57,8 @@ static func parse_map_text(text: String) -> Dictionary:
 				in_brush = true
 				current_brush = {"faces": []}
 				continue
+			errors.append("Line %d: brush inside a brush" % line_no)
+			continue
 		if line == "}":
 			if in_brush:
 				current_entity["brushes"].append(current_brush)
@@ -65,16 +70,25 @@ static func parse_map_text(text: String) -> Dictionary:
 				current_entity = {}
 				in_entity = false
 				continue
+			errors.append("Line %d: closing brace with nothing open" % line_no)
+			continue
 		if in_brush:
 			var face = _parse_face_line(line, face_re)
-			if not face.is_empty():
+			if face.is_empty():
+				errors.append("Line %d: face is not three planar points" % line_no)
+			else:
 				current_brush["faces"].append(face)
 			continue
 		if in_entity:
 			var kv = _parse_key_value(line)
 			if kv.size() == 2:
 				current_entity["properties"][kv[0]] = kv[1]
+			else:
+				errors.append("Line %d: not a key value pair" % line_no)
 			continue
+		errors.append("Line %d: text outside any block" % line_no)
+	if in_brush or in_entity:
+		errors.append("Unclosed block at end of file")
 	# Weld near-coincident vertices across all parsed faces to close micro-gaps
 	if import_weld_tolerance > 0.0:
 		for entity in entities:
@@ -93,11 +107,14 @@ static func parse_map_text(text: String) -> Dictionary:
 		for brush in entity.get("brushes", []):
 			var info = _brush_from_faces(brush.get("faces", []))
 			if info.is_empty():
+				errors.append("A brush in '%s' has no usable geometry" % entity_class)
 				continue
 			if entity_class != "" and entity_class != "worldspawn":
 				info["brush_entity_class"] = entity_class
 			brushes.append(info)
-	return {"entities": entity_points, "brushes": brushes}
+	if entities.is_empty() and text.strip_edges() != "":
+		errors.append("No map blocks found")
+	return {"entities": entity_points, "brushes": brushes, "errors": errors}
 
 
 static func export_map_from_level(level_root: Node, adapter: HFMapAdapterType = null) -> String:
@@ -224,7 +241,11 @@ static func _brush_from_faces(faces: Array) -> Dictionary:
 		if face_points.size() < 3:
 			continue
 		var local_verts: Array = []
-		for p in face_points:
+		# Mirror of the export: undo the .map plane order so the stored face keeps
+		# FaceData's clockwise-from-outside winding.
+		var wound: Array = face_points.duplicate()
+		wound.reverse()
+		for p in wound:
 			var pt: Vector3 = p
 			local_verts.append([pt.x - center.x, pt.y - center.y, pt.z - center.z])
 		serialized_faces.append({"local_verts": local_verts, "winding_version": 1})
@@ -333,7 +354,10 @@ static func _faces_to_map_lines(
 		var a: Vector3 = brush.global_transform * face.local_verts[0]
 		var b: Vector3 = brush.global_transform * face.local_verts[1]
 		var c: Vector3 = brush.global_transform * face.local_verts[2]
-		lines.append(adapter.format_face_line(a, b, c, DEFAULT_TEXTURE, face))
+		# FaceData winds clockwise seen from outside. A .map plane is read as
+		# (b - a) x (c - a), so the points go out in the reverse order or every
+		# hull comes out inside out.
+		lines.append(adapter.format_face_line(a, c, b, DEFAULT_TEXTURE, face))
 	return lines
 
 

--- a/addons/hammerforge/systems/hf_file_system.gd
+++ b/addons/hammerforge/systems/hf_file_system.gd
@@ -60,11 +60,36 @@ func load_hflevel(path: String = "") -> bool:
 	return true
 
 
+## Parse a .map without touching the level. The dock preflights with this so a
+## malformed file never clears the current work.
+func validate_map(path: String) -> Dictionary:
+	if path == "" or not FileAccess.file_exists(path):
+		return {"ok": false, "error": "File not found: %s" % path}
+	var map_data = MapIO.load_map(path)
+	if map_data.is_empty():
+		return {"ok": false, "error": "Could not read %s" % path.get_file()}
+	var errors: Array = map_data.get("errors", [])
+	if not errors.is_empty():
+		return {"ok": false, "error": str(errors[0])}
+	return {"ok": true, "error": ""}
+
+
+func _report_map_error(path: String, message: String) -> void:
+	var text := "Map import failed (%s): %s" % [path.get_file(), message]
+	push_error(text)
+	if root and root.has_signal("user_message"):
+		root.user_message.emit(text, 2)
+
+
 func import_map(path: String) -> int:
 	if path == "":
 		return ERR_INVALID_PARAMETER
 	var map_data = MapIO.load_map(path)
 	if map_data.is_empty():
+		return ERR_INVALID_DATA
+	var errors: Array = map_data.get("errors", [])
+	if not errors.is_empty():
+		_report_map_error(path, str(errors[0]))
 		return ERR_INVALID_DATA
 	root.clear_brushes()
 	root._clear_entities()

--- a/tests/test_hf_file_system.gd
+++ b/tests/test_hf_file_system.gd
@@ -111,3 +111,111 @@ func test_changed_save_rewrites_file():
 	await _drain_write()
 	var loaded: Dictionary = HFLevelIO.load_from_path(_save_path)
 	assert_eq(int(loaded.get("n", 0)), 2)
+
+
+# ===========================================================================
+# Malformed .map import (#174)
+# ===========================================================================
+
+
+func _import_root() -> Node3D:
+	var s := GDScript.new()
+	s.source_code = """
+extends Node3D
+
+var cleared: int = 0
+var created: Array = []
+
+signal user_message(text: String, level: int)
+
+func clear_brushes() -> void:
+	cleared += 1
+
+func _clear_entities() -> void:
+	cleared += 1
+
+func create_brush_from_info(info: Dictionary) -> Node:
+	created.append(info)
+	return null
+
+func _create_entity_from_map(_info: Dictionary) -> Node:
+	return null
+"""
+	s.reload()
+	var node := Node3D.new()
+	node.set_script(s)
+	add_child_autoqfree(node)
+	return node
+
+
+func _write_map(path: String, text: String) -> String:
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(text)
+	f = null
+	return path
+
+
+func _good_map_text() -> String:
+	return (
+		"{\n"
+		+ '"classname" "worldspawn"'
+		+ "\n{\n"
+		+ "( 0 0 0 ) ( 10 0 0 ) ( 0 10 0 ) brick 0 0 0 1 1\n"
+		+ "( 0 0 0 ) ( 0 10 0 ) ( 0 0 10 ) brick 0 0 0 1 1\n"
+		+ "( 0 0 0 ) ( 0 0 10 ) ( 10 0 0 ) brick 0 0 0 1 1\n"
+		+ "( 10 0 0 ) ( 0 0 10 ) ( 0 10 0 ) brick 0 0 0 1 1\n"
+		+ "}\n}\n"
+	)
+
+
+func test_malformed_map_import_is_refused_and_leaves_the_level_alone():
+	var import_root := _import_root()
+	var fs := HFFileSystemType.new(import_root)
+	var path := _write_map("user://hf_broken_import_test.map", "not a map")
+	assert_eq(fs.import_map(path), ERR_INVALID_DATA)
+	assert_push_error("Map import failed")
+	assert_eq(import_root.cleared, 0, "A rejected import must not clear the level")
+	assert_eq(import_root.created.size(), 0)
+	DirAccess.remove_absolute(path)
+
+
+func test_unbalanced_map_import_is_refused():
+	var import_root := _import_root()
+	var fs := HFFileSystemType.new(import_root)
+	var text := "{\n" + '"classname" "worldspawn"' + "\n{\n"
+	var path := _write_map("user://hf_unbalanced_import_test.map", text)
+	assert_eq(fs.import_map(path), ERR_INVALID_DATA)
+	assert_push_error("Map import failed")
+	assert_eq(import_root.cleared, 0)
+	DirAccess.remove_absolute(path)
+
+
+func test_well_formed_map_import_still_replaces_the_level():
+	var import_root := _import_root()
+	var fs := HFFileSystemType.new(import_root)
+	var path := _write_map("user://hf_good_import_test.map", _good_map_text())
+	assert_eq(fs.import_map(path), OK)
+	assert_eq(import_root.cleared, 2, "A good import clears brushes and entities")
+	assert_eq(import_root.created.size(), 1)
+	DirAccess.remove_absolute(path)
+
+
+func test_validate_map_reports_the_first_problem():
+	var fs := HFFileSystemType.new(_import_root())
+	var path := _write_map("user://hf_validate_import_test.map", "not a map")
+	var result: Dictionary = fs.validate_map(path)
+	assert_false(bool(result.get("ok", true)))
+	assert_ne(str(result.get("error", "")), "", "The dock needs something to show the user")
+	DirAccess.remove_absolute(path)
+
+
+func test_validate_map_passes_a_good_file():
+	var fs := HFFileSystemType.new(_import_root())
+	var path := _write_map("user://hf_validate_good_test.map", _good_map_text())
+	assert_true(bool(fs.validate_map(path).get("ok", false)))
+	DirAccess.remove_absolute(path)
+
+
+func test_validate_map_rejects_a_missing_file():
+	var fs := HFFileSystemType.new(_import_root())
+	assert_false(bool(fs.validate_map("user://hf_does_not_exist.map").get("ok", true)))

--- a/tests/test_map_export.gd
+++ b/tests/test_map_export.gd
@@ -425,3 +425,182 @@ func test_export_writes_func_detail_as_own_entity_block():
 	var world_idx := text.find('"classname" "worldspawn"')
 	var detail_idx := text.find('"classname" "func_detail"')
 	assert_gt(detail_idx, world_idx, "Brush entity block comes after worldspawn")
+
+
+# ===========================================================================
+# Face plane winding (#148)
+# ===========================================================================
+
+
+## Pull the three plane points out of a face line without a regex, so this
+## helper stays readable next to the winding it is checking.
+func _plane_points(line: String) -> Array:
+	var points: Array = []
+	for part in line.split("(", false):
+		var close := part.find(")")
+		if close < 0:
+			continue
+		var nums := part.substr(0, close).strip_edges().split(" ", false)
+		if nums.size() < 3:
+			continue
+		points.append(Vector3(float(nums[0]), float(nums[1]), float(nums[2])))
+		if points.size() == 3:
+			break
+	return points
+
+
+func _first_plane_normal(line: String) -> Vector3:
+	return MapIO._face_normal(_plane_points(line))
+
+
+func _wrap_worldspawn(face_lines: Array) -> String:
+	var text := "{\n" + '"classname" "worldspawn"' + "\n{\n"
+	for line in face_lines:
+		text += str(line) + "\n"
+	return text + "}\n}\n"
+
+
+func test_custom_face_planes_point_outward_like_box_planes():
+	var brush := DraftBrush.new()
+	add_child_autoqfree(brush)
+	brush.shape = LevelRoot.BrushShape.BOX
+	brush.size = Vector3(2, 2, 2)
+	var box_lines: Array[String] = MapIO._box_to_map_lines(brush)
+	brush.shape = LevelRoot.BrushShape.CUSTOM
+	brush.faces = brush._build_box_faces()
+	var face_lines: Array[String] = MapIO._faces_to_map_lines(brush)
+
+	assert_eq(face_lines.size(), box_lines.size(), "Both paths write six planes")
+	for i in range(box_lines.size()):
+		var box_n := _first_plane_normal(box_lines[i])
+		var face_n := _first_plane_normal(face_lines[i])
+		assert_almost_eq(
+			face_n.dot(box_n),
+			1.0,
+			0.001,
+			"Face plane %d must point the same way as the box plane" % i
+		)
+
+
+func test_custom_face_plane_normal_matches_the_face_it_came_from():
+	var brush := DraftBrush.new()
+	add_child_autoqfree(brush)
+	brush.shape = LevelRoot.BrushShape.CUSTOM
+	brush.size = Vector3(2, 2, 2)
+	brush.faces = brush._build_box_faces()
+	var lines: Array[String] = MapIO._faces_to_map_lines(brush)
+	# _build_box_faces order starts with Right (+X).
+	assert_almost_eq(_first_plane_normal(lines[0]).x, 1.0, 0.001)
+
+
+func _face_outward(a: Vector3, b: Vector3, c: Vector3) -> Vector3:
+	# FaceData is clockwise from outside, so its normal is (c - a) x (b - a).
+	return (c - a).cross(b - a).normalized()
+
+
+func test_exported_plane_normal_matches_the_source_face_normal():
+	var source := [Vector3(0, 0, 0), Vector3(10, 0, 0), Vector3(0, 10, 0)]
+	var brush := DraftBrush.new()
+	add_child_autoqfree(brush)
+	brush.shape = LevelRoot.BrushShape.CUSTOM
+	var face := FaceData.new()
+	face.local_verts = PackedVector3Array(source)
+	var faces: Array[FaceData] = []
+	faces.append(face)
+	brush.faces = faces
+	var line: String = MapIO._faces_to_map_lines(brush)[0]
+	var expected := _face_outward(source[0], source[1], source[2])
+	assert_almost_eq(
+		MapIO._face_normal(_plane_points(line)).dot(expected),
+		1.0,
+		0.001,
+		"The written plane must face the same way as the face it came from"
+	)
+
+
+func test_tilted_hull_round_trip_keeps_face_winding():
+	var brush := DraftBrush.new()
+	add_child_autoqfree(brush)
+	brush.shape = LevelRoot.BrushShape.CUSTOM
+	var source := [
+		[Vector3(0, 0, 0), Vector3(10, 0, 0), Vector3(0, 10, 0)],
+		[Vector3(0, 0, 0), Vector3(0, 10, 0), Vector3(0, 0, 10)],
+		[Vector3(0, 0, 0), Vector3(0, 0, 10), Vector3(10, 0, 0)],
+		[Vector3(10, 0, 0), Vector3(0, 0, 10), Vector3(0, 10, 0)],
+	]
+	var faces: Array[FaceData] = []
+	for verts in source:
+		var fd := FaceData.new()
+		fd.local_verts = PackedVector3Array(verts)
+		faces.append(fd)
+	brush.faces = faces
+	var parsed: Dictionary = MapIO.parse_map_text(
+		_wrap_worldspawn(MapIO._faces_to_map_lines(brush))
+	)
+	assert_eq(parsed.get("errors", []), [], "Our own export has to parse clean")
+	var brushes: Array = parsed.get("brushes", [])
+	assert_eq(brushes.size(), 1)
+	assert_eq(int(brushes[0]["shape"]), LevelRoot.BrushShape.CUSTOM)
+	var imported: Array = brushes[0]["faces"]
+	assert_eq(imported.size(), source.size())
+	for i in range(source.size()):
+		var v: Array = imported[i]["local_verts"]
+		var got := _face_outward(
+			Vector3(v[0][0], v[0][1], v[0][2]),
+			Vector3(v[1][0], v[1][1], v[1][2]),
+			Vector3(v[2][0], v[2][1], v[2][2])
+		)
+		var want := _face_outward(source[i][0], source[i][1], source[i][2])
+		assert_almost_eq(got.dot(want), 1.0, 0.001, "Face %d came back inside out" % i)
+
+
+# ===========================================================================
+# Malformed map input (#174)
+# ===========================================================================
+
+
+func test_parse_arbitrary_text_reports_an_error():
+	var parsed: Dictionary = MapIO.parse_map_text("not a map")
+	assert_gt((parsed.get("errors", []) as Array).size(), 0, "Garbage is not a valid map")
+	assert_eq(parsed.get("brushes", []), [])
+
+
+func test_parse_empty_text_is_not_an_error():
+	var parsed: Dictionary = MapIO.parse_map_text("")
+	assert_eq(parsed.get("errors", []), [], "An empty file has nothing wrong with it")
+
+
+func test_parse_unbalanced_braces_reports_an_error():
+	var parsed: Dictionary = MapIO.parse_map_text("{\n" + '"classname" "worldspawn"' + "\n")
+	assert_gt((parsed.get("errors", []) as Array).size(), 0)
+
+
+func test_parse_stray_closing_brace_reports_an_error():
+	var text := "{\n" + '"classname" "worldspawn"' + "\n}\n}\n"
+	var parsed: Dictionary = MapIO.parse_map_text(text)
+	assert_gt((parsed.get("errors", []) as Array).size(), 0)
+
+
+func test_parse_invalid_face_line_reports_an_error():
+	var parsed: Dictionary = MapIO.parse_map_text(
+		_wrap_worldspawn(["( 0 0 0 ) ( 10 0 0 ) brick 0 0 0 1 1"])
+	)
+	assert_gt((parsed.get("errors", []) as Array).size(), 0, "Two points do not define a plane")
+
+
+func test_parse_well_formed_map_reports_no_errors():
+	var parsed: Dictionary = (
+		MapIO
+		. parse_map_text(
+			_wrap_worldspawn(
+				[
+					"( 0 0 0 ) ( 10 0 0 ) ( 0 10 0 ) brick 0 0 0 1 1",
+					"( 0 0 0 ) ( 0 10 0 ) ( 0 0 10 ) brick 0 0 0 1 1",
+					"( 0 0 0 ) ( 0 0 10 ) ( 10 0 0 ) brick 0 0 0 1 1",
+					"( 10 0 0 ) ( 0 0 10 ) ( 0 10 0 ) brick 0 0 0 1 1",
+				]
+			)
+		)
+	)
+	assert_eq(parsed.get("errors", []), [], "A good map must not raise a false alarm")
+	assert_eq((parsed.get("brushes", []) as Array).size(), 1)


### PR DESCRIPTION
Both issues are MapIO trusting input and output it never checked.

**Winding (#148).** `_faces_to_map_lines()` wrote `local_verts[0..2]` straight out. FaceData winds clockwise from outside, a `.map` plane is read as `(b - a) x (c - a)`, so every custom, beveled, carved, polygon and prism brush exported with inward planes. The points now go out reversed.

The same conversion was missing on import, so `_brush_from_faces()` stored real `.map` files inside out too. It now reverses the plane order back into FaceData winding. Box export already matched the format and is untouched.

**Malformed input (#174).** `parse_map_text()` returned `{"entities": [], "brushes": []}` for any text, so importing a junk file cleared the level and reported success. It now returns an `errors` array covering unbalanced braces, braces with nothing open, face lines that are not three points, key/value lines that are not, text outside any block, and brushes that produce no geometry. `import_map()` refuses before it clears anything, and `HFDockFileHandler.on_map_import_selected()` validates through the new `validate_map()` before opening an undo action, so a bad file leaves no entry on the undo stack.

14 new tests. 12 fail without the source changes; the other two are negative cases that must keep passing.

Fixes #148
Fixes #174