### PR TITLE
Build both entity pickers from the same merged definitions

### DIFF
--- a/addons/hammerforge/dock.gd
+++ b/addons/hammerforge/dock.gd
@@ -353,6 +353,8 @@ var syncing_grid := false
 var presets_dir := "res://addons/hammerforge/presets"
 var entity_defs_path := "res://addons/hammerforge/entities.json"
 var entity_defs: Array = []
+## Path the palette was last built from, so a root swap can rebuild it.
+var _loaded_entity_defs_path := ""
 var preset_buttons: Array[Button] = []
 var entity_palette_buttons: Array[Button] = []
 var preset_context_button: Button = null
@@ -1943,6 +1945,10 @@ func _process(_delta):
 		_disconnect_root_signals()
 		connected_root = level_root
 		_connect_root_signals()
+		# A root can point at its own definitions file, so rebuild both entity
+		# pickers when the one we loaded from is no longer the active one.
+		if _effective_entity_defs_path() != _loaded_entity_defs_path:
+			_load_entity_definitions()
 		# Pass root to tutorial wizard if active
 		if _tutorial_wizard and is_instance_valid(_tutorial_wizard) and level_root:
 			_tutorial_wizard.set_root(level_root, self)
@@ -4871,34 +4877,21 @@ func _load_presets() -> void:
 			_create_preset_button(preset, path)
 
 
+## The definitions file this dock should read. The active LevelRoot owns the
+## path, so a project pointing its root somewhere custom is honoured here too.
+func _effective_entity_defs_path() -> String:
+	if level_root and is_instance_valid(level_root):
+		var root_path := str(level_root.get("entity_definitions_path"))
+		if root_path != "":
+			return root_path
+	return entity_defs_path
+
+
 func _load_entity_definitions() -> void:
-	entity_defs.clear()
-	_clear_entity_palette()
-	if not ResourceLoader.exists(entity_defs_path):
-		return
-	var file = FileAccess.open(entity_defs_path, FileAccess.READ)
-	if not file:
-		_log("Failed to open entity definitions: %s" % entity_defs_path, true)
-		return
-	var text = file.get_as_text()
-	var data = JSON.parse_string(text)
-	if data == null:
-		_log("Failed to parse entity definitions: %s" % entity_defs_path, true)
-		return
-	if data is Dictionary:
-		var entries = data.get("entities", [])
-		if entries is Array and entries.size() > 0:
-			entity_defs = entries
-			return
-		for key in data.keys():
-			var entry = data[key]
-			if entry is Dictionary:
-				var record = entry.duplicate(true)
-				record["id"] = str(key)
-				entity_defs.append(record)
-	elif data is Array:
-		entity_defs = data
+	entity_defs = HFEntityDef.load_merged_raw_entries(_effective_entity_defs_path())
+	_loaded_entity_defs_path = _effective_entity_defs_path()
 	_populate_entity_palette()
+	_populate_brush_entity_classes()
 
 
 func get_entity_definitions() -> Array:
@@ -4909,7 +4902,7 @@ func _populate_brush_entity_classes() -> void:
 	if not brush_entity_class_opt:
 		return
 	brush_entity_class_opt.clear()
-	var defs = HFEntityDef.load_merged_definitions(entity_defs_path)
+	var defs = HFEntityDef.load_merged_definitions(_effective_entity_defs_path())
 	var brush_defs = HFEntityDef.filter_brush_entities(defs)
 	if brush_defs.is_empty():
 		# Fallback: ensure at least the built-in brush entity classes are available.
@@ -4930,6 +4923,10 @@ func _populate_entity_palette() -> void:
 		return
 	for entry in entity_defs:
 		if not (entry is Dictionary):
+			continue
+		# Brush entities are placed by assigning a class to a brush, not from
+		# this palette. They belong to the brush entity dropdown.
+		if bool(entry.get("is_brush_entity", false)):
 			continue
 		var entity_id = str(entry.get("id", entry.get("class", "")))
 		if entity_id == "":

--- a/addons/hammerforge/hf_entity_def.gd
+++ b/addons/hammerforge/hf_entity_def.gd
@@ -146,6 +146,70 @@ static func load_definitions_from_file(path: String) -> Array[HFEntityDef]:
 	return defs
 
 
