### PR TITLE
Commit Clip to Face Plane through undo and let it see its targets

### DIFF
--- a/addons/hammerforge/hf_dome_builder.gd.uid
+++ b/addons/hammerforge/hf_dome_builder.gd.uid
@@ -1,0 +1,1 @@
+uid://dega042yxktd8

--- a/addons/hammerforge/hf_generator_schema.gd.uid
+++ b/addons/hammerforge/hf_generator_schema.gd.uid
@@ -1,0 +1,1 @@
+uid://dxp2ur3aejja7

--- a/addons/hammerforge/hf_spiral_stairs_builder.gd.uid
+++ b/addons/hammerforge/hf_spiral_stairs_builder.gd.uid
@@ -1,0 +1,1 @@
+uid://d2pjblcqs4pbf

--- a/addons/hammerforge/hf_stairs_builder.gd.uid
+++ b/addons/hammerforge/hf_stairs_builder.gd.uid
@@ -1,0 +1,1 @@
+uid://buqr6funwpa7n

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -1276,6 +1276,19 @@ func clip_brush_to_face_plane(
 	return brush_system.clip_brush_to_face_plane(brush_id, source_brush_id, face_index)
 
 
+func face_world_plane(source_brush_id: String, face_index: int) -> Plane:
+	return brush_system.face_world_plane(source_brush_id, face_index)
+
+
+func plane_splits_brush(brush_id: String, plane: Plane) -> bool:
+	return brush_system.plane_splits_brush(brush_id, plane)
+
+
+## Named for the undo helper, which resolves the do method on LevelRoot by name.
+func clip_brushes_by_plane(brush_ids: Array, plane: Plane) -> int:
+	return brush_system.clip_brushes_by_plane(brush_ids, plane)
+
+
 func clip_brush_by_id(brush_id: String, axis: int, split_pos: float) -> HFOpResult:
 	return brush_system.clip_brush_by_id(brush_id, axis, split_pos)
 

--- a/addons/hammerforge/plugin_edit_actions.gd
+++ b/addons/hammerforge/plugin_edit_actions.gd
@@ -349,26 +349,73 @@ static func clip_to_face_plane_selected(plugin: Object, root: Node) -> bool:
 		root.user_message.emit("Clip to Face: no usable face is selected", 1)
 		return false
 
-	var targets := collect_managed_targets(plugin, root)
-	var brush_ids: Array = targets["brush_ids"]
+	var plane: Plane = root.brush_system.face_world_plane(source_id, face_index)
+	if plane.normal.length_squared() < 0.5:
+		root.user_message.emit("Clip to Face: the selected face has no usable plane", 1)
+		return false
+
+	var brush_ids := clip_target_brush_ids(plugin, root)
 	if brush_ids.is_empty():
 		root.user_message.emit("Clip to Face: select the brushes to cut", 1)
 		return false
 
-	var cut_any := false
+	# Ask before committing. An action that cuts nothing would still open an undo
+	# entry and claim the level changed.
+	var cuttable: Array = []
 	for brush_id in brush_ids:
-		var check: HFOpResult = root.brush_system.clip_brush_to_face_plane(
-			str(brush_id), source_id, face_index
-		)
-		if check.ok:
-			cut_any = true
-	if not cut_any:
+		if root.brush_system.plane_splits_brush(str(brush_id), plane):
+			cuttable.append(str(brush_id))
+	if cuttable.is_empty():
 		root.user_message.emit(
 			"Clip to Face: that plane does not pass through any selected brush", 1
 		)
-	else:
-		plugin._record_history("Clip to Face Plane")
-	return cut_any
+		return false
+
+	HFUndoHelper.commit(
+		plugin._get_undo_redo(),
+		root,
+		"Clip to Face Plane",
+		"clip_brushes_by_plane",
+		[cuttable, plane],
+		false,
+		Callable(plugin, "_record_history")
+	)
+	_release_face_select_after_cut(plugin, root)
+	return true
+
+
+## The brushes a face-plane cut should take, including the ones Face Select hid.
+##
+## Entering Face Select empties the object selection on purpose, so by the time a
+## reference face exists there is nothing left in the live selection to cut. The
+## objects that were selected on the way in are the ones the user meant.
+static func clip_target_brush_ids(plugin: Object, root: Node) -> Array:
+	var brush_ids: Array = collect_managed_targets(plugin, root)["brush_ids"]
+	if not brush_ids.is_empty():
+		return brush_ids
+	var saved: Array = plugin.get("_face_mode_saved_object_selection")
+	if saved == null:
+		return brush_ids
+	for node in saved:
+		if not is_instance_valid(node) or not (node is Node3D) or not root.is_brush_node(node):
+			continue
+		var info = root.get_brush_info_from_node(node)
+		var brush_id := str(info.get("brush_id", ""))
+		if brush_id != "":
+			brush_ids.append(brush_id)
+	return brush_ids
+
+
+## Both selections named brushes that the cut has just replaced. Drop them and
+## leave Face Select rather than restoring a selection of freed nodes.
+static func _release_face_select_after_cut(plugin: Object, root: Node) -> void:
+	var saved: Array = plugin.get("_face_mode_saved_object_selection")
+	if saved != null:
+		saved.clear()
+	if root and root.has_method("clear_face_selection"):
+		root.clear_face_selection()
+	if plugin.has_method("_close_face_select_mode"):
+		plugin._close_face_select_mode()
 
 
 static func clip_selected(plugin: Object, root: Node) -> bool:

--- a/addons/hammerforge/plugin_input_router.gd
+++ b/addons/hammerforge/plugin_input_router.gd
@@ -155,6 +155,14 @@ static func handle_keyboard(
 			return clip_guard
 		plugin._clip_selected(root)
 		return STOP
+	# No selection guard: Face Select empties the object selection by design, and
+	# the command reads the objects that were selected on the way in. Its own
+	# messages say what is missing.
+	if keymap.matches("clip_to_face", event):
+		if root == null:
+			return PASS
+		plugin._clip_to_face_plane_selected(root)
+		return STOP
 	if keymap.matches("carve", event):
 		var carve_guard = plugin._guard_hammerforge_shortcut(root, true, 1, "Carve")
 		if carve_guard != SHORTCUT_APPLY:

--- a/addons/hammerforge/systems/hf_brush_system.gd
+++ b/addons/hammerforge/systems/hf_brush_system.gd
@@ -1573,23 +1573,69 @@ func clip_brush_by_id(brush_id: String, axis: int, split_pos: float) -> HFOpResu
 func clip_brush_to_face_plane(
 	brush_id: String, source_brush_id: String, face_index: int
 ) -> HFOpResult:
+	var plane := face_world_plane(source_brush_id, face_index)
+	if plane.normal.length_squared() < 0.5:
+		return _op_fail(
+			"Clip: no usable reference face selected", "Select a face to cut along, then clip"
+		)
+	return clip_brush_by_plane(brush_id, plane)
+
+
+## The world-space plane a brush face lies in. A zero normal means there is no
+## usable face there.
+##
+## Read once and passed around as a plain Plane so a cut survives its reference
+## brush: the reference can itself be one of the targets, and then it no longer
+## exists by the time a redo replays the cut.
+func face_world_plane(source_brush_id: String, face_index: int) -> Plane:
 	var source = _find_brush_by_id(source_brush_id)
 	if not source or not (source is DraftBrush):
-		return _op_fail("Clip: reference brush not found")
+		return Plane()
 	var source_draft := source as DraftBrush
 	_ensure_faces(source_draft)
 	var faces: Array = source_draft.get_faces()
 	if face_index < 0 or face_index >= faces.size():
-		return _op_fail("Clip: no reference face selected", "Select a face to cut along, then clip")
+		return Plane()
 	var face: FaceData = faces[face_index]
 	if face == null or face.local_verts.size() < 3:
-		return _op_fail("Clip: the reference face has no geometry")
+		return Plane()
 	var xform := source_draft.global_transform
 	var world_normal: Vector3 = (xform.basis * face.normal).normalized()
 	if world_normal.length_squared() < 0.5:
-		return _op_fail("Clip: the reference face has no direction")
+		return Plane()
 	var world_point: Vector3 = xform * face.local_verts[0]
-	return clip_brush_by_plane(brush_id, Plane(world_normal, world_normal.dot(world_point)))
+	return Plane(world_normal, world_normal.dot(world_point))
+
+
+## True when the plane actually passes through the brush, so a clip would produce
+## two pieces. Asked before an undo action is opened, so a cut that would do
+## nothing never reaches the history.
+func plane_splits_brush(brush_id: String, plane: Plane) -> bool:
+	if brush_id == "" or plane.normal.length_squared() < 0.5:
+		return false
+	var brush = _find_brush_by_id(brush_id)
+	if not brush or not (brush is DraftBrush):
+		return false
+	var draft := brush as DraftBrush
+	_ensure_faces(draft)
+	var faces: Array = draft.get_faces()
+	if faces.size() < 4:
+		return false
+	var local_plane := draft.global_transform.affine_inverse() * plane
+	var halves: Dictionary = HFConvexClip.split(faces, local_plane)
+	return not halves["front"].is_empty() and not halves["back"].is_empty()
+
+
+## Cut every named brush along one plane. Returns how many were cut.
+##
+## One call so the whole batch is a single undo action: a multi-brush cut that
+## undid a piece at a time would leave the level half cut.
+func clip_brushes_by_plane(brush_ids: Array, plane: Plane) -> int:
+	var cut := 0
+	for brush_id in brush_ids:
+		if clip_brush_by_plane(str(brush_id), plane).ok:
+			cut += 1
+	return cut
 
 
 # ---------------------------------------------------------------------------

--- a/tests/solid_checks.gd.uid
+++ b/tests/solid_checks.gd.uid
@@ -1,0 +1,1 @@
+uid://b73y24fg3nlu4

--- a/tests/test_clip_to_face_plane.gd
+++ b/tests/test_clip_to_face_plane.gd
@@ -1,0 +1,345 @@
+extends GutTest
+
+## Clip to Face Plane against the two things it has to survive: the undo stack,
+## and the Face Select mode transitions the user actually goes through.
+##
+## The undo checks run on a real LevelRoot and drive `capture_state()` and
+## `restore_state()` directly, because that is the pair the editor action is
+## built from. An EditorUndoRedoManager cannot be constructed outside the
+## editor, so the manager itself is not what is under test here — the do method
+## being replayable and the undo snapshot being taken are.
+
+const HFPluginEditActions = preload("res://addons/hammerforge/plugin_edit_actions.gd")
+const HFPluginToolModes = preload("res://addons/hammerforge/plugin_tool_modes.gd")
+const DraftBrush = preload("res://addons/hammerforge/brush_instance.gd")
+
+var root: LevelRoot
+
+
+func before_each():
+	root = LevelRoot.new()
+	root.auto_spawn_player = false
+	root.commit_freeze = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func after_each():
+	root = null
+
+
+func _make_brush(position: Vector3, size: Vector3) -> DraftBrush:
+	var brush = (
+		root
+		. create_brush_from_info(
+			{
+				"shape": root.BrushShape.BOX,
+				"size": size,
+				"transform": Transform3D(Basis.IDENTITY, position),
+			}
+		)
+	)
+	return brush as DraftBrush
+
+
+func _brush_id(brush: DraftBrush) -> String:
+	return str(root.get_brush_info_from_node(brush).get("brush_id", ""))
+
+
+func _draft_brushes() -> Array:
+	var out: Array = []
+	for node in root._iter_pick_nodes():
+		if node is DraftBrush:
+			out.append(node)
+	return out
+
+
+## The plane through world X = 0, facing +X.
+func _yz_plane() -> Plane:
+	return Plane(Vector3.RIGHT, 0.0)
+
+
+# ===========================================================================
+# The batch is one replayable operation (#197)
+# ===========================================================================
+
+
+func test_one_call_cuts_every_named_brush():
+	var a := _make_brush(Vector3.ZERO, Vector3(64, 64, 64))
+	var b := _make_brush(Vector3(0, 96, 0), Vector3(64, 64, 64))
+
+	var cut := root.clip_brushes_by_plane([_brush_id(a), _brush_id(b)], _yz_plane())
+
+	assert_eq(cut, 2, "both brushes straddle the plane, so both are cut")
+	assert_eq(_draft_brushes().size(), 4, "two brushes become four pieces")
+
+
+func test_the_batch_survives_undo_and_redo_as_one_step():
+	var a := _make_brush(Vector3.ZERO, Vector3(64, 64, 64))
+	var b := _make_brush(Vector3(0, 96, 0), Vector3(64, 64, 64))
+	var ids := [_brush_id(a), _brush_id(b)]
+	var plane := _yz_plane()
+
+	# This pair is exactly what the editor action registers: restore_state as the
+	# undo method against a snapshot taken before the first cut, and the batch
+	# call as the do method.
+	var before := root.capture_state()
+	root.clip_brushes_by_plane(ids, plane)
+	assert_eq(_draft_brushes().size(), 4)
+
+	root.restore_state(before)
+	assert_eq(_draft_brushes().size(), 2, "undo has to bring back every original brush")
+	for brush in _draft_brushes():
+		assert_almost_eq(brush.size.x, 64.0, 0.001, "an undone piece is a whole brush again")
+
+	root.clip_brushes_by_plane(ids, plane)
+	assert_eq(_draft_brushes().size(), 4, "redo replays the whole batch, not just the last brush")
+
+
+func test_a_redo_still_works_when_the_reference_brush_was_one_of_the_targets():
+	# The cut is carried as a plane rather than a brush and face index, so the
+	# reference disappearing into its own pieces cannot break the replay.
+	var reference := _make_brush(Vector3(0, 0, 0), Vector3(64, 64, 64))
+	var reference_id := _brush_id(reference)
+	var plane: Plane = root.face_world_plane(reference_id, 0)
+	assert_gt(plane.normal.length_squared(), 0.5, "the reference face has to give a plane")
+
+	var target := _make_brush(Vector3(16, 0, 0), Vector3(64, 64, 64))
+	var ids := [reference_id, _brush_id(target)]
+
+	var before := root.capture_state()
+	assert_eq(root.clip_brushes_by_plane(ids, plane), 1, "only the target straddles that plane")
+	root.restore_state(before)
+	assert_eq(root.clip_brushes_by_plane(ids, plane), 1, "the replay does not need the reference")
+
+
+func test_a_plane_that_misses_a_brush_is_reported_before_anything_is_cut():
+	var away := _make_brush(Vector3(500, 0, 0), Vector3(64, 64, 64))
+
+	assert_false(
+		root.plane_splits_brush(_brush_id(away), _yz_plane()),
+		"a plane outside the brush must be refused before the undo action opens"
+	)
+	assert_eq(_draft_brushes().size(), 1, "asking must not change anything")
+
+
+# ===========================================================================
+# The Face Select round trip (#196)
+# ===========================================================================
+
+
+class FakeButton:
+	extends RefCounted
+
+	var button_pressed := false
+
+	func set_pressed_no_signal(value: bool) -> void:
+		button_pressed = value
+
+
+class FakeDock:
+	extends RefCounted
+
+	var paint_mode := FakeButton.new()
+	var tool_select := FakeButton.new()
+	var face_select_mode := FakeButton.new()
+	var toasts: Array = []
+
+	func show_toast(text: String, level: int = 0) -> void:
+		toasts.append({"text": text, "level": level})
+
+	func is_face_select_mode_enabled() -> bool:
+		return face_select_mode.button_pressed
+
+
+class FakeGizmoPlugin:
+	extends RefCounted
+
+	func cancel_active_handle_action() -> void:
+		pass
+
+
+class FakeToolRegistry:
+	extends RefCounted
+
+	func has_active_external_tool() -> bool:
+		return false
+
+	func deactivate_current() -> void:
+		pass
+
+
+class FakePlugin:
+	extends RefCounted
+
+	var dock := FakeDock.new()
+	var brush_gizmo_plugin := FakeGizmoPlugin.new()
+	var _tool_registry := FakeToolRegistry.new()
+	var _radial_menu = null
+	var active_root: Node = null
+	var undo_redo_manager = null
+	var hf_selection: Array = []
+	var _face_mode_saved_object_selection: Array = []
+	var _vertex_mode := false
+	var _vertex_drag_active := false
+	var _texture_picker_active := false
+	var _applying_hf_selection := false
+	var history: Array = []
+	var closed_face_select := 0
+
+	func _get_level_root() -> Node:
+		return active_root
+
+	func _brush_gizmo_action_active() -> bool:
+		return false
+
+	func _finish_stale_paint_strokes(_root, _input_state, _paint_tool) -> bool:
+		return false
+
+	func _cancel_selection_gesture() -> bool:
+		return false
+
+	func _toggle_vertex_mode(_root: Node) -> void:
+		_vertex_mode = false
+
+	func _update_hud_context() -> void:
+		pass
+
+	func _ensure_selection_runtime_state() -> void:
+		pass
+
+	func _current_selection_nodes() -> Array:
+		return hf_selection.duplicate()
+
+	func _apply_hf_selection(_selection) -> void:
+		pass
+
+	func _managed_entity_owner(_root: Node, _node: Node) -> Node:
+		return null
+
+	func _get_undo_redo():
+		return null
+
+	func _record_history(action_name: String) -> void:
+		history.append(action_name)
+
+	func _close_face_select_mode(_message: String = "") -> bool:
+		closed_face_select += 1
+		dock.face_select_mode.button_pressed = false
+		return true
+
+	func get_editor_interface():
+		return self
+
+	func get_selection():
+		return null
+
+
+var plugin: FakePlugin
+
+
+## Walk the real mode transitions: select the targets, then open Face Select,
+## then pick the reference face. Nothing here assigns the two selection stores
+## by hand, which is the whole point of the issue.
+func _enter_face_select_with(targets: Array, reference: DraftBrush, face_index: int) -> void:
+	plugin = FakePlugin.new()
+	plugin.active_root = root
+	plugin.hf_selection = targets.duplicate()
+	plugin.dock.face_select_mode.button_pressed = true
+	HFPluginToolModes.on_face_select_mode_toggled(plugin, true)
+	root.face_selection = {_brush_id(reference): [face_index]}
+
+
+func test_face_select_hides_the_object_selection_but_the_cut_still_finds_it():
+	var target := _make_brush(Vector3.ZERO, Vector3(64, 64, 64))
+	# Turned 45 degrees about Z and set aside on Z, so its +X face plane still
+	# runs diagonally through the target.
+	var reference := _make_brush(Vector3(0, 0, 64), Vector3(32, 32, 32))
+	reference.rotation_degrees = Vector3(0, 0, 45)
+	reference.rebuild_preview()
+	_enter_face_select_with([target], reference, 0)
+
+	assert_eq(plugin._current_selection_nodes().size(), 0, "Face Select empties the selection")
+	assert_eq(
+		plugin._face_mode_saved_object_selection.size(), 1, "and saves what was selected first"
+	)
+
+	var cut := HFPluginEditActions.clip_to_face_plane_selected(plugin, root)
+
+	assert_true(cut, "the command has to find the targets Face Select put away")
+	assert_eq(plugin.history, ["Clip to Face Plane"], "one history entry for the whole cut")
+	assert_eq(_draft_brushes().size(), 3, "the target became two pieces beside the reference")
+
+
+func test_the_cut_leaves_no_stale_selection_behind():
+	var target := _make_brush(Vector3.ZERO, Vector3(64, 64, 64))
+	# Turned 45 degrees about Z and set aside on Z, so its +X face plane still
+	# runs diagonally through the target.
+	var reference := _make_brush(Vector3(0, 0, 64), Vector3(32, 32, 32))
+	reference.rotation_degrees = Vector3(0, 0, 45)
+	reference.rebuild_preview()
+	_enter_face_select_with([target], reference, 0)
+
+	assert_true(HFPluginEditActions.clip_to_face_plane_selected(plugin, root))
+
+	assert_true(root.face_selection.is_empty(), "the reference face is released")
+	assert_eq(
+		plugin._face_mode_saved_object_selection.size(),
+		0,
+		"the saved objects were replaced by the cut, so they must not be restored"
+	)
+	assert_eq(plugin.closed_face_select, 1, "Face Select closes once the cut is done")
+
+
+func test_more_than_one_saved_target_is_cut_in_one_step():
+	var first := _make_brush(Vector3.ZERO, Vector3(64, 64, 64))
+	var second := _make_brush(Vector3(0, 96, 0), Vector3(64, 64, 64))
+	# Far above both targets, but its +X face plane is vertical and crosses both.
+	var reference := _make_brush(Vector3(0, 200, 0), Vector3(32, 32, 32))
+	_enter_face_select_with([first, second], reference, 0)
+
+	assert_true(HFPluginEditActions.clip_to_face_plane_selected(plugin, root))
+
+	assert_eq(plugin.history.size(), 1, "a multi-brush cut is one undo step, not one per brush")
+	assert_eq(_draft_brushes().size(), 5, "both targets split, the reference is untouched")
+
+
+func test_a_plane_that_cuts_nothing_records_no_history():
+	var away := _make_brush(Vector3(500, 0, 0), Vector3(16, 16, 16))
+	var reference := _make_brush(Vector3.ZERO, Vector3(32, 32, 32))
+	_enter_face_select_with([away], reference, 0)
+
+	assert_false(HFPluginEditActions.clip_to_face_plane_selected(plugin, root))
+
+	assert_eq(plugin.history, [], "a cut that does nothing must not reach the undo history")
+	assert_eq(_draft_brushes().size(), 2, "and must not delete anything")
+
+
+# ===========================================================================
+# Wiring contracts
+# ===========================================================================
+
+
+func test_the_command_commits_through_the_undo_helper():
+	var source := FileAccess.get_file_as_string("res://addons/hammerforge/plugin_edit_actions.gd")
+	var start := source.find("static func clip_to_face_plane_selected")
+	assert_gt(start, -1, "the command must exist")
+	var body := source.substr(start, source.find("\nstatic func", start + 1) - start)
+	assert_true(body.contains("HFUndoHelper.commit("), "the cut has to open an undo action")
+	assert_true(body.contains('"clip_brushes_by_plane"'), "and dispatch the whole batch by name")
+	assert_false(
+		body.contains("plugin._record_history("), "a history label on its own is not an undo action"
+	)
+
+
+func test_the_viewport_routes_the_advertised_shortcut():
+	var source := FileAccess.get_file_as_string("res://addons/hammerforge/plugin_input_router.gd")
+	assert_true(
+		source.contains('keymap.matches("clip_to_face", event)'),
+		"Alt+Shift+X is advertised, so the viewport has to dispatch it"
+	)
+	assert_true(source.contains("plugin._clip_to_face_plane_selected(root)"))
+
+
+func test_level_root_exposes_the_method_undo_dispatches_by_name():
+	assert_true(root.has_method("clip_brushes_by_plane"))

--- a/tests/test_clip_to_face_plane.gd.uid
+++ b/tests/test_clip_to_face_plane.gd.uid
@@ -1,0 +1,1 @@
+uid://co555y1cyo8n6

--- a/tests/test_cutting_commands.gd
+++ b/tests/test_cutting_commands.gd
@@ -96,7 +96,7 @@ func test_clip_to_face_asks_for_a_face_before_cutting_anything():
 	assert_true(body.contains("root.face_selection"), "the plane comes from the face selection")
 	assert_lt(
 		body.find("face_selection.is_empty()"),
-		body.find("clip_brush_to_face_plane"),
+		body.find("clip_brushes_by_plane"),
 		"the missing-face check must run before anything is cut"
 	)
 	assert_true(body.contains("user_message.emit"), "a refusal must reach the user")

--- a/tests/test_dome_builder.gd.uid
+++ b/tests/test_dome_builder.gd.uid
@@ -1,0 +1,1 @@
+uid://cvoasr60v3hu8

--- a/tests/test_generator_schema.gd.uid
+++ b/tests/test_generator_schema.gd.uid
@@ -1,0 +1,1 @@
+uid://bodu53yoq14i7

--- a/tests/test_spiral_stairs_builder.gd.uid
+++ b/tests/test_spiral_stairs_builder.gd.uid
@@ -1,0 +1,1 @@
+uid://com8drxqxqvl8

--- a/tests/test_stairs_builder.gd.uid
+++ b/tests/test_stairs_builder.gd.uid
@@ -1,0 +1,1 @@
+uid://chcjs46abtelw

--- a/tests/test_suite_integrity.gd.uid
+++ b/tests/test_suite_integrity.gd.uid
@@ -1,0 +1,1 @@
+uid://c06gqyurepgix


### PR DESCRIPTION
Fixes #197
Fixes #196

Two problems in the same command.

**Undo (#197).** `clip_to_face_plane_selected()` looped over the targets calling `clip_brush_to_face_plane()` directly and then recorded a history label. A history label is not an undo action, so an advertised destructive command could replace several authored brushes with no way back.

The batch now goes through `HFUndoHelper.commit()` as one action against a new `LevelRoot.clip_brushes_by_plane(brush_ids, plane)`. The plane is read once up front rather than being re-derived from the reference brush on every replay, so a redo still works when the reference brush was itself one of the targets. `plane_splits_brush()` is asked before the action opens, so a cut that would do nothing no longer lands in the history.

**Selection (#196).** Entering Face Select saves the object selection and then clears it, so by the time a reference face exists there was nothing left for `collect_managed_targets()` to return. The command now falls back to that saved selection. After a successful cut it clears the saved list and the face selection and leaves Face Select, rather than restoring a selection of brushes the cut has just replaced.

Alt+Shift+X was in the keymap and in the docs but the viewport router never dispatched it, so the flow in #196 could not be followed from the viewport at all. Routed, with no selection count guard, because Face Select empties that selection on purpose.

New coverage in `tests/test_clip_to_face_plane.gd`: a real undo and redo round trip on a real `LevelRoot`, the reference-was-a-target replay, one and multiple targets, and the Face Select flow driven through the actual `on_face_select_mode_toggled()` transitions rather than by assigning the two selection stores by hand.