### PR TITLE
Tell the truth about a refused Create or Update, and route Ctrl+Shift+A

### DIFF
--- a/addons/hammerforge/dock_brush_handler.gd
+++ b/addons/hammerforge/dock_brush_handler.gd
@@ -650,26 +650,56 @@ static func on_create_structure(dock: Object) -> void:
 		return
 	var type := structure_type(dock)
 	var settings := collect_structure_settings(dock)
-	var label := HFGeneratorSystem.display_name(type)
 	# Editing an existing structure rather than making another one: the section
 	# switched to Update when a piece of it was selected.
-	if dock._active_generator_id != "":
-		dock._commit_state_action(
-			"Update %s" % label, "regenerate_generator", [dock._active_generator_id, settings]
-		)
-		dock._set_status("%s rebuilt" % label)
-		refresh_structure_section(dock)
+	var generator_id := str(dock._active_generator_id)
+	if generator_id != "":
+		_update_structure(dock, generator_id, settings)
+		return
+	var label := HFGeneratorSystem.display_name(type)
+	# Ask whether these settings build before opening an undo action. Each field
+	# can be in range while the combination is not, and a refused build would
+	# otherwise leave an empty entry in the history under a success message.
+	var check: HFOpResult = dock.level_root.can_build_generator(type, settings)
+	if not check.ok:
+		dock._set_status(check.user_text(), true)
 		return
 	var targets := _transform_targets(dock)
 	var centre: Vector3 = dock.level_root.resolve_transform_pivot(
 		targets["brush_ids"], targets["entity_paths"]
 	)
+	var before: int = dock.level_root.generator_count()
 	dock._commit_state_action(
 		"Create %s" % label,
 		"create_generator",
 		[type, settings, Transform3D(Basis.IDENTITY, centre)]
 	)
-	dock._set_status("Created a %s" % label.to_lower())
+	if dock.level_root.generator_count() > before:
+		dock._set_status("Created a %s" % label.to_lower())
+	else:
+		dock._set_status("%s was not created" % label, true)
+	refresh_structure_section(dock)
+
+
+## Rebuild the selected structure. A refused rebuild has to leave it alone and
+## say so, rather than reporting that it was rebuilt.
+static func _update_structure(dock: Object, generator_id: String, settings: Dictionary) -> void:
+	var record = dock.level_root.generator_for_id(generator_id)
+	if record == null:
+		dock._set_status("That structure is no longer in the level", true)
+		refresh_structure_section(dock)
+		return
+	var label := HFGeneratorSystem.display_name(record.type)
+	var check: HFOpResult = dock.level_root.can_build_generator(record.type, settings)
+	if not check.ok:
+		dock._set_status("%s not changed. %s" % [label, check.user_text()], true)
+		return
+	dock._commit_state_action("Update %s" % label, "regenerate_generator", [generator_id, settings])
+	if dock.level_root.has_generator(generator_id):
+		dock._set_status("%s rebuilt" % label)
+	else:
+		dock._set_status("%s was not rebuilt" % label, true)
+	refresh_structure_section(dock)
 
 
 static func on_rotate_selection(dock: Object, direction: int) -> void:

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -1266,6 +1266,25 @@ func edited_generator_pieces(generator_id: String) -> int:
 	return generator_system.edited_piece_count(generator_id) if generator_system else 0
 
 
+## Whether these settings would build. Asked before an undo action is opened.
+func can_build_generator(type: String, settings: Dictionary) -> HFOpResult:
+	return HFGeneratorSystem.can_build(type, settings)
+
+
+## How many live structures the level holds. The dock reads this either side of a
+## build to tell a real one from a refused one.
+func generator_count() -> int:
+	return generator_system.generators.size() if generator_system else 0
+
+
+func has_generator(generator_id: String) -> bool:
+	return generator_system != null and generator_system.generators.has(generator_id)
+
+
+func generator_for_id(generator_id: String):
+	return generator_system.generator_for_id(generator_id) if generator_system else null
+
+
 func clip_brush_by_plane(brush_id: String, plane: Plane) -> HFOpResult:
 	return brush_system.clip_brush_by_plane(brush_id, plane)
 

