### PR TITLE
Keep the save queue in order and stop losing region paint

### DIFF
--- a/addons/hammerforge/systems/hf_file_system.gd
+++ b/addons/hammerforge/systems/hf_file_system.gd
@@ -29,7 +29,20 @@ func save_hflevel(path: String = "", force: bool = false, autosave: bool = false
 	ensure_dir_for_path(target)
 	if root.paint_system:
 		root.paint_system.set_region_base_path(target)
-		root.paint_system.save_loaded_regions()
+		var regions: Dictionary = root.paint_system.save_loaded_regions()
+		if not bool(regions.get("ok", true)):
+			# The index would claim region data that is missing or stale, and the
+			# level write would still report success. Stop here instead.
+			var message := str(regions.get("error", "region write failed"))
+			push_error("HFLevel: %s" % message)
+			# Report it as the kind of save it actually was, the way the worker
+			# results are reported in _process_hflevel_saves.
+			if autosave:
+				if root.has_signal("autosave_failed"):
+					root.autosave_failed.emit(message)
+			elif root.has_signal("hflevel_save_failed"):
+				root.hflevel_save_failed.emit(target, message)
+			return ERR_FILE_CANT_WRITE
 	var encoded: Dictionary = {}
 	var captured: Variant = root._capture_hflevel_state()
 	if captured is Dictionary:
@@ -155,6 +168,13 @@ func start_hflevel_thread(
 			return
 		_apply_thread_result(_hflevel_thread.wait_to_finish())
 		_hflevel_thread = null
+		# Collecting a finished worker does not entitle this job to run next.
+		# Anything already queued was asked for first and still owns its slot.
+		if not _hflevel_pending.is_empty():
+			job["force"] = true
+			_hflevel_pending.append(job)
+			_start_next_pending()
+			return
 	_hflevel_thread = Thread.new()
 	_hflevel_thread.start(Callable(self, "_hflevel_thread_encode_and_write").bind(job))
 
@@ -259,9 +279,7 @@ func process_thread_queue() -> String:
 		var result: Variant = _hflevel_thread.wait_to_finish()
 		_hflevel_thread = null
 		var error := _apply_thread_result(result)
-		if not _hflevel_pending.is_empty():
-			var next: Dictionary = _hflevel_pending.pop_front()
-			_start_pending_job(next)
+		_start_next_pending()
 		return error
 	return ""
 
@@ -298,14 +316,23 @@ func _apply_thread_result(result: Variant) -> String:
 	return ""
 
 
-func _start_pending_job(job: Dictionary) -> void:
+func _start_pending_job(job: Dictionary) -> bool:
 	var pending_path: String = str(job.get("path", ""))
 	if pending_path == "" or not (job.get("encoded") is Dictionary):
 		push_warning("HFLevel: Discarding pending write with empty path or payload")
-		return
+		return false
 	_hflevel_thread = Thread.new()
 	job["last_hash"] = _hflevel_last_hash
 	_hflevel_thread.start(Callable(self, "_hflevel_thread_encode_and_write").bind(job))
+	return true
+
+
+## Start the oldest queued write, skipping any that cannot run. Without the
+## loop a discarded job would leave the queue stalled with no live thread.
+func _start_next_pending() -> void:
+	while not _hflevel_pending.is_empty():
+		if _start_pending_job(_hflevel_pending.pop_front()):
+			return
 
 
 func _flush_job_sync(job: Dictionary) -> void:

--- a/addons/hammerforge/systems/hf_paint_system.gd
+++ b/addons/hammerforge/systems/hf_paint_system.gd
@@ -20,6 +20,8 @@ const HFLevelIO = preload("../hflevel_io.gd")
 
 var root: Node3D
 var region_manager: HFTerrainRegionManager
+## Regions whose write already failed, so the warning is not repeated every frame.
+var _region_save_warned: Dictionary = {}
 var region_streaming_enabled: bool = false
 var region_memory_budget_mb: int = 256
 var region_show_grid: bool = false
@@ -545,16 +547,25 @@ func _region_file_path(region_id: Vector2i) -> String:
 	return dir.path_join(file_name)
 
 
-func save_loaded_regions() -> void:
+func save_loaded_regions() -> Dictionary:
 	if not region_streaming_enabled:
-		return
+		return {"ok": true, "failed": [], "error": ""}
 	if region_manager.region_base_path == "":
-		return
+		return {"ok": true, "failed": [], "error": ""}
 	var dir = _region_dir_for_base_path(region_manager.region_base_path)
 	if not DirAccess.dir_exists_absolute(dir):
 		DirAccess.make_dir_recursive_absolute(dir)
+	var failed: Array[Vector2i] = []
 	for rid in region_manager.loaded_regions.keys():
-		_save_region_file(rid)
+		if _save_region_file(rid) != OK:
+			failed.append(rid)
+	if failed.is_empty():
+		return {"ok": true, "failed": [], "error": ""}
+	return {
+		"ok": false,
+		"failed": failed,
+		"error": "Could not write %d region file(s) next to the level" % failed.size(),
+	}
 
 
 func load_region_index(index_data: Dictionary, hflevel_path: String = "") -> void:
@@ -760,9 +771,21 @@ func _load_region(region_id: Vector2i) -> void:
 	_reconcile_dirty_chunks(dirty_list)
 
 
-func _unload_region(region_id: Vector2i) -> void:
+## Streaming a region out throws away its chunks, so the paint has to reach
+## disk first. A failed write keeps the region loaded rather than losing it.
+func _unload_region(region_id: Vector2i) -> bool:
 	if not root.paint_layers:
-		return
+		return false
+	# An empty region has nothing to lose, so it always streams out.
+	if _region_has_data(region_id) and _save_region_file(region_id) != OK:
+		if not _region_save_warned.has(region_id):
+			_region_save_warned[region_id] = true
+			if root.has_signal("user_message"):
+				root.user_message.emit(
+					"Kept region %s loaded: its paint could not be written" % str(region_id), 2
+				)
+		return false
+	_region_save_warned.erase(region_id)
 	var chunk_bounds = _region_chunk_bounds(region_id)
 	var min_chunk = chunk_bounds.position
 	var max_chunk = chunk_bounds.position + chunk_bounds.size - Vector2i.ONE
@@ -773,6 +796,7 @@ func _unload_region(region_id: Vector2i) -> void:
 		if not removed.is_empty():
 			_reconcile_dirty_chunks(removed, layer)
 	region_manager.mark_unloaded(region_id)
+	return true
 
 
 func _reconcile_dirty_chunks(dirty: Array[Vector2i], layer_override: HFPaintLayer = null) -> void:
@@ -813,9 +837,9 @@ func _get_layer_by_id(layer_id: StringName) -> HFPaintLayer:
 	return null
 
 
-func _save_region_file(region_id: Vector2i) -> void:
+func _save_region_file(region_id: Vector2i) -> int:
 	if not root.paint_layers:
-		return
+		return OK
 	var data: Dictionary = {"version": 1, "region_id": [region_id.x, region_id.y], "layers": []}
 	var chunk_bounds = _region_chunk_bounds(region_id)
 	var min_chunk = chunk_bounds.position
@@ -866,16 +890,21 @@ func _save_region_file(region_id: Vector2i) -> void:
 		var path = _region_file_path(region_id)
 		if path != "" and FileAccess.file_exists(path):
 			DirAccess.remove_absolute(path)
-		return
+		return OK
 	var encoded = HFLevelIO.encode_variant(data)
 	var path = _region_file_path(region_id)
 	if path == "":
-		return
+		return ERR_INVALID_PARAMETER
 	var dir = path.get_base_dir()
 	if not DirAccess.dir_exists_absolute(dir):
 		DirAccess.make_dir_recursive_absolute(dir)
-	HFLevelIO.save_to_path(path, encoded, root.hflevel_compress)
+	var err := HFLevelIO.save_to_path(path, encoded, root.hflevel_compress)
+	if err != OK:
+		push_error("HFPaint: could not write region %s (error: %d)" % [str(region_id), err])
+		return err
+	# Only claim the sidecar exists once it really does.
 	region_manager.region_index[region_id] = {"has_data": true}
+	return OK
 
 
 func _update_region_overlay() -> void:

--- a/tests/test_hf_file_system.gd
+++ b/tests/test_hf_file_system.gd
@@ -34,6 +34,9 @@ var hflevel_autosave_path: String = "user://hf_encode_thread_test.hflevel"
 var hflevel_compress: bool = false
 var hflevel_autosave_keep: int = 0
 var paint_system = null
+
+signal hflevel_save_failed(path: String, error_message: String)
+signal autosave_failed(error_message: String)
 var captured: Dictionary = {"name": "level", "n": 1}
 func _capture_hflevel_state() -> Dictionary:
 	return captured
@@ -111,3 +114,143 @@ func test_changed_save_rewrites_file():
 	await _drain_write()
 	var loaded: Dictionary = HFLevelIO.load_from_path(_save_path)
 	assert_eq(int(loaded.get("n", 0)), 2)
+
+
+# ===========================================================================
+# Save queue ordering (#51)
+# ===========================================================================
+
+
+func _third_save_path() -> String:
+	return "user://hf_encode_thread_test_third.hflevel"
+
+
+func _big_capture(tag: String) -> Dictionary:
+	# Big enough that the write thread is still running when the next save
+	# arrives, which is what puts a job in the pending queue.
+	var filler: Array = []
+	for i in range(60000):
+		filler.append(i)
+	return {"name": tag, "filler": filler}
+
+
+func _queue_a_save_behind_a_running_one() -> void:
+	root.captured = _big_capture("A")
+	assert_eq(files.save_hflevel(_save_path, true), OK)
+	root.captured = {"name": "B"}
+	assert_eq(files.save_hflevel(_second_save_path(), true), OK)
+	assert_eq(files._hflevel_pending.size(), 1, "B has to be queued behind a running A")
+	while files._hflevel_thread and files._hflevel_thread.is_alive():
+		await get_tree().process_frame
+
+
+func test_a_finished_worker_does_not_let_a_new_save_jump_the_queue():
+	# A has finished but has not been collected, B is queued behind it, and C
+	# arrives now. B and C share a path, so whichever runs last owns the file.
+	await _queue_a_save_behind_a_running_one()
+	root.captured = {"name": "C"}
+	assert_eq(files.save_hflevel(_second_save_path(), true), OK)
+	await _drain_write()
+
+	var order: Array = []
+	for entry in files.take_completed_saves():
+		order.append(str(entry.get("path", "")))
+	assert_eq(
+		order,
+		[_save_path, _second_save_path(), _second_save_path()],
+		"Completion has to follow the order the saves were asked for"
+	)
+	var loaded: Dictionary = HFLevelIO.load_from_path(_second_save_path())
+	assert_eq(str(loaded.get("name", "")), "C", "The newest save owns the file")
+
+
+func test_three_distinct_paths_complete_in_order():
+	await _queue_a_save_behind_a_running_one()
+	root.captured = {"name": "C"}
+	assert_eq(files.save_hflevel(_third_save_path(), true), OK)
+	await _drain_write()
+
+	var order: Array = []
+	for entry in files.take_completed_saves():
+		order.append(str(entry.get("path", "")))
+	assert_eq(order, [_save_path, _second_save_path(), _third_save_path()])
+	assert_eq(str(HFLevelIO.load_from_path(_second_save_path()).get("name", "")), "B")
+	assert_eq(str(HFLevelIO.load_from_path(_third_save_path()).get("name", "")), "C")
+	DirAccess.remove_absolute(_third_save_path())
+
+
+func test_a_discarded_pending_job_does_not_stall_the_queue():
+	assert_eq(files.save_hflevel(_save_path, true), OK)
+	while files._hflevel_thread and files._hflevel_thread.is_alive():
+		await get_tree().process_frame
+	files._hflevel_pending.append({"path": "", "encoded": {}})
+	root.captured = {"name": "after"}
+	assert_eq(files.save_hflevel(_second_save_path(), true), OK)
+	await _drain_write()
+	assert_true(
+		FileAccess.file_exists(_second_save_path()),
+		"A junk entry must not strand the writes behind it"
+	)
+
+
+# ===========================================================================
+# Region sidecar failures block the level save (#173)
+# ===========================================================================
+
+
+func _paint_shim(ok: bool) -> Node:
+	var s := GDScript.new()
+	s.source_code = (
+		"""
+extends Node
+
+var base_paths: Array = []
+var save_calls: int = 0
+
+func set_region_base_path(path: String) -> void:
+	base_paths.append(path)
+
+func save_loaded_regions() -> Dictionary:
+	save_calls += 1
+	return {"ok": %s, "failed": [], "error": "sidecar directory is not writable"}
+"""
+		% ("true" if ok else "false")
+	)
+	s.reload()
+	var node := Node.new()
+	node.set_script(s)
+	add_child_autoqfree(node)
+	return node
+
+
+func test_region_write_failure_blocks_the_level_save():
+	root.paint_system = _paint_shim(false)
+	var failures: Array = []
+	root.hflevel_save_failed.connect(func(p, m): failures.append([p, m]))
+	assert_ne(files.save_hflevel(_save_path, true), OK)
+	assert_push_error("sidecar directory is not writable")
+	assert_eq(failures.size(), 1, "The dock has to hear that the save failed")
+	assert_eq(str(failures[0][0]), _save_path)
+	assert_false(
+		FileAccess.file_exists(_save_path), "No level file may claim region data that is missing"
+	)
+
+
+func test_region_write_failure_on_autosave_reports_as_an_autosave():
+	root.paint_system = _paint_shim(false)
+	var manual: Array = []
+	var auto: Array = []
+	root.hflevel_save_failed.connect(func(_p, _m): manual.append(true))
+	root.autosave_failed.connect(func(m): auto.append(m))
+	assert_ne(files.save_hflevel(_save_path, true, true), OK)
+	assert_push_error("sidecar directory is not writable")
+	assert_eq(auto.size(), 1, "An autosave failure is not a manual save failure")
+	assert_eq(manual.size(), 0)
+
+
+func test_region_write_success_lets_the_level_save_proceed():
+	root.paint_system = _paint_shim(true)
+	assert_eq(files.save_hflevel(_save_path, true), OK)
+	await _drain_write()
+	assert_true(FileAccess.file_exists(_save_path))
+	assert_eq(root.paint_system.save_calls, 1)

--- a/tests/test_paint_system.gd
+++ b/tests/test_paint_system.gd
@@ -27,6 +27,10 @@ func _root_shim_script() -> GDScript:
 extends Node3D
 var paint_layers
 var paint_tool
+var hflevel_compress: bool = false
+var generated_region_overlay = null
+
+signal user_message(text: String, level: int)
 """
 	s.reload()
 	return s
@@ -46,3 +50,132 @@ func test_layer_names_use_display_then_id():
 	assert_eq(names.size(), 2)
 	assert_eq(names[0], "Floor")
 	assert_eq(str(names[1]), "layer_1")
+
+
+# ===========================================================================
+# Region streaming persistence (#172, #173)
+# ===========================================================================
+
+var _region_level_path := "user://hf_region_stream_test.hflevel"
+
+
+func _region_dir() -> String:
+	return ProjectSettings.globalize_path("user://hf_region_stream_test.hfregions")
+
+
+func _clean_region_dir() -> void:
+	var dir := _region_dir()
+	if not DirAccess.dir_exists_absolute(dir):
+		return
+	for f in DirAccess.get_files_at(dir):
+		DirAccess.remove_absolute(dir.path_join(f))
+	DirAccess.remove_absolute(dir)
+
+
+func _streaming_system() -> HFPaintSystem:
+	root.hflevel_compress = false
+	_clean_region_dir()
+	sys.region_streaming_enabled = true
+	sys.region_manager.region_size_cells = 32
+	sys.region_manager.streaming_radius = 0
+	sys.region_manager.chunk_size = 32
+	sys._sync_region_manager()
+	sys.set_region_base_path(_region_level_path)
+	return sys
+
+
+func _paint_cell(cell: Vector2i) -> void:
+	_floor_layer().set_cell(cell, true)
+
+
+func _floor_layer():
+	for layer in root.paint_layers.layers:
+		if layer and layer.layer_id == &"floor":
+			return layer
+	return root.paint_layers.create_layer(&"floor", 0.0)
+
+
+func test_unloading_a_region_writes_its_paint_first():
+	_streaming_system()
+	_paint_cell(Vector2i(1, 1))
+	sys.region_manager.mark_loaded(Vector2i(0, 0))
+	assert_true(sys._unload_region(Vector2i(0, 0)), "An empty destination must accept the write")
+	var path: String = sys._region_file_path(Vector2i(0, 0))
+	assert_true(FileAccess.file_exists(path), "Streaming out must persist before it drops chunks")
+	_clean_region_dir()
+
+
+func test_unloaded_region_reloads_with_its_paint():
+	_streaming_system()
+	_paint_cell(Vector2i(1, 1))
+	sys.region_manager.mark_loaded(Vector2i(0, 0))
+	sys._unload_region(Vector2i(0, 0))
+	var layer = _floor_layer()
+	assert_eq(layer.get_chunk_ids().size(), 0, "The region really was streamed out")
+	sys._load_region(Vector2i(0, 0))
+	assert_gt(layer.get_chunk_ids().size(), 0, "Coming back must restore the paint")
+	_clean_region_dir()
+
+
+func test_unload_keeps_the_region_when_the_write_fails():
+	_streaming_system()
+	_paint_cell(Vector2i(1, 1))
+	# A regular file where the sidecar directory belongs blocks every write.
+	var blocker := FileAccess.open("user://hf_region_stream_test.hfregions", FileAccess.WRITE)
+	blocker.store_string("not a directory")
+	blocker = null
+	sys.region_manager.mark_loaded(Vector2i(0, 0))
+	var layer = _floor_layer()
+	var before: int = layer.get_chunk_ids().size()
+	assert_false(sys._unload_region(Vector2i(0, 0)), "A failed write must refuse the unload")
+	assert_push_error("could not write region")
+	assert_eq(layer.get_chunk_ids().size(), before, "The paint stays in memory")
+	assert_true(sys.region_manager.is_loaded(Vector2i(0, 0)))
+	DirAccess.remove_absolute("user://hf_region_stream_test.hfregions")
+
+
+func test_unloading_an_empty_region_still_streams_out():
+	_streaming_system()
+	root.paint_layers.create_layer(&"floor", 0.0)
+	sys.region_manager.mark_loaded(Vector2i(5, 5))
+	assert_true(sys._unload_region(Vector2i(5, 5)), "Nothing to lose, nothing to block on")
+	_clean_region_dir()
+
+
+func test_save_loaded_regions_reports_a_failed_write():
+	_streaming_system()
+	_paint_cell(Vector2i(1, 1))
+	sys.region_manager.mark_loaded(Vector2i(0, 0))
+	var blocker := FileAccess.open("user://hf_region_stream_test.hfregions", FileAccess.WRITE)
+	blocker.store_string("not a directory")
+	blocker = null
+	var result: Dictionary = sys.save_loaded_regions()
+	assert_false(bool(result.get("ok", true)), "A failed sidecar is not a successful save")
+	assert_eq((result.get("failed", []) as Array).size(), 1)
+	assert_push_error("could not write region")
+	DirAccess.remove_absolute("user://hf_region_stream_test.hfregions")
+
+
+func test_save_loaded_regions_reports_success():
+	_streaming_system()
+	_paint_cell(Vector2i(1, 1))
+	sys.region_manager.mark_loaded(Vector2i(0, 0))
+	var result: Dictionary = sys.save_loaded_regions()
+	assert_true(bool(result.get("ok", false)))
+	assert_eq(result.get("failed", []), [])
+	_clean_region_dir()
+
+
+func test_failed_region_write_is_not_recorded_as_having_data():
+	_streaming_system()
+	_paint_cell(Vector2i(1, 1))
+	var blocker := FileAccess.open("user://hf_region_stream_test.hfregions", FileAccess.WRITE)
+	blocker.store_string("not a directory")
+	blocker = null
+	assert_ne(sys._save_region_file(Vector2i(0, 0)), OK)
+	assert_push_error("could not write region")
+	assert_false(
+		sys.region_manager.region_index.has(Vector2i(0, 0)),
+		"The index must not claim a sidecar that was never written"
+	)
+	DirAccess.remove_absolute("user://hf_region_stream_test.hfregions")


### PR DESCRIPTION
Three ways a save could lose work or lie about it.

**Queue order (#51).** `start_hflevel_thread()` collected a finished worker and then started the new job immediately, jumping any job already queued behind that worker. With both aimed at the same path the older snapshot won. A collected worker now hands its slot to the oldest queued job and the new one goes to the back. `_start_next_pending()` skips jobs it cannot start, so a discarded entry cannot leave the queue stalled with no live thread.

**Region unload (#172).** `_unload_region()` removed a region's chunks without writing them. It now persists first, and a failed write keeps the region loaded and warns once instead of every frame. An empty region has nothing to lose and still streams out.

**Sidecar failures (#173).** `_save_region_file()` ignored the result of `save_to_path()` and marked the region as having data either way. It now returns the error and only records data on success. `save_loaded_regions()` returns `{ok, failed, error}`, and `save_hflevel()` stops before the level write rather than shipping an index pointing at missing region files. The failure is reported as an autosave or a manual save to match what it actually was.

12 new tests. The queue tests reproduce the exact reported outcome without the fix: the file ends up holding B after C was requested.

Fixes #51
Fixes #172
Fixes #173