### PR TITLE
Keep scale through Reset Rotation and move face data through Flip

### DIFF
--- a/addons/hammerforge/systems/hf_transform_system.gd
+++ b/addons/hammerforge/systems/hf_transform_system.gd
@@ -276,9 +276,12 @@ func flip(brush_ids: Array, entity_paths: Array, axis_index: int, pivot: Vector3
 	return changed
 
 
-## Clear each brush's rotation, keeping its position. This is what makes hollow,
-## clip, and carve reachable again after a rotation — all three refuse a rotated
-## brush through `HFBrushSystem._check_axis_aligned_box()`.
+## Clear each brush's rotation, keeping its position and its size.
+##
+## Rotation is only one part of a basis. Godot's own scale gizmo writes into the
+## same matrix, so replacing the whole basis with the identity would quietly
+## resize the brush as well. `basis = rotation * scale` and `get_scale()` reads
+## the scale half back out, so the cleared basis is that scale on its own.
 func reset_rotation(brush_ids: Array) -> int:
 	var changed := 0
 	for brush_id in brush_ids:
@@ -286,16 +289,21 @@ func reset_rotation(brush_ids: Array) -> int:
 		if draft == null:
 			continue
 		var xform := draft.global_transform
-		if xform.basis.is_equal_approx(Basis.IDENTITY):
+		var scale := xform.basis.get_scale()
+		var cleared := Basis.from_scale(scale)
+		# Scale alone is not rotation. Leave it exactly as the user set it.
+		if xform.basis.is_equal_approx(cleared):
 			continue
 		# A basis that only swaps and flips whole axes is describing a box that is
 		# already axis-aligned, just bookkept oddly. Fold the swap into `size` so
 		# clearing the basis leaves the geometry exactly where it was — otherwise a
-		# quarter turn would snap a non-cube box back to its old footprint.
+		# quarter turn would snap a non-cube box back to its old footprint. The
+		# scale is per local axis, so it has to travel with the swap.
 		var permutation := axis_permutation(xform.basis)
 		if not permutation.is_empty() and draft.shape == DraftBrush.BrushShape.BOX:
 			draft.size = permuted_size(draft.size, permutation)
-		draft.global_transform = Transform3D(Basis.IDENTITY, xform.origin)
+			cleared = Basis.from_scale(permuted_size(scale, permutation))
+		draft.global_transform = Transform3D(cleared, xform.origin)
 		_tag_dirty(draft)
 		changed += 1
 	return changed
@@ -431,8 +439,20 @@ func _flip_brush(draft: DraftBrush, axis_index: int, pivot: Vector3) -> void:
 	_ensure_faces(draft)
 	# A primitive that a local mirror maps onto itself needs no geometry surgery:
 	# the fold-back reflection lands every generated vertex on another vertex of
-	# the same shape, and the per-face data rides along to where that face went.
+	# the same shape.
 	var keeps_primitive := _primitive_survives_mirror(draft, local_axis)
+	# The shape survives, but the authored appearance does not ride along on its
+	# own. Face data is held by index, and the mirror sends each face to where a
+	# different face used to be, so a material on the positive X side would stay
+	# on positive X after an X flip. Move the data to follow the geometry.
+	var remapped := false
+	if keeps_primitive:
+		remapped = remap_mirrored_faces(draft, local_axis)
+		if not remapped and _face_appearance_varies(draft):
+			# The faces cannot be paired up, which is rare and shape-specific. The
+			# appearance would land on the wrong sides, so take the exact path
+			# instead and accept becoming CUSTOM.
+			keeps_primitive = false
 	if not keeps_primitive:
 		draft.mark_faces_authoritative()
 	draft.global_transform = flipped_transform(
@@ -440,8 +460,95 @@ func _flip_brush(draft: DraftBrush, axis_index: int, pivot: Vector3) -> void:
 	)
 	if not keeps_primitive:
 		mirror_faces(draft.get_faces(), local_axis)
+	if remapped or not keeps_primitive:
 		draft.rebuild_preview()
 	_tag_dirty(draft)
+
+
+## Move each face's data to the face the mirror sends its geometry to, keeping
+## every face's vertices where the primitive generates them.
+##
+## Reflecting local vertex `v` puts it where the world mirror sent the old vertex
+## at `H * v`, so the face that now occupies a given place is the one that used to
+## occupy its reflection. `mirror_face()` turns the source face's geometry back
+## into the target's, winding included, and carries its material, UVs and paint
+## with it. False when the faces cannot be paired one to one, having changed
+## nothing.
+func remap_mirrored_faces(draft: DraftBrush, local_axis: int) -> bool:
+	var faces: Array = draft.get_faces()
+	var count := faces.size()
+	if count < 2:
+		return false
+	var by_place := {}
+	for face in faces:
+		if face == null or face.local_verts.is_empty():
+			return false
+		var place := _face_place(face, -1)
+		if by_place.has(place):
+			return false
+		by_place[place] = face
+	var sources: Array[FaceData] = []
+	for face in faces:
+		var mirrored := _face_place(face, local_axis)
+		if not by_place.has(mirrored):
+			return false
+		sources.append(by_place[mirrored])
+	# The mirror is its own inverse, so the pairing above is a bijection and every
+	# face is mirrored exactly once.
+	for face in sources:
+		mirror_face(face, local_axis)
+	draft.faces = sources
+	return true
+
+
+## An order-independent name for the place a face occupies, optionally after
+## reflecting it through one local axis. Two faces of one brush never share one.
+static func _face_place(face: FaceData, mirror_axis: int) -> String:
+	var parts := PackedStringArray()
+	for vertex in face.local_verts:
+		var point: Vector3 = vertex
+		if mirror_axis >= 0:
+			point[mirror_axis] = -point[mirror_axis]
+		parts.append(_quantize(point))
+	parts.sort()
+	return "|".join(parts)
+
+
+## True when the brush's faces do not all look alike, which is the only case
+## where it matters which face the data ends up on.
+static func _face_appearance_varies(draft: DraftBrush) -> bool:
+	var first := ""
+	var seen := false
+	for face in draft.faces:
+		if face == null:
+			continue
+		# Paint is authored one face at a time, so treat any of it as worth moving
+		# rather than trying to compare weight images.
+		if not face.paint_layers.is_empty():
+			return true
+		var signature := _appearance_signature(face)
+		if not seen:
+			first = signature
+			seen = true
+		elif signature != first:
+			return true
+	return false
+
+
+static func _appearance_signature(face: FaceData) -> String:
+	return (
+		"%d/%d/%.4f,%.4f/%.4f,%.4f/%.4f/%d"
+		% [
+			face.material_idx,
+			face.uv_projection,
+			face.uv_scale.x,
+			face.uv_scale.y,
+			face.uv_offset.x,
+			face.uv_offset.y,
+			face.uv_rotation,
+			face.custom_uvs.size(),
+		]
+	)
 
 
 ## True when reflecting the brush's local vertices through `local_axis` leaves

--- a/tests/test_transform_system.gd
+++ b/tests/test_transform_system.gd
@@ -484,6 +484,109 @@ func test_flip_preserves_per_face_materials():
 		assert_eq(after[i].material_idx, i, "face %d kept its material" % i)
 
 
+## The material on the face whose outward world normal points along `direction`.
+func _material_facing(draft: DraftBrush, direction: Vector3) -> int:
+	var basis := draft.global_transform.basis
+	for face in draft.get_faces():
+		if face == null:
+			continue
+		var world_normal: Vector3 = (basis * face.normal).normalized()
+		if world_normal.dot(direction.normalized()) > 0.99:
+			return face.material_idx
+	return -999
+
+
+func _face_facing(draft: DraftBrush, direction: Vector3):
+	var basis := draft.global_transform.basis
+	for face in draft.get_faces():
+		if face == null:
+			continue
+		var world_normal: Vector3 = (basis * face.normal).normalized()
+		if world_normal.dot(direction.normalized()) > 0.99:
+			return face
+	return null
+
+
+func _paint_a_box(brush_id: String) -> DraftBrush:
+	var b := _make_brush(Vector3(48, 0, 0), Vector3(32, 16, 8), brush_id)
+	_face_facing(b, Vector3.RIGHT).material_idx = 10
+	_face_facing(b, Vector3.LEFT).material_idx = 20
+	return b
+
+
+func test_flip_moves_per_face_material_to_the_mirrored_side():
+	# The whole point of a mirror is that what was on the right ends up on the
+	# left. A box stays a box through the flip, so nothing else moves the data.
+	var b := _paint_a_box("f1")
+
+	sys.flip(["f1"], [], 0, Vector3.ZERO)
+
+	assert_eq(_material_facing(b, Vector3.RIGHT), 20, "the left face is now on the right")
+	assert_eq(_material_facing(b, Vector3.LEFT), 10, "and the right face is now on the left")
+
+
+func test_flip_moves_per_face_uv_settings_to_the_mirrored_side():
+	var b := _make_brush(Vector3(48, 0, 0), Vector3(32, 16, 8), "f1")
+	var right = _face_facing(b, Vector3.RIGHT)
+	right.uv_offset = Vector2(7, 3)
+	right.uv_rotation = 0.5
+	right.uv_scale = Vector2(2, 4)
+
+	sys.flip(["f1"], [], 0, Vector3.ZERO)
+
+	var moved = _face_facing(b, Vector3.LEFT)
+	assert_almost_eq(moved.uv_offset.x, 7.0, EPS, "uv offset travels with the face")
+	assert_almost_eq(moved.uv_rotation, 0.5, EPS, "so does uv rotation")
+	assert_almost_eq(moved.uv_scale.y, 4.0, EPS, "so does uv scale")
+
+
+func test_flip_moves_paint_layers_to_the_mirrored_side():
+	var b := _make_brush(Vector3(48, 0, 0), Vector3(32, 16, 8), "f1")
+	var layer := FaceDataScript.PaintLayer.new()
+	layer.opacity = 0.25
+	_face_facing(b, Vector3.RIGHT).paint_layers.append(layer)
+
+	sys.flip(["f1"], [], 0, Vector3.ZERO)
+
+	var moved = _face_facing(b, Vector3.LEFT)
+	assert_eq(moved.paint_layers.size(), 1, "the painted face is now the left one")
+	assert_almost_eq(float(moved.paint_layers[0].opacity), 0.25, EPS)
+	assert_eq(
+		_face_facing(b, Vector3.RIGHT).paint_layers.size(), 0, "and the right one is unpainted"
+	)
+
+
+func test_flip_twice_returns_every_face_to_its_own_side():
+	var b := _paint_a_box("f1")
+
+	sys.flip(["f1"], [], 0, Vector3.ZERO)
+	sys.flip(["f1"], [], 0, Vector3.ZERO)
+
+	assert_eq(_material_facing(b, Vector3.RIGHT), 10, "two mirrors are the identity")
+	assert_eq(_material_facing(b, Vector3.LEFT), 20)
+
+
+func test_flip_keeps_a_painted_box_parametric():
+	var b := _paint_a_box("f1")
+	sys.flip(["f1"], [], 0, Vector3.ZERO)
+	assert_eq(
+		b.shape,
+		DraftBrush.BrushShape.BOX,
+		"moving the face data must not cost the brush its resize handles"
+	)
+
+
+func test_flip_moves_face_data_on_the_axis_it_was_asked_for():
+	var b := _make_brush(Vector3(0, 48, 0), Vector3(32, 16, 8), "f1")
+	_face_facing(b, Vector3.UP).material_idx = 3
+	_face_facing(b, Vector3.RIGHT).material_idx = 9
+
+	sys.flip(["f1"], [], 1, Vector3.ZERO)
+
+	assert_eq(_material_facing(b, Vector3.DOWN), 3, "a Y flip swaps top and bottom")
+	assert_eq(_material_facing(b, Vector3.RIGHT), 9, "and leaves the sides where they were")
+
+
 func test_flip_mirrors_entity_position_and_yaw():
 	var e := _make_entity(Vector3(100, 0, 0), "Mirror")
 	e.entity_data = {"angle": 30.0}
@@ -553,6 +656,76 @@ func test_reset_rotation_clears_the_basis_a_rotation_put_there():
 	assert_false(b.global_transform.basis.is_equal_approx(Basis.IDENTITY))
 	assert_eq(sys.reset_rotation(["r1"]), 1)
 	assert_true(b.global_transform.basis.is_equal_approx(Basis.IDENTITY))
+
+
+## The world-space extent of a brush along each axis.
+func _world_extent(draft: DraftBrush) -> Vector3:
+	var low := Vector3.INF
+	var high := -Vector3.INF
+	for v in _world_verts(draft):
+		low = Vector3(minf(low.x, v.x), minf(low.y, v.y), minf(low.z, v.z))
+		high = Vector3(maxf(high.x, v.x), maxf(high.y, v.y), maxf(high.z, v.z))
+	return high - low
+
+
+func test_reset_rotation_leaves_a_scaled_box_alone():
+	# Scaling with Godot's own gizmo writes into the basis. It is not rotation, so
+	# there is nothing here to clear.
+	var b := _make_brush(Vector3(48, 12, -7), Vector3(32, 32, 32), "r1")
+	b.global_transform = Transform3D(Basis.from_scale(Vector3(2, 3, 4)), b.global_position)
+	var extent := _world_extent(b)
+
+	assert_eq(sys.reset_rotation(["r1"]), 0, "a scaled box is not a rotated box")
+
+	assert_true(
+		b.global_transform.basis.get_scale().is_equal_approx(Vector3(2, 3, 4)),
+		"the scale the user set has to survive: got %s" % b.global_transform.basis.get_scale()
+	)
+	assert_true(_world_extent(b).is_equal_approx(extent), "and the brush stays the size it was")
+
+
+func test_reset_rotation_keeps_the_scale_of_a_rotated_and_scaled_box():
+	var b := _make_brush(Vector3.ZERO, Vector3(32, 16, 8), "r1")
+	b.global_transform = Transform3D(
+		Basis(Vector3.UP, deg_to_rad(37.0)) * Basis.from_scale(Vector3(2, 3, 4)), Vector3.ZERO
+	)
+
+	assert_eq(sys.reset_rotation(["r1"]), 1)
+
+	var basis := b.global_transform.basis
+	assert_true(
+		basis.orthonormalized().is_equal_approx(Basis.IDENTITY),
+		"the rotation is what was asked to go"
+	)
+	assert_true(
+		basis.get_scale().is_equal_approx(Vector3(2, 3, 4)),
+		"the scale is not: got %s" % basis.get_scale()
+	)
+	assert_true(
+		_world_extent(b).is_equal_approx(Vector3(64, 48, 32)),
+		"a 32 by 16 by 8 box scaled 2, 3, 4 measures 64 by 48 by 32: got %s" % _world_extent(b)
+	)
+
+
+func test_reset_rotation_keeps_a_quarter_turned_scaled_box_exactly_where_it_is():
+	# A quarter turn is folded into `size` rather than undone, so the geometry does
+	# not move at all. The scale has to be folded with it or the box changes size.
+	var b := _make_brush(Vector3.ZERO, Vector3(32, 16, 8), "r1")
+	b.global_transform = Transform3D(
+		Basis(Vector3.UP, deg_to_rad(90.0)) * Basis.from_scale(Vector3(2, 3, 4)), Vector3.ZERO
+	)
+	var extent := _world_extent(b)
+
+	assert_eq(sys.reset_rotation(["r1"]), 1)
+
+	assert_true(
+		b.global_transform.basis.orthonormalized().is_equal_approx(Basis.IDENTITY),
+		"the quarter turn is gone"
+	)
+	assert_true(
+		_world_extent(b).is_equal_approx(extent),
+		"but the brush occupies the same space: %s became %s" % [extent, _world_extent(b)]
+	)
 
 
 # ===========================================================================


### PR DESCRIPTION
Fixes #195
Fixes #194

Two defects in `HFTransformSystem`, both where a command touched more than it was asked to.

**Reset Rotation (#195).** The method assigned `Basis.IDENTITY`, and `axis_permutation()` normalises the columns, so a purely scaled box read as an axis permutation and had its scale wiped along with a rotation it did not have. `basis = rotation * scale`, so the cleared basis is now `Basis.from_scale(basis.get_scale())`. A brush that is only scaled is left alone entirely. The quarter-turn fold into `size` now permutes the scale with it, so a turned and scaled box still occupies exactly the space it did.

**Flip (#194).** When a local mirror maps a primitive onto itself the geometry needs no surgery, so the code left the faces alone. But face data is held by index, and the mirror sends each face to where a different face used to be, so a material on the positive X face stayed on positive X after an X flip.

`remap_mirrored_faces()` now pairs each face with the face its own reflection lands on, mirrors that source back into place with the existing `mirror_face()`, and writes the array back in the primitive's own order. Material, UV fields, custom UVs and paint layers all travel together, and the brush keeps its shape and its resize handles. When the faces cannot be paired one to one, which is shape-specific and rare, the flip falls back to the exact path only if the faces actually differ from each other. There is nothing to move when they all look alike.

Coverage in `tests/test_transform_system.gd`: spatial assertions that read the material, UV settings and paint layers off the face whose outward world normal points a given way, rather than asserting an array index kept its value. Plus a scaled box, a rotated and scaled box, and a quarter-turned and scaled box measured by world extent. All seven new tests fail on `main`.