--- a/addons/hammerforge/plugin_input_router.gd
+++ b/addons/hammerforge/plugin_input_router.gd
@@ -167,6 +167,13 @@ static func handle_keyboard(
 			return merge_guard
 		plugin._merge_selected(root)
 		return STOP
+	# Create Structure needs a level and the dock that holds the settings, but no
+	# selection: with nothing selected it builds at the world origin.
+	if keymap.matches("create_arch", event):
+		if root == null or dock == null:
+			return PASS
+		dock._on_create_structure()
+		return STOP
 	# Nudge keys
 	var nudge = plugin._get_nudge_direction(event.keycode)
 	if nudge != Vector3.ZERO and not event.ctrl_pressed and not event.alt_pressed:

--- a/addons/hammerforge/systems/hf_generator_system.gd
+++ b/addons/hammerforge/systems/hf_generator_system.gd
@@ -101,6 +101,24 @@ static func build_faces(type: String, settings: Dictionary) -> Array:
 	return builder.build(settings) if builder else []
 
 
+## Whether these settings would build, without building anything that lasts.
+##
+## Each field can be in range while the combination is not: a wall as thick as
+## the arch is wide, an arc of zero, a wide arc across too few segments. The
+## builder refuses those, so the dock has to be able to ask before it opens an
+## undo action and tells the user it worked.
+static func can_build(type: String, settings: Dictionary) -> HFOpResult:
+	var check := validate(type, settings)
+	if not check.ok:
+		return check
+	if build_faces(type, settings).is_empty():
+		return HFOpResult.fail(
+			"%s: those settings produce no geometry" % display_name(type),
+			"Widen the structure or add segments"
+		)
+	return HFOpResult.success()
+
+
 # ---------------------------------------------------------------------------
 # Creating, changing and forgetting
 # ---------------------------------------------------------------------------
@@ -197,6 +215,10 @@ func remove(generator_id: String) -> bool:
 # ---------------------------------------------------------------------------
 # Lookups
 # ---------------------------------------------------------------------------
+
+
+func generator_for_id(generator_id: String) -> HFGenerator:
+	return generators.get(generator_id, null)
 
 
 func generator_for_brush(brush_id: String) -> HFGenerator:

--- a/tests/test_structure_dock_commands.gd
+++ b/tests/test_structure_dock_commands.gd
@@ -1,0 +1,255 @@
+extends GutTest
+
+## The Structure section as the user drives it: a real dock, a real LevelRoot,
+## and the advertised shortcut sent as a real key event.
+##
+## Settings that are each in range can still be a combination the builder
+## refuses, so what the dock says afterwards is the thing worth checking.
+
+const DockScene = preload("res://addons/hammerforge/dock.tscn")
+const HFPluginInputRouter = preload("res://addons/hammerforge/plugin_input_router.gd")
+const HFKeymapScript = preload("res://addons/hammerforge/hf_keymap.gd")
+
+var dock: HammerForgeDock
+var root: LevelRoot
+
+
+func before_each() -> void:
+	dock = DockScene.instantiate()
+	add_child_autoqfree(dock)
+	root = LevelRoot.new()
+	root.auto_spawn_player = false
+	root.commit_freeze = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	dock.level_root = root
+	_choose_arch()
+
+
+func after_each() -> void:
+	dock = null
+	root = null
+
+
+func _choose_arch() -> void:
+	for index in dock.structure_type_option.item_count:
+		if str(dock.structure_type_option.get_item_metadata(index)) == "arch":
+			dock.structure_type_option.selected = index
+			break
+	HFDockBrushHandler.rebuild_structure_fields(dock)
+
+
+func _set_field(key: String, value: float) -> void:
+	var control = dock.structure_fields.get(key, null)
+	assert_not_null(control, "the arch has a %s control" % key)
+	control.set_value_no_signal(value)
+
+
+func _status() -> String:
+	return dock.status_label.text if dock.status_label else ""
+
+
+func _only_record():
+	for generator_id in root.generator_system.generators:
+		return root.generator_system.generators[generator_id]
+	return null
+
+
+func _generated_brushes() -> Array:
+	var out: Array = []
+	var record = _only_record()
+	if record == null:
+		return out
+	for brush_id in record.brush_ids:
+		var brush = root.brush_system.find_brush_by_id(str(brush_id))
+		if brush != null:
+			out.append(brush)
+	return out
+
+
+# ===========================================================================
+# Create
+# ===========================================================================
+
+
+func test_a_valid_create_builds_and_says_what_it_made():
+	dock._on_create_structure()
+
+	assert_eq(root.generator_count(), 1, "the control case has to actually build")
+	assert_eq(_status(), "Created a arch")
+
+
+func test_a_wall_as_thick_as_the_radius_is_refused_out_loud():
+	# Each field is inside its own range. The combination leaves no opening.
+	_set_field("radius", 128.0)
+	_set_field("wall_thickness", 128.0)
+
+	dock._on_create_structure()
+
+	assert_eq(root.generator_count(), 0, "nothing was built")
+	assert_true(
+		_status().begins_with("Arch: wall thickness"),
+		"the dock has to say why, not report success: got '%s'" % _status()
+	)
+
+
+func test_a_zero_arc_is_refused_out_loud():
+	_set_field("arc_degrees", 0.0)
+
+	dock._on_create_structure()
+
+	assert_eq(root.generator_count(), 0)
+	assert_true(_status().contains("arc angle"), "got '%s'" % _status())
+
+
+func test_an_arc_across_too_few_segments_is_refused_out_loud():
+	_set_field("arc_degrees", 360.0)
+	_set_field("segments", 1.0)
+
+	dock._on_create_structure()
+
+	assert_eq(root.generator_count(), 0)
+	assert_true(_status().contains("segment"), "got '%s'" % _status())
+
+
+# ===========================================================================
+# Update
+# ===========================================================================
+
+
+func _create_then_select_a_piece() -> void:
+	dock._on_create_structure()
+	assert_eq(root.generator_count(), 1, "the update tests need something to update")
+	dock.set_selection_nodes([_generated_brushes()[0]])
+	assert_ne(str(dock._active_generator_id), "", "selecting a piece switches to Update")
+
+
+func test_a_valid_update_rebuilds_and_says_so():
+	_create_then_select_a_piece()
+	_set_field("radius", 192.0)
+
+	dock._on_create_structure()
+
+	assert_eq(_status(), "Arch rebuilt")
+	assert_almost_eq(float(_only_record().settings["radius"]), 192.0, 0.001)
+
+
+func test_a_refused_update_leaves_the_structure_exactly_as_it_was():
+	_create_then_select_a_piece()
+	var settings_before: Dictionary = _only_record().settings.duplicate(true)
+	var ids_before := Array(_only_record().brush_ids)
+
+	_set_field("arc_degrees", 0.0)
+	dock._on_create_structure()
+
+	assert_true(
+		_status().begins_with("Arch not changed"),
+		"a refused update must say the structure was left alone: got '%s'" % _status()
+	)
+	assert_eq(_only_record().settings, settings_before, "the stored settings are untouched")
+	assert_eq(Array(_only_record().brush_ids), ids_before, "and so is the geometry")
+
+
+func test_a_refused_update_does_not_report_a_rebuild():
+	_create_then_select_a_piece()
+	_set_field("wall_thickness", 4096.0)
+
+	dock._on_create_structure()
+
+	assert_false(_status().contains("rebuilt"), "got '%s'" % _status())
+	assert_eq(root.generator_count(), 1, "and the structure is still there")
+
+
+# ===========================================================================
+# The advertised shortcut (#198)
+# ===========================================================================
+
+
+class FakeInputState:
+	extends RefCounted
+
+	func is_dragging() -> bool:
+		return false
+
+	func is_extruding() -> bool:
+		return false
+
+	func is_idle() -> bool:
+		return true
+
+
+class RecordingDock:
+	extends RefCounted
+
+	var creates := 0
+
+	func _on_create_structure() -> void:
+		creates += 1
+
+	func show_toast(_text: String, _level: int = 0) -> void:
+		pass
+
+
+class FakePlugin:
+	extends RefCounted
+
+	var dock := RecordingDock.new()
+	var _keymap = null
+	var _hotkey_palette = null
+	var _radial_menu = null
+	var _tool_registry = null
+	var _operation_replay = null
+
+	func _handle_numeric_input(_event, _root) -> int:
+		return EditorPlugin.AFTER_GUI_INPUT_PASS
+
+	func _cancel_escape_step(_root) -> bool:
+		return false
+
+
+func _ctrl_shift_a() -> InputEventKey:
+	var event := InputEventKey.new()
+	event.keycode = KEY_A
+	event.pressed = true
+	event.ctrl_pressed = true
+	event.shift_pressed = true
+	return event
+
+
+func test_ctrl_shift_a_reaches_the_structure_command():
+	var plugin := FakePlugin.new()
+	var keymap := HFKeymapScript.new()
+	keymap._bindings = HFKeymapScript._default_bindings()
+	plugin._keymap = keymap
+	var router_root := Node3D.new()
+	router_root.set_script(_router_root_script())
+	add_child_autoqfree(router_root)
+	router_root.input_state = FakeInputState.new()
+
+	var handled: int = HFPluginInputRouter.handle_keyboard(
+		plugin, _ctrl_shift_a(), router_root, 0, false
+	)
+
+	assert_eq(plugin.dock.creates, 1, "the advertised binding has to reach the command")
+	assert_eq(handled, EditorPlugin.AFTER_GUI_INPUT_STOP, "and consume the key")
+
+
+func test_the_binding_is_still_the_one_that_is_advertised():
+	var keymap := HFKeymapScript.new()
+	keymap._bindings = HFKeymapScript._default_bindings()
+	var binding: Dictionary = keymap.get_all_bindings()["create_arch"]
+	assert_eq(int(binding["keycode"]), KEY_A)
+	assert_true(bool(binding.get("ctrl", false)))
+	assert_true(bool(binding.get("shift", false)))
+	assert_eq(HFKeymapScript.get_action_label("create_arch"), "Create Structure")
+
+
+func _router_root_script() -> GDScript:
+	var script := GDScript.new()
+	script.source_code = """
+extends Node3D
+
+var input_state = null
+"""
+	script.reload()
+	return script


### PR DESCRIPTION
Fixes #199
Fixes #198

**Reporting (#199).** `on_create_structure()` committed through `dock._commit_state_action()`, which returns nothing, and then set a success status unconditionally. The schema controls let through combinations the builder refuses, so the dock reported Created or rebuilt over an empty undo entry and no geometry.

`HFGeneratorSystem.can_build()` runs the builder's own validation and checks the settings produce faces, without building anything that lasts. The dock asks before it opens an action. A refused Create says why and builds nothing. A refused Update says the structure was not changed and leaves it alone, which `regenerate()` already guaranteed internally but the dock did not say. After a commit both paths read the level back, so an internal failure is reported as one instead of assumed away.

**Shortcut (#198).** `create_arch` is Ctrl+Shift+A in `HFKeymap.DEFAULT_BINDINGS`, labelled Create Structure, and advertised in the guide and the shortcut surfaces, but `HFPluginInputRouter.handle_keyboard()` never checked for it. Routed now, with a level and dock guard rather than a selection count guard: Create Structure builds at the world origin when nothing is selected. The legacy action id is unchanged so existing custom keymaps keep resolving.

Coverage in `tests/test_structure_dock_commands.gd`: a real dock instantiated from `dock.tscn` against a real `LevelRoot`, driving the invalid combinations from the issue plus a valid control, and asserting on the status line and the stored record. Plus a real Ctrl+Shift+A `InputEventKey` sent through `handle_keyboard()`, proving the dock handler is called. Six of the nine fail on `main` with exactly the reported symptoms: "Created a arch" for a refused build and "Arch rebuilt" for a refused update.