### PR TITLE
Carry painted faces through a rebuild, and drop records with their geometry

### DIFF
--- a/addons/hammerforge/dock.gd
+++ b/addons/hammerforge/dock.gd
@@ -479,6 +479,10 @@ var structure_warning: Label = null
 ## The generator the selection belongs to, if any. Empty means the Arch
 ## section is creating rather than editing.
 var _active_generator_id: String = ""
+
+## The structure and settings the user has already been warned about, so a second
+## press of Update goes ahead rather than warning again forever.
+var _structure_overwrite_ack: String = ""
 var dup_rise_spin: SpinBox = null
 var rotate_ccw_btn: Button = null
 var rotate_cw_btn: Button = null

--- a/addons/hammerforge/dock_brush_handler.gd
+++ b/addons/hammerforge/dock_brush_handler.gd
@@ -569,6 +569,8 @@ static func refresh_structure_section(dock: Object) -> void:
 		_show_edit_warning(dock, 0)
 		return
 
+	if str(dock._active_generator_id) != str(record.generator_id):
+		dock._structure_overwrite_ack = ""
 	dock._active_generator_id = record.generator_id
 	if structure_type(dock) != record.type:
 		_select_type(dock, record.type)
@@ -694,12 +696,49 @@ static func _update_structure(dock: Object, generator_id: String, settings: Dict
 	if not check.ok:
 		dock._set_status("%s not changed. %s" % [label, check.user_text()], true)
 		return
+	# Painting a generated structure is normal authoring work. A rebuild carries it
+	# across whenever the pieces still line up, and when they do not the user gets
+	# to see that before it goes, with Detach sitting beside the button.
+	if not _confirm_appearance_overwrite(dock, generator_id, settings):
+		return
 	dock._commit_state_action("Update %s" % label, "regenerate_generator", [generator_id, settings])
+	dock._structure_overwrite_ack = ""
 	if dock.level_root.has_generator(generator_id):
 		dock._set_status("%s rebuilt" % label)
 	else:
 		dock._set_status("%s was not rebuilt" % label, true)
 	refresh_structure_section(dock)
+
+
+## False when the user has not yet seen that this rebuild would drop painted
+## faces. The first press warns and stops; a second press of the same settings
+## goes ahead, and Detach is the other way out.
+static func _confirm_appearance_overwrite(
+	dock: Object, generator_id: String, settings: Dictionary
+) -> bool:
+	if not dock.level_root.has_method("generator_appearance_at_risk"):
+		return true
+	var at_risk: int = dock.level_root.generator_appearance_at_risk(generator_id, settings).size()
+	if at_risk <= 0:
+		dock._structure_overwrite_ack = ""
+		return true
+	var token := "%s|%d" % [generator_id, hash(settings)]
+	if str(dock._structure_overwrite_ack) == token:
+		return true
+	dock._structure_overwrite_ack = token
+	_show_paint_warning(dock, at_risk)
+	dock._set_status("Press Update again to rebuild over the painted faces", true)
+	return false
+
+
+static func _show_paint_warning(dock: Object, at_risk: int) -> void:
+	if dock == null or dock.structure_warning == null:
+		return
+	dock.structure_warning.visible = true
+	dock.structure_warning.text = (
+		"%d piece%s painted faces these settings cannot keep. Update again to rebuild over %s, or Detach to keep them."
+		% [at_risk, " has" if at_risk == 1 else "s have", "it" if at_risk == 1 else "them"]
+	)
 
 
 static func on_rotate_selection(dock: Object, direction: int) -> void:

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -1285,6 +1285,14 @@ func generator_for_id(generator_id: String):
 	return generator_system.generator_for_id(generator_id) if generator_system else null
 
 
+## The generated pieces whose painted faces a rebuild with these settings could
+## not put back.
+func generator_appearance_at_risk(generator_id: String, settings: Dictionary) -> PackedStringArray:
+	if not generator_system:
+		return PackedStringArray()
+	return generator_system.appearance_at_risk(generator_id, settings)
+
+
 func clip_brush_by_plane(brush_id: String, plane: Plane) -> HFOpResult:
 	return brush_system.clip_brush_by_plane(brush_id, plane)
 

--- a/addons/hammerforge/systems/hf_brush_system.gd
+++ b/addons/hammerforge/systems/hf_brush_system.gd
@@ -720,6 +720,13 @@ func clear_brushes() -> void:
 				root.draft_brushes_node.remove_child(child)
 				child.queue_free()
 	_clear_generated()
+	# The records describe geometry that has just gone. Keeping them would leave
+	# orphans in the next save and in every undo snapshot after this one.
+	# Restoring a state puts the records for that state back afterwards, and
+	# deleting a single generated piece still goes nowhere near here, because that
+	# record is what warns about the gap and rebuilds it.
+	if root.generator_system:
+		root.generator_system.clear()
 	_clear_preview()
 	clear_pending_cuts()
 	_clear_committed_cuts()

--- a/addons/hammerforge/systems/hf_generator_system.gd
+++ b/addons/hammerforge/systems/hf_generator_system.gd
@@ -164,18 +164,18 @@ func regenerate(generator_id: String, settings: Dictionary) -> HFOpResult:
 	if face_sets.is_empty():
 		return HFOpResult.fail("Generator: those settings produce no geometry")
 
-	# Materials are what a designer adds after generating, so losing them on every
+	# Appearance is what a designer adds after generating, so losing it on every
 	# radius nudge would make this not worth using. Captured in order and put back
 	# by index; when the piece count changes there is no correspondence past the
 	# shorter list, and the extra pieces take the default.
-	var materials := _capture_materials(record)
+	var appearance := _capture_appearance(record)
 	# Where the structure is now, not where it was made. Read before anything is
 	# deleted, because it is the existing pieces that say where they have gone.
 	record.placement.origin += relocation_delta(generator_id)
 	_delete_brushes(record.brush_ids, generator_id)
 
 	record.settings = settings.duplicate(true)
-	record.brush_ids = _spawn(face_sets, record.placement, generator_id, materials)
+	record.brush_ids = _spawn(face_sets, record.placement, generator_id, appearance)
 	if record.brush_ids.is_empty():
 		generators.erase(generator_id)
 		return HFOpResult.fail("Generator: those settings produce no geometry")
@@ -347,7 +347,7 @@ func clear() -> void:
 
 
 func _spawn(
-	face_sets: Array, placement: Transform3D, generator_id: String, materials: Array
+	face_sets: Array, placement: Transform3D, generator_id: String, appearance: Array
 ) -> PackedStringArray:
 	if root == null or root.get("brush_system") == null:
 		return PackedStringArray()
@@ -359,17 +359,116 @@ func _spawn(
 		if brush == null:
 			continue
 		brush.set_meta(GENERATOR_META, generator_id)
-		if i < materials.size() and materials[i] != null:
-			brush.material_override = materials[i]
+		if i < appearance.size():
+			_apply_appearance(brush, appearance[i])
 	return created
 
 
-func _capture_materials(record: HFGenerator) -> Array:
+## What each piece looks like, in the order the pieces were built.
+##
+## The override material is the whole-brush one. The face entries are what the
+## Paint tab writes, which is per face and is the work most worth not losing:
+## painting a generated arch and then nudging its radius should not reset it.
+func _capture_appearance(record: HFGenerator) -> Array:
 	var out: Array = []
 	for brush_id in record.brush_ids:
 		var brush = _brush(str(brush_id))
-		out.append(brush.material_override if brush else null)
+		if brush == null:
+			out.append({})
+			continue
+		var faces: Array = []
+		for face in brush.faces:
+			faces.append(_face_appearance(face))
+		out.append({"override": brush.material_override, "faces": faces})
 	return out
+
+
+static func _face_appearance(face) -> Dictionary:
+	if face == null:
+		return {}
+	return {
+		"material_idx": face.material_idx,
+		"uv_projection": face.uv_projection,
+		"uv_scale": face.uv_scale,
+		"uv_offset": face.uv_offset,
+		"uv_rotation": face.uv_rotation,
+		"custom_uvs": face.custom_uvs,
+		"paint_layers": face.paint_layers,
+	}
+
+
+## Put back what a piece looked like.
+##
+## Faces are matched by index, which is a real correspondence only while the
+## rebuilt piece has the same faces in the same order. A piece whose face count
+## changed keeps the whole-brush material and takes default faces, and
+## `appearance_at_risk()` is what says so before the rebuild happens.
+static func _apply_appearance(brush, appearance) -> void:
+	if not (appearance is Dictionary) or appearance.is_empty():
+		return
+	if appearance.get("override", null) != null:
+		brush.material_override = appearance["override"]
+	var stored: Array = appearance.get("faces", [])
+	var faces: Array = brush.faces
+	if stored.size() != faces.size():
+		return
+	for i in faces.size():
+		_restore_face(faces[i], stored[i])
+	brush.rebuild_preview()
+
+
+static func _restore_face(face, stored) -> void:
+	if face == null or not (stored is Dictionary) or stored.is_empty():
+		return
+	face.material_idx = int(stored.get("material_idx", -1))
+	face.uv_projection = int(stored.get("uv_projection", face.uv_projection))
+	face.uv_scale = stored.get("uv_scale", face.uv_scale)
+	face.uv_offset = stored.get("uv_offset", face.uv_offset)
+	face.uv_rotation = float(stored.get("uv_rotation", 0.0))
+	var uvs: PackedVector2Array = stored.get("custom_uvs", PackedVector2Array())
+	if uvs.size() == face.local_verts.size():
+		face.custom_uvs = uvs
+	var layers: Array = stored.get("paint_layers", [])
+	if not layers.is_empty():
+		face.paint_layers.assign(layers)
+
+
+## The pieces whose authored appearance a rebuild with these settings could not
+## put back: the ones a shorter piece list drops, and the ones whose faces would
+## no longer line up one to one.
+##
+## Asked before an Update, because that is the last moment the user can choose
+## Detach instead. A piece with nothing authored on it is never at risk; there is
+## nothing there to lose.
+func appearance_at_risk(generator_id: String, settings: Dictionary) -> PackedStringArray:
+	var out := PackedStringArray()
+	if not generators.has(generator_id):
+		return out
+	var record: HFGenerator = generators[generator_id]
+	var face_sets := build_faces(record.type, settings)
+	for i in record.brush_ids.size():
+		var brush = _owned_brush(str(record.brush_ids[i]), generator_id)
+		if brush == null or not _has_authored_faces(brush):
+			continue
+		if i >= face_sets.size() or face_sets[i].size() != brush.faces.size():
+			out.append(str(record.brush_ids[i]))
+	return out
+
+
+## True when any face of the piece carries appearance the Paint tab put there.
+static func _has_authored_faces(brush) -> bool:
+	for face in brush.faces:
+		if face == null:
+			continue
+		if face.material_idx != -1 or not face.paint_layers.is_empty():
+			return true
+		if not face.custom_uvs.is_empty() or not is_zero_approx(face.uv_rotation):
+			return true
+		if not face.uv_scale.is_equal_approx(Vector2.ONE):
+			return true
+		if not face.uv_offset.is_equal_approx(Vector2.ZERO):
+			return true
+	return false
 
 
 ## Delete only the brushes that still say they belong to this generator.

--- a/tests/test_generator_record_lifecycle.gd
+++ b/tests/test_generator_record_lifecycle.gd
@@ -1,0 +1,231 @@
+extends GutTest
+
+## What a generator record owns, and for how long.
+##
+## Painting goes in through `assign_material_to_faces_by_id()`, which is the
+## method the Paint tab actually calls, rather than through `material_override`.
+## Setting the override exercises a different path and would not have caught the
+## defect this covers.
+
+const HFGeneratorSystemScript = preload("res://addons/hammerforge/systems/hf_generator_system.gd")
+const DraftBrush = preload("res://addons/hammerforge/brush_instance.gd")
+
+var root: LevelRoot
+
+
+func before_each() -> void:
+	root = LevelRoot.new()
+	root.auto_spawn_player = false
+	root.commit_freeze = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func after_each() -> void:
+	root = null
+
+
+func _arch(overrides: Dictionary = {}) -> Dictionary:
+	var settings: Dictionary = HFGeneratorSystemScript.default_settings("arch")
+	for key in overrides:
+		settings[key] = overrides[key]
+	return settings
+
+
+func _create_arch(overrides: Dictionary = {}) -> String:
+	var before: Array = root.generator_system.generators.keys()
+	assert_true(root.create_generator("arch", _arch(overrides), Transform3D.IDENTITY).ok)
+	for generator_id in root.generator_system.generators:
+		if not (generator_id in before):
+			return str(generator_id)
+	return ""
+
+
+func _record(generator_id: String):
+	return root.generator_system.generators[generator_id]
+
+
+func _piece(generator_id: String, index: int) -> DraftBrush:
+	return root.brush_system.find_brush_by_id(str(_record(generator_id).brush_ids[index]))
+
+
+## Paint one face the way the Paint tab does.
+func _paint_face(generator_id: String, piece_index: int, face_index: int, material: int) -> void:
+	var brush_id := str(_record(generator_id).brush_ids[piece_index])
+	root.assign_material_to_faces_by_id(brush_id, [face_index], material)
+	assert_eq(
+		root.brush_system.find_brush_by_id(brush_id).faces[face_index].material_idx,
+		material,
+		"the fixture has to actually paint something"
+	)
+
+
+# ===========================================================================
+# Appearance survives a rebuild (#190)
+# ===========================================================================
+
+
+func test_a_painted_face_survives_a_radius_change():
+	var generator_id := _create_arch()
+	_paint_face(generator_id, 0, 0, 7)
+
+	assert_true(root.regenerate_generator(generator_id, _arch({"radius": 192.0})).ok)
+
+	assert_eq(
+		_piece(generator_id, 0).faces[0].material_idx,
+		7,
+		"changing a setting must not reset the paint the feature promises to keep"
+	)
+
+
+func test_uv_edits_survive_a_rebuild():
+	var generator_id := _create_arch()
+	var face = _piece(generator_id, 1).faces[2]
+	face.uv_offset = Vector2(9, 4)
+	face.uv_scale = Vector2(2, 3)
+	face.uv_rotation = 0.75
+	face.uv_projection = FaceData.UVProjection.PLANAR_X
+
+	assert_true(root.regenerate_generator(generator_id, _arch({"radius": 160.0})).ok)
+
+	var rebuilt = _piece(generator_id, 1).faces[2]
+	assert_almost_eq(rebuilt.uv_offset.x, 9.0, 0.001)
+	assert_almost_eq(rebuilt.uv_scale.y, 3.0, 0.001)
+	assert_almost_eq(rebuilt.uv_rotation, 0.75, 0.001)
+	assert_eq(rebuilt.uv_projection, FaceData.UVProjection.PLANAR_X)
+
+
+func test_every_painted_face_keeps_its_own_material():
+	var generator_id := _create_arch()
+	_paint_face(generator_id, 0, 0, 3)
+	_paint_face(generator_id, 0, 2, 8)
+
+	assert_true(root.regenerate_generator(generator_id, _arch({"depth": 96.0})).ok)
+
+	var faces = _piece(generator_id, 0).faces
+	assert_eq(faces[0].material_idx, 3, "faces are put back one for one, not all the same")
+	assert_eq(faces[2].material_idx, 8)
+	assert_eq(faces[1].material_idx, -1, "and an unpainted face stays unpainted")
+
+
+func test_the_whole_brush_material_still_survives():
+	var generator_id := _create_arch()
+	var material := StandardMaterial3D.new()
+	_piece(generator_id, 0).material_override = material
+
+	assert_true(root.regenerate_generator(generator_id, _arch({"radius": 160.0})).ok)
+
+	assert_same(_piece(generator_id, 0).material_override, material)
+
+
+func test_extra_pieces_take_the_default():
+	var generator_id := _create_arch({"segments": 9})
+	_paint_face(generator_id, 0, 0, 5)
+
+	assert_true(root.regenerate_generator(generator_id, _arch({"segments": 11})).ok)
+
+	assert_eq(_record(generator_id).brush_ids.size(), 11)
+	assert_eq(_piece(generator_id, 0).faces[0].material_idx, 5, "the matched piece keeps its face")
+	assert_eq(_piece(generator_id, 10).faces[0].material_idx, -1, "the new one starts plain")
+
+
+# ===========================================================================
+# Saying so when it cannot be kept (#190)
+# ===========================================================================
+
+
+func test_nothing_is_at_risk_when_the_pieces_line_up():
+	var generator_id := _create_arch()
+	_paint_face(generator_id, 0, 0, 7)
+
+	var at_risk := root.generator_appearance_at_risk(generator_id, _arch({"radius": 192.0}))
+
+	assert_eq(
+		at_risk.size(), 0, "a radius nudge keeps every face, so there is nothing to warn about"
+	)
+
+
+func test_a_painted_piece_that_would_be_dropped_is_named():
+	var generator_id := _create_arch({"segments": 9})
+	_paint_face(generator_id, 8, 0, 7)
+
+	var at_risk := root.generator_appearance_at_risk(generator_id, _arch({"segments": 5}))
+
+	assert_eq(at_risk.size(), 1, "the painted piece past the new end is at risk")
+	assert_eq(str(at_risk[0]), str(_record(generator_id).brush_ids[8]))
+
+
+func test_an_unpainted_piece_that_would_be_dropped_is_not_named():
+	var generator_id := _create_arch({"segments": 9})
+
+	var at_risk := root.generator_appearance_at_risk(generator_id, _arch({"segments": 5}))
+
+	assert_eq(at_risk.size(), 0, "there is nothing on those pieces to lose")
+
+
+# ===========================================================================
+# Whole-level replacement (#191)
+# ===========================================================================
+
+
+func test_clearing_the_brushes_clears_the_records():
+	_create_arch()
+	assert_eq(root.generator_count(), 1)
+
+	root.clear_brushes()
+
+	assert_eq(root.generator_count(), 0, "a record without geometry is an orphan")
+
+
+func test_a_replacing_map_import_leaves_no_orphan_record():
+	_create_arch()
+	var path := "user://hf_test_replacement.map"
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	file.store_string(_minimal_map_text())
+	file.close()
+
+	assert_eq(root.import_map(path), OK)
+
+	assert_eq(root.generator_count(), 0, "the arch is gone, so its record has to be too")
+	assert_eq(root.capture_state().get("generators", []).size(), 0, "and it is not saved either")
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+
+
+func test_undoing_a_replacement_brings_the_records_back():
+	var generator_id := _create_arch()
+	var before := root.capture_state()
+
+	root.clear_brushes()
+	assert_eq(root.generator_count(), 0)
+
+	root.restore_state(before)
+
+	assert_eq(root.generator_count(), 1, "undo restores the records with the geometry")
+	assert_true(root.has_generator(generator_id))
+	assert_eq(_record(generator_id).brush_ids.size(), before["generators"][0]["brush_ids"].size())
+
+
+func test_deleting_one_generated_piece_still_keeps_the_record():
+	# That record is what warns about the gap and rebuilds it, so this behaviour is
+	# deliberate and has to stay.
+	var generator_id := _create_arch()
+
+	root.delete_brush_by_id(str(_record(generator_id).brush_ids[0]))
+
+	assert_eq(root.generator_count(), 1)
+
+
+func _minimal_map_text() -> String:
+	return """// replacement
+{
+"classname" "worldspawn"
+{
+( -64 -64 -16 ) ( -64 -63 -16 ) ( -64 -64 -15 ) FLOOR 0 0 0 1 1
+( -64 -64 -16 ) ( -64 -64 -15 ) ( -63 -64 -16 ) FLOOR 0 0 0 1 1
+( -64 -64 -16 ) ( -63 -64 -16 ) ( -64 -63 -16 ) FLOOR 0 0 0 1 1
+( 64 64 16 ) ( 64 65 16 ) ( 65 64 16 ) FLOOR 0 0 0 1 1
+( 64 64 16 ) ( 65 64 16 ) ( 64 64 17 ) FLOOR 0 0 0 1 1
+( 64 64 16 ) ( 64 64 17 ) ( 64 65 16 ) FLOOR 0 0 0 1 1
+}
+}
+"""

--- a/tests/test_structure_dock_commands.gd
+++ b/tests/test_structure_dock_commands.gd
@@ -161,6 +161,54 @@ func test_a_refused_update_does_not_report_a_rebuild():
 
 
 # ===========================================================================
+# Rebuilding over painted faces
+# ===========================================================================
+
+
+func test_an_update_that_would_drop_paint_warns_before_it_does_it():
+	_set_field("segments", 9.0)
+	_create_then_select_a_piece()
+	# The last piece is the one a shorter arch would not have.
+	var last := str(_only_record().brush_ids[8])
+	root.assign_material_to_faces_by_id(last, [0], 7)
+	_set_field("segments", 5.0)
+
+	dock._on_create_structure()
+
+	assert_eq(_only_record().brush_ids.size(), 9, "the first press must not rebuild")
+	assert_true(dock.structure_warning.visible, "the warning has to be shown")
+	assert_true(
+		dock.structure_warning.text.contains("Detach"),
+		"and has to offer the other way out: got '%s'" % dock.structure_warning.text
+	)
+
+
+func test_pressing_update_again_goes_ahead():
+	_set_field("segments", 9.0)
+	_create_then_select_a_piece()
+	root.assign_material_to_faces_by_id(str(_only_record().brush_ids[8]), [0], 7)
+	_set_field("segments", 5.0)
+
+	dock._on_create_structure()
+	dock._on_create_structure()
+
+	assert_eq(_status(), "Arch rebuilt")
+	assert_eq(_only_record().brush_ids.size(), 5)
+
+
+func test_an_update_that_keeps_the_paint_does_not_warn():
+	_create_then_select_a_piece()
+	root.assign_material_to_faces_by_id(str(_only_record().brush_ids[0]), [0], 7)
+	_set_field("radius", 192.0)
+
+	dock._on_create_structure()
+
+	assert_eq(_status(), "Arch rebuilt", "a radius nudge keeps every face, so it just rebuilds")
+	var rebuilt = root.brush_system.find_brush_by_id(str(_only_record().brush_ids[0]))
+	assert_eq(rebuilt.faces[0].material_idx, 7, "and the paint is still there")
+
+
+# ===========================================================================
 # The advertised shortcut (#198)
 # ===========================================================================
 


### PR DESCRIPTION
Fixes #190
Fixes #191

Stacked on #203, which this needs for the dock to be able to report anything truthfully.

**Appearance (#190).** `regenerate()` captured only `DraftBrush.material_override`. The Paint tab writes `FaceData.material_idx`, per-face UV projection, scale, offset and rotation, custom UVs and paint layers, and none of it survived a rebuild. `_capture_appearance()` now takes all of it and `_apply_appearance()` puts it back, matched by piece index and then by face index.

Face index is a real correspondence only while the rebuilt piece has the same faces. `appearance_at_risk()` names the painted pieces a given set of settings could not put back: the ones a shorter piece list drops, and the ones whose face count would change. The dock asks before an Update, shows the warning, and waits for a second press. Detach is the other way out and is already beside the button.

**Records (#191).** `HFBrushSystem.clear_brushes()` never touched the generator system, so `import_map()` and `_load_example_data()` replaced the geometry and kept the records for what they had just deleted. Those orphans went into every later undo snapshot and every `.hflevel` save. It clears them now. `restore_state()` calls `clear_brushes()` and then restores the records for the state it is restoring, so undo is unaffected, and deleting one generated piece still leaves its record alone because that record is what warns about the gap and rebuilds it.

Coverage in `tests/test_generator_record_lifecycle.gd`, painting through `assign_material_to_faces_by_id()` because that is the method the Paint tab calls. Setting `material_override` exercises a different path, which is why the tests added with #188 did not catch this. Ten of the twelve fail on `main`. Three more dock-level tests in `tests/test_structure_dock_commands.gd` cover the warning, the second press, and an update that keeps the paint and so does not warn.