### PR TITLE
Generate LODs through ImporterMesh and build the atlas mip chain

### DIFF
--- a/addons/hammerforge/baker.gd
+++ b/addons/hammerforge/baker.gd
@@ -3,6 +3,9 @@ extends Node
 class_name Baker
 
 const DEFAULT_UV2_TEXEL_SIZE := 0.1
+const HFLog = preload("hf_log.gd")
+const LOD_NORMAL_MERGE_ANGLE := 25.0
+const LOD_NORMAL_SPLIT_ANGLE := 60.0
 const DraftBrush = preload("brush_instance.gd")
 const FaceData = preload("face_data.gd")
 const MaterialManager = preload("material_manager.gd")
@@ -548,8 +551,26 @@ func _postprocess_mesh(
 			if unwrapped is Mesh:
 				result = unwrapped
 		if generate_lods and result is ArrayMesh:
-			(result as ArrayMesh).generate_lods()
+			result = _mesh_with_lods(result as ArrayMesh)
 	return result
+
+
+## LOD generation lives on ImporterMesh, not ArrayMesh. Round trip through one
+## and hand back the original mesh if the engine cannot build any levels.
+## The angles are the values Godot uses for its own scene imports.
+func _mesh_with_lods(mesh: ArrayMesh) -> ArrayMesh:
+	if mesh.get_surface_count() == 0:
+		return mesh
+	var importer := ImporterMesh.from_mesh(mesh)
+	if importer == null:
+		HFLog.warn("Bake: could not build an ImporterMesh, skipping LOD generation")
+		return mesh
+	importer.generate_lods(LOD_NORMAL_MERGE_ANGLE, LOD_NORMAL_SPLIT_ANGLE, [])
+	var out := importer.get_mesh()
+	if out == null:
+		HFLog.warn("Bake: LOD generation produced no mesh, keeping the original")
+		return mesh
+	return out
 
 
 func _unwrap_uv0(mesh: ArrayMesh) -> ArrayMesh:

--- a/addons/hammerforge/hf_material_atlas.gd
+++ b/addons/hammerforge/hf_material_atlas.gd
@@ -155,6 +155,9 @@ static func build_atlas(material_keys: Array, exclude_keys: Dictionary = {}) -> 
 		result.atlased_keys.append(tile["key"])
 
 	# Create atlas material.
+	# The material asks for mipmapped filtering and the gutter padding exists to
+	# stop tiles bleeding across mip levels, so the levels have to be built.
+	_build_mipmaps(atlas_img, "albedo")
 	var atlas_tex = ImageTexture.create_from_image(atlas_img)
 	var mat = StandardMaterial3D.new()
 	mat.albedo_texture = atlas_tex
@@ -194,9 +197,27 @@ static func _build_pbr_channels(
 		if channel_img == null:
 			_record_skip(result, channel, "a supplied texture could not be read")
 			continue
+		_build_mipmaps(channel_img, channel)
 		var channel_tex := ImageTexture.create_from_image(channel_img)
 		_apply_channel(result.atlas_material, channel, channel_tex, suppliers[0])
 		result.atlased_channels.append(channel)
+
+
+## Build the mip chain the atlas material asks for. A failure here is silent at
+## runtime: the sampler just has nothing to fall back on, so say something.
+static func _build_mipmaps(img: Image, label: String) -> void:
+	if img == null:
+		return
+	if img.generate_mipmaps() != OK:
+		(
+			HFLog
+			. warn(
+				(
+					"HammerForge: material atlas could not build mipmaps for the %s texture. Distant surfaces will shimmer."
+					% label
+				)
+			)
+		)
 
 
 ## Record a slot the atlas cannot carry, and say so in the editor log. The whole

--- a/tests/test_baker.gd
+++ b/tests/test_baker.gd
@@ -537,3 +537,58 @@ func test_convex_simplify_reduces_points():
 	var pts_none: int = (shapes_none[0] as ConvexPolygonShape3D).points.size()
 	var pts_half: int = (shapes_half[0] as ConvexPolygonShape3D).points.size()
 	assert_lt(pts_half, pts_none, "convex_simplify=0.5 should produce fewer points than 0.0")
+
+
+# ===========================================================================
+# LOD generation (#138)
+# ===========================================================================
+
+
+func _make_dense_mesh() -> ArrayMesh:
+	var sphere := SphereMesh.new()
+	sphere.radial_segments = 64
+	sphere.rings = 32
+	var mesh := ArrayMesh.new()
+	mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, sphere.get_mesh_arrays())
+	return mesh
+
+
+func test_postprocess_with_lods_does_not_error():
+	var mesh := _make_dense_mesh()
+	var out: Mesh = baker._postprocess_mesh(mesh, true, false, 0.1)
+	assert_not_null(out, "Turning on Generate LODs must not abort the bake")
+	assert_true(out is ArrayMesh)
+	assert_eq((out as ArrayMesh).get_surface_count(), 1)
+
+
+func test_array_mesh_has_no_generate_lods():
+	# The reason the bake used to abort. If a future Godot adds it, revisit
+	# _mesh_with_lods rather than leaving the ImporterMesh detour in place.
+	assert_false(ClassDB.class_has_method("ArrayMesh", "generate_lods", true))
+	assert_true(ClassDB.class_has_method("ImporterMesh", "generate_lods", true))
+
+
+func test_postprocess_with_lods_produces_lod_levels():
+	var out: Mesh = baker._postprocess_mesh(_make_dense_mesh(), true, false, 0.1)
+	var importer := ImporterMesh.from_mesh(out)
+	assert_gt(importer.get_surface_lod_count(0), 0, "A dense mesh should come back simplified")
+
+
+func test_postprocess_with_lods_keeps_surface_materials():
+	var mat := _make_colored_material(Color.RED)
+	var mesh := _make_dense_mesh()
+	mesh.surface_set_material(0, mat)
+	var out: Mesh = baker._postprocess_mesh(mesh, true, false, 0.1)
+	assert_eq(out.surface_get_material(0), mat, "LOD generation must not drop materials")
+
+
+func test_postprocess_with_lods_tolerates_an_empty_mesh():
+	var out: Mesh = baker._postprocess_mesh(ArrayMesh.new(), true, false, 0.1)
+	assert_not_null(out)
+	assert_eq((out as ArrayMesh).get_surface_count(), 0)
+
+
+func test_postprocess_without_lods_returns_the_same_mesh():
+	var mesh := _make_dense_mesh()
+	var out: Mesh = baker._postprocess_mesh(mesh, false, false, 0.1)
+	assert_eq(out, mesh, "Leaving the option off must not rebuild the mesh")

--- a/tests/test_material_atlas.gd
+++ b/tests/test_material_atlas.gd
@@ -628,3 +628,28 @@ func test_atlas_bake_all_tiling_same_material_no_atlas():
 			mi = child
 	assert_not_null(mi)
 	assert_eq(mi.mesh.get_surface_count(), 2, "All tiling: no atlas possible, 2 separate surfaces")
+
+
+# ===========================================================================
+# Atlas mipmaps (#157)
+# ===========================================================================
+
+
+func test_atlas_texture_has_the_mipmaps_its_filter_asks_for():
+	var result = HFMaterialAtlasScript.build_atlas(
+		[_make_textured_material(Color.RED), _make_textured_material(Color.BLUE)]
+	)
+	assert_not_null(result.atlas_material)
+	assert_eq(
+		result.atlas_material.texture_filter,
+		BaseMaterial3D.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS,
+		"The material still asks for mipmapped filtering"
+	)
+	var img: Image = result.atlas_material.albedo_texture.get_image()
+	assert_true(img.has_mipmaps(), "The sampler needs mip levels to sample")
+	assert_gt(img.get_mipmap_count(), 0)
+
+
+func test_single_material_atlas_also_gets_mipmaps():
+	var result = HFMaterialAtlasScript.build_atlas([_make_textured_material(Color.GREEN)])
+	assert_true(result.atlas_material.albedo_texture.get_image().has_mipmaps())


### PR DESCRIPTION
Two bake outputs that asked the engine for something it was never given.

**LODs (#138).** `ArrayMesh` has no `generate_lods` in Godot 4, so ticking the option threw `Invalid call` and killed the bake. `_postprocess_mesh()` now goes through `ImporterMesh.from_mesh()`, `generate_lods()`, `get_mesh()`. Angles are 25.0 and 60.0, the values Godot uses for its own scene imports. An empty mesh or a failed conversion returns the original with a warning rather than aborting.

**Mipmaps (#157).** The atlas material sets `TEXTURE_FILTER_LINEAR_WITH_MIPMAPS` and the gutter padding exists specifically to stop tiles bleeding across mip levels, but no mip levels were built. The albedo atlas and every PBR channel atlas now generate them, and a failure is logged rather than leaving the sampler with nothing.

7 new tests. All fail without the source changes.

Verified against Godot 4.7 directly: `ClassDB.class_has_method("ArrayMesh", "generate_lods")` is false, `ImporterMesh` is true, and the `from_mesh` / `generate_lods` / `get_mesh` round trip produces 9 LOD levels on a dense mesh while keeping surface materials.

Fixes #138
Fixes #157