+## Read the raw JSON entries from a definitions file, normalising the classname
+## onto an "id" key. Unlike load_definitions() this keeps every key the file
+## carries, so the dock palette still gets its labels, previews and categories.
+static func load_raw_entries(path: String) -> Array[Dictionary]:
+	var entries: Array[Dictionary] = []
+	if path == "" or not FileAccess.file_exists(path):
+		return entries
+	var file := FileAccess.open(path, FileAccess.READ)
+	if not file:
+		return entries
+	var data = JSON.parse_string(file.get_as_text())
+	if data == null:
+		return entries
+	var raw: Array = []
+	if data is Dictionary:
+		var listed = data.get("entities", [])
+		if listed is Array and not listed.is_empty():
+			raw = listed
+		else:
+			for key in data.keys():
+				var entry = data[key]
+				if entry is Dictionary:
+					var record: Dictionary = entry.duplicate(true)
+					record["id"] = str(key)
+					raw.append(record)
+	elif data is Array:
+		raw = data
+	for entry in raw:
+		if not (entry is Dictionary):
+			continue
+		var record: Dictionary = (entry as Dictionary).duplicate(true)
+		var classname_value := str(
+			record.get("id", record.get("classname", record.get("class", "")))
+		)
+		if classname_value == "":
+			continue
+		record["id"] = classname_value
+		entries.append(record)
+	return entries
+
+
+## The raw entries a project actually sees: plugin file overlaid with the
+## project file, same classname replacing the plugin entry.
+static func load_merged_raw_entries(
+	plugin_path: String, project_path: String = PROJECT_DEFINITIONS_PATH
+) -> Array[Dictionary]:
+	var by_name: Dictionary = {}
+	var order: Array[String] = []
+	for entry in load_raw_entries(plugin_path):
+		var key := str(entry.get("id", ""))
+		if not by_name.has(key):
+			order.append(key)
+		by_name[key] = entry
+	for entry in load_raw_entries(project_path):
+		var key := str(entry.get("id", ""))
+		if not by_name.has(key):
+			order.append(key)
+		by_name[key] = entry
+	var out: Array[Dictionary] = []
+	for key in order:
+		out.append(by_name[key])
+	return out
+
+
 ## Overlay project defs onto plugin defs. Same classname replaces the plugin entry.
 static func merge_definitions(
 	base: Array[HFEntityDef], overlay: Array[HFEntityDef]

--- a/tests/test_dock_entity_definitions.gd
+++ b/tests/test_dock_entity_definitions.gd
@@ -1,0 +1,119 @@
+extends GutTest
+## The point entity palette and the brush entity dropdown have to agree about
+## which definitions exist, including a project overlay. See #175.
+
+const DockScene = preload("res://addons/hammerforge/dock.tscn")
+const HFEntityDef = preload("res://addons/hammerforge/hf_entity_def.gd")
+
+var dock: HammerForgeDock
+var _defs_path := "user://hf_dock_defs_test.json"
+
+
+func before_each() -> void:
+	dock = DockScene.instantiate()
+	add_child_autoqfree(dock)
+
+
+func after_each() -> void:
+	dock = null
+	if FileAccess.file_exists(_defs_path):
+		DirAccess.remove_absolute(_defs_path)
+
+
+func _write_defs(text: String) -> void:
+	var f := FileAccess.open(_defs_path, FileAccess.WRITE)
+	f.store_string(text)
+	f = null
+
+
+func _palette_ids() -> Array:
+	var ids: Array = []
+	for button in dock.entity_palette_buttons:
+		ids.append(str(button.entity_id))
+	return ids
+
+
+func _brush_class_names() -> Array:
+	var names: Array = []
+	for i in range(dock.brush_entity_class_opt.item_count):
+		names.append(dock.brush_entity_class_opt.get_item_text(i))
+	return names
+
+
+func test_custom_point_entity_reaches_the_palette():
+	_write_defs('{"info_custom": {"class": "Node3D", "is_brush_entity": false}}')
+	dock.entity_defs_path = _defs_path
+	dock._load_entity_definitions()
+	assert_true(_palette_ids().has("info_custom"), "A project point entity must be placeable")
+
+
+func test_custom_brush_entity_reaches_the_dropdown_and_not_the_palette():
+	_write_defs('{"func_secret": {"is_brush_entity": true}}')
+	dock.entity_defs_path = _defs_path
+	dock._load_entity_definitions()
+	assert_true(_brush_class_names().has("func_secret"), "Brush classes come from the dropdown")
+	assert_false(
+		_palette_ids().has("func_secret"), "A brush entity is not placed from the point palette"
+	)
+
+
+func test_both_pickers_read_the_same_definitions():
+	_write_defs(
+		'{"info_custom": {"is_brush_entity": false},' + ' "func_secret": {"is_brush_entity": true}}'
+	)
+	dock.entity_defs_path = _defs_path
+	dock._load_entity_definitions()
+	assert_eq(_palette_ids(), ["info_custom"])
+	assert_eq(_brush_class_names(), ["func_secret"])
+
+
+func test_palette_is_built_even_when_the_file_uses_an_entities_array():
+	_write_defs('{"entities": [{"id": "info_listed", "is_brush_entity": false}]}')
+	dock.entity_defs_path = _defs_path
+	dock._load_entity_definitions()
+	assert_true(
+		_palette_ids().has("info_listed"),
+		"The entities-array form used to return before the palette was built"
+	)
+
+
+func test_plugin_definitions_still_populate_the_palette():
+	dock._load_entity_definitions()
+	assert_gt(_palette_ids().size(), 0, "The shipped entities.json must still show up")
+	assert_true(_palette_ids().has("player_start"))
+
+
+func test_palette_is_built_from_the_merged_definitions():
+	# This is what the split was: the palette read one file directly while the
+	# brush dropdown read the merged set, so a project overlay reached only one.
+	dock._load_entity_definitions()
+	var expected: Array = []
+	for entry in HFEntityDef.load_merged_raw_entries(dock._effective_entity_defs_path()):
+		expected.append(str(entry.get("id", "")))
+	var loaded: Array = []
+	for entry in dock.entity_defs:
+		loaded.append(str(entry.get("id", "")))
+	assert_eq(loaded, expected, "The dock must read the merged definitions, overlay included")
+
+
+func test_effective_path_follows_the_active_root():
+	assert_eq(dock._effective_entity_defs_path(), dock.entity_defs_path)
+	var root := LevelRoot.new()
+	root.auto_spawn_player = false
+	root.entity_definitions_path = _defs_path
+	add_child_autoqfree(root)
+	dock.level_root = root
+	assert_eq(
+		dock._effective_entity_defs_path(),
+		_defs_path,
+		"A root pointing somewhere custom owns the path"
+	)
+
+
+func test_empty_root_path_falls_back_to_the_dock_default():
+	var root := LevelRoot.new()
+	root.auto_spawn_player = false
+	root.entity_definitions_path = ""
+	add_child_autoqfree(root)
+	dock.level_root = root
+	assert_eq(dock._effective_entity_defs_path(), dock.entity_defs_path)

--- a/tests/test_entity_def.gd
+++ b/tests/test_entity_def.gd
@@ -29,3 +29,102 @@ func test_load_definitions_from_file_missing_is_empty():
 
 func test_project_path_constant():
 	assert_eq(HFEntityDef.PROJECT_DEFINITIONS_PATH, "res://hammerforge_entities.json")
+
+
+# ===========================================================================
+# Raw merged entries: what both dock pickers read (#175)
+# ===========================================================================
+
+var _plugin_defs_path := "user://hf_defs_plugin_test.json"
+var _project_defs_path := "user://hf_defs_project_test.json"
+
+
+func after_each():
+	for path in [_plugin_defs_path, _project_defs_path]:
+		if FileAccess.file_exists(path):
+			DirAccess.remove_absolute(path)
+
+
+func _write_json(path: String, text: String) -> String:
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(text)
+	f = null
+	return path
+
+
+func _entry_by_id(entries: Array, id: String) -> Dictionary:
+	for entry in entries:
+		if str(entry.get("id", "")) == id:
+			return entry
+	return {}
+
+
+func test_raw_entries_keep_keys_the_typed_loader_drops():
+	_write_json(
+		_plugin_defs_path,
+		'{"player_start": {"class": "Node3D", "label": "Player Start", "preview": {"type": "capsule"}}}'
+	)
+	var entries := HFEntityDef.load_raw_entries(_plugin_defs_path)
+	assert_eq(entries.size(), 1)
+	var entry := entries[0]
+	assert_eq(str(entry.get("id", "")), "player_start")
+	assert_eq(str(entry.get("label", "")), "Player Start", "The palette shows this")
+	assert_true(entry.has("preview"), "The palette icon comes from this")
+
+
+func test_raw_entries_from_a_top_level_array():
+	_write_json(_project_defs_path, '[{"classname": "info_custom", "is_brush_entity": false}]')
+	var entries := HFEntityDef.load_raw_entries(_project_defs_path)
+	assert_eq(entries.size(), 1)
+	assert_eq(str(entries[0].get("id", "")), "info_custom")
+
+
+func test_raw_entries_missing_file_is_empty():
+	assert_eq(HFEntityDef.load_raw_entries("user://hf_defs_nope.json").size(), 0)
+
+
+func test_merged_raw_entries_include_project_only_point_entities():
+	_write_json(_plugin_defs_path, '{"light_point": {"class": "OmniLight3D"}}')
+	_write_json(
+		_project_defs_path,
+		'{"info_custom": {"class": "Node3D", "is_brush_entity": false}, "func_secret": {"is_brush_entity": true}}'
+	)
+	var merged := HFEntityDef.load_merged_raw_entries(_plugin_defs_path, _project_defs_path)
+	assert_eq(merged.size(), 3)
+	assert_false(_entry_by_id(merged, "info_custom").is_empty(), "Project point entity is present")
+	assert_true(bool(_entry_by_id(merged, "func_secret").get("is_brush_entity", false)))
+
+
+func test_merged_raw_entries_project_overrides_the_plugin_entry():
+	_write_json(_plugin_defs_path, '{"light_point": {"label": "plugin"}}')
+	_write_json(_project_defs_path, '{"light_point": {"label": "project"}}')
+	var merged := HFEntityDef.load_merged_raw_entries(_plugin_defs_path, _project_defs_path)
+	assert_eq(merged.size(), 1)
+	assert_eq(str(merged[0].get("label", "")), "project")
+
+
+func test_merged_raw_entries_keep_plugin_order_first():
+	_write_json(_plugin_defs_path, '[{"id": "a"}, {"id": "b"}]')
+	_write_json(_project_defs_path, '[{"id": "b"}, {"id": "c"}]')
+	var merged := HFEntityDef.load_merged_raw_entries(_plugin_defs_path, _project_defs_path)
+	var ids: Array = []
+	for entry in merged:
+		ids.append(str(entry.get("id", "")))
+	assert_eq(ids, ["a", "b", "c"], "An override keeps its original slot")
+
+
+func test_merged_raw_and_typed_loaders_agree_on_classnames():
+	_write_json(_plugin_defs_path, '{"light_point": {"class": "OmniLight3D"}}')
+	_write_json(
+		_project_defs_path,
+		'{"info_custom": {"is_brush_entity": false}, "func_secret": {"is_brush_entity": true}}'
+	)
+	var raw_ids: Array = []
+	for entry in HFEntityDef.load_merged_raw_entries(_plugin_defs_path, _project_defs_path):
+		raw_ids.append(str(entry.get("id", "")))
+	var typed_ids: Array = []
+	for def in HFEntityDef.load_merged_definitions(_plugin_defs_path, _project_defs_path):
+		typed_ids.append(def.classname)
+	raw_ids.sort()
+	typed_ids.sort()
+	assert_eq(raw_ids, typed_ids, "The two pickers must not disagree about what exists")


### PR DESCRIPTION
`HFDock._load_entity_definitions()` opened its hard coded `entity_defs_path` directly while `_populate_brush_entity_classes()` used `HFEntityDef.load_merged_definitions()`. A project point entity in `hammerforge_entities.json` showed up in `level_root.entity_definitions` but was not placeable.

The typed loader could not just be swapped in: `HFEntityDef.to_dict()` drops `label`, `preview`, `category` and everything else the palette renders from. So `HFEntityDef` gains `load_raw_entries()` and `load_merged_raw_entries()`, which merge by classname and keep every key the file carries. Plugin entries keep their slot when a project overrides them.

The path now comes from the active LevelRoot's `entity_definitions_path` when it has one, and both pickers rebuild when a root with a different path connects.

Two things fell out of that:
- The `{"entities": [...]}` form of the file returned before `_populate_entity_palette()` was ever called, so that shape produced an empty palette.
- Brush entities no longer appear in the point palette. They are placed by assigning a class to a brush, not from there.

13 new tests, including a dock test with one custom point entity and one custom brush entity.

Fixes #175