### PR TITLE
Float the history preview instead of growing the panel

### DIFF
--- a/addons/hammerforge/ui/hf_history_browser.gd
+++ b/addons/hammerforge/ui/hf_history_browser.gd
@@ -56,9 +56,12 @@ func _build_ui() -> void:
 	_list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_scroll.add_child(_list)
 
-	# Thumbnail preview (shown on hover, floats above)
+	# Thumbnail preview (shown on hover, floats above). top_level keeps it out of
+	# this VBoxContainer's layout, so showing it cannot push the dock around.
 	_preview_rect = TextureRect.new()
+	_preview_rect.top_level = true
 	_preview_rect.custom_minimum_size = Vector2(THUMB_WIDTH * 2, THUMB_HEIGHT * 2)
+	_preview_rect.size = Vector2(THUMB_WIDTH * 2, THUMB_HEIGHT * 2)
 	_preview_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
 	_preview_rect.visible = false
 	_preview_rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -190,7 +193,36 @@ func _on_row_hovered(index: int) -> void:
 	var entry: Dictionary = _entries[index]
 	if entry["thumbnail"] and _preview_rect:
 		_preview_rect.texture = entry["thumbnail"]
+		_preview_rect.global_position = _preview_position_for_row(index)
 		_preview_rect.visible = true
+
+
+## Park the floating preview beside its row, pulled back inside the window when
+## the row sits near an edge.
+func _preview_position_for_row(index: int) -> Vector2:
+	return _clamp_preview_position(_preview_anchor_for_row(index), get_viewport_rect().size)
+
+
+## Where the preview wants to sit: just right of the panel, level with the row.
+func _preview_anchor_for_row(index: int) -> Vector2:
+	var anchor := global_position
+	if _list and index >= 0 and index < _list.get_child_count():
+		var row := _list.get_child(index) as Control
+		if row:
+			anchor = row.global_position
+	return Vector2(global_position.x + size.x + 4.0, anchor.y)
+
+
+## Pull the preview back inside `bounds`. A viewport too small to hold it at all
+## pins it to the origin rather than pushing it off the other edge.
+func _clamp_preview_position(target: Vector2, bounds: Vector2) -> Vector2:
+	var preview_size := Vector2(THUMB_WIDTH * 2, THUMB_HEIGHT * 2)
+	var out := target
+	if bounds.x > 0.0:
+		out.x = clampf(out.x, 0.0, maxf(0.0, bounds.x - preview_size.x))
+	if bounds.y > 0.0:
+		out.y = clampf(out.y, 0.0, maxf(0.0, bounds.y - preview_size.y))
+	return out
 
 
 func _on_row_unhovered() -> void:

--- a/tests/test_history_browser.gd
+++ b/tests/test_history_browser.gd
@@ -99,3 +99,101 @@ func test_record_entry_appends_without_dropping_existing_rows():
 	browser.record_entry("Create Brush", 1)
 	browser.record_entry("Move Brush", 2)
 	assert_eq(browser._list.get_child_count(), 2)
+
+
+# ===========================================================================
+# Hover preview must not disturb the dock layout (#142)
+# ===========================================================================
+
+
+func _thumbnail() -> ImageTexture:
+	var img := Image.create(browser.THUMB_WIDTH, browser.THUMB_HEIGHT, false, Image.FORMAT_RGBA8)
+	img.fill(Color.RED)
+	return ImageTexture.create_from_image(img)
+
+
+func _record_with_thumbnail(action_name: String, version: int) -> void:
+	browser.record_entry(action_name, version)
+	browser._entries[browser._entries.size() - 1]["thumbnail"] = _thumbnail()
+	browser._rebuild_list()
+
+
+func test_preview_is_outside_the_box_layout():
+	assert_true(
+		browser._preview_rect.top_level,
+		"An in-flow preview makes the container reserve space for it"
+	)
+
+
+func test_showing_the_preview_does_not_change_the_container_height():
+	_record_with_thumbnail("Create Brush", 1)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var before := browser.get_combined_minimum_size().y
+	browser._on_row_hovered(0)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var during := browser.get_combined_minimum_size().y
+	browser._on_row_unhovered()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var after := browser.get_combined_minimum_size().y
+	assert_true(browser._preview_rect.visible == false)
+	assert_almost_eq(during, before, 0.001, "Hovering must not grow the panel")
+	assert_almost_eq(after, before, 0.001, "Unhovering must not shrink it back")
+
+
+func test_hover_shows_the_thumbnail():
+	_record_with_thumbnail("Create Brush", 1)
+	browser._on_row_hovered(0)
+	assert_true(browser._preview_rect.visible)
+	assert_not_null(browser._preview_rect.texture)
+	browser._on_row_unhovered()
+	assert_false(browser._preview_rect.visible)
+
+
+func test_preview_anchor_follows_the_hovered_row():
+	browser.size = Vector2(240, 300)
+	_record_with_thumbnail("Create Brush", 1)
+	_record_with_thumbnail("Move Brush", 2)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var first := browser._preview_anchor_for_row(0)
+	var second := browser._preview_anchor_for_row(1)
+	assert_ne(first.y, second.y, "The preview tracks the row the cursor is on")
+	assert_almost_eq(first.x, second.x, 0.001, "Both sit off the same edge of the panel")
+
+
+func test_preview_anchor_sits_clear_of_the_panel():
+	browser.size = Vector2(240, 300)
+	_record_with_thumbnail("Create Brush", 1)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_gte(
+		browser._preview_anchor_for_row(0).x,
+		browser.global_position.x + browser.size.x,
+		"The preview must not sit on top of the list it describes"
+	)
+
+
+func test_preview_is_pulled_back_inside_the_window():
+	var bounds := Vector2(800, 600)
+	var clamped := browser._clamp_preview_position(Vector2(780, 590), bounds)
+	assert_almost_eq(clamped.x, 800.0 - browser.THUMB_WIDTH * 2, 0.001)
+	assert_almost_eq(clamped.y, 600.0 - browser.THUMB_HEIGHT * 2, 0.001)
+
+
+func test_preview_clamp_leaves_a_position_that_already_fits():
+	var clamped := browser._clamp_preview_position(Vector2(100, 50), Vector2(800, 600))
+	assert_eq(clamped, Vector2(100, 50))
+
+
+func test_preview_clamp_pins_to_origin_when_there_is_no_room():
+	var clamped := browser._clamp_preview_position(Vector2(40, 40), Vector2(64, 64))
+	assert_eq(clamped, Vector2.ZERO, "A window too small to hold it must not push it off-screen")
+
+
+func test_hovering_an_entry_without_a_thumbnail_shows_nothing():
+	browser.record_entry("No Thumb", 1)
+	browser._on_row_hovered(0)
+	assert_false(browser._preview_rect.visible)


### PR DESCRIPTION
`_preview_rect` was an in-flow child of `HFHistoryBrowser`, a `VBoxContainer`, so showing it on hover reserved 160 by 96 pixels at the bottom of the list and hiding it took them back. Moving the mouse down the list pumped the dock layout.

It is `top_level` now, which keeps it out of the box layout, and `_on_row_hovered()` parks it beside the hovered row. `_clamp_preview_position()` pulls it back inside the window when the row sits near an edge, and pins it to the origin rather than pushing it off the other side when the window cannot hold it at all.

9 new tests. Without `top_level` the container's minimum height jumps from 175 to 275 on hover, which is the reported jitter; with it the height does not move.

Fixes #142