### PR TITLE
Centre open stairs on the geometry they emit

### DIFF
--- a/addons/hammerforge/hf_spiral_stairs_builder.gd
+++ b/addons/hammerforge/hf_spiral_stairs_builder.gd
@@ -183,7 +183,18 @@ static func build(settings: Dictionary) -> Array:
 	var start := deg_to_rad(float(merged["start_degrees"]))
 
 	var climb := float(steps) * rise
-	var y_shift := -climb * 0.5
+	var has_post := bool(merged["center_post"])
+	var post_height := maxf(climb, thickness)
+	# Centred on the geometry actually emitted. The treads start at the underside
+	# of the first one rather than at the foot of the climb, so a flight without a
+	# post to fill that gap would otherwise sit half a tread high. With a post this
+	# comes out at the same place it always did.
+	var lowest := rise - thickness
+	var highest := climb
+	if has_post:
+		lowest = minf(lowest, 0.0)
+		highest = maxf(highest, post_height)
+	var y_shift := -(lowest + highest) * 0.5
 
 	var out: Array = []
 	for i in steps:
@@ -191,8 +202,8 @@ static func build(settings: Dictionary) -> Array:
 		var a0 := start + turn * float(i)
 		var a1 := start + turn * float(i + 1)
 		out.append(_tread_faces(outer, inner, a0, a1, top - thickness, top))
-	if bool(merged["center_post"]):
-		out.append(_post_faces(inner, y_shift, y_shift + maxf(climb, thickness)))
+	if has_post:
+		out.append(_post_faces(inner, y_shift, y_shift + post_height))
 	return out
 
 

--- a/addons/hammerforge/hf_stairs_builder.gd
+++ b/addons/hammerforge/hf_stairs_builder.gd
@@ -140,8 +140,13 @@ static func build(settings: Dictionary) -> Array:
 	var thickness: float = merged["tread_thickness"]
 
 	# Centred on its own middle, the way every other generator is, so placing it
-	# on a selection puts the middle of the flight where you were looking.
-	var y_shift := -float(steps) * rise * 0.5
+	# on a selection puts the middle of the flight where you were looking. That
+	# has to be the middle of the geometry actually emitted: an open flight starts
+	# at the underside of its first tread, not at the foot of the climb, so
+	# centring on the nominal climb would leave it half a tread out.
+	var lowest := (rise - thickness) if open_treads else 0.0
+	var highest := float(steps) * rise
+	var y_shift := -(lowest + highest) * 0.5
 	var z_shift := -float(steps) * tread * 0.5
 
 	var out: Array = []

--- a/tests/test_spiral_stairs_builder.gd
+++ b/tests/test_spiral_stairs_builder.gd
@@ -105,6 +105,38 @@ func test_the_flight_is_centred_on_its_own_origin_vertically():
 	assert_almost_eq(box.get_center().y, 0.0, EPS)
 
 
+func test_a_postless_flight_is_centred_too():
+	# The post used to fill the gap under the first tread and hide the fact that
+	# the treads alone were centred on the climb rather than on themselves.
+	var box: AABB = SolidChecks.structure_bounds(
+		HFSpiralStairsBuilderScript.build(_settings({"center_post": false}))
+	)
+	assert_almost_eq(box.get_center().y, 0.0, EPS, "a postless spiral sat above its origin")
+
+
+func test_a_postless_flight_stays_centred_at_other_rises_and_thicknesses():
+	for overrides in [
+		{"center_post": false, "rise": 24.0, "tread_thickness": 4.0},
+		{"center_post": false, "rise": 12.0, "tread_thickness": 12.0},
+		{"center_post": false, "rise": 10.0, "tread_thickness": 20.0, "steps": 6},
+	]:
+		var box: AABB = SolidChecks.structure_bounds(
+			HFSpiralStairsBuilderScript.build(_settings(overrides))
+		)
+		assert_almost_eq(box.get_center().y, 0.0, EPS, "off centre for %s" % overrides)
+
+
+func test_a_flight_with_a_post_stays_centred_at_other_rises_and_thicknesses():
+	for overrides in [
+		{"center_post": true, "rise": 24.0, "tread_thickness": 4.0},
+		{"center_post": true, "rise": 10.0, "tread_thickness": 20.0, "steps": 6},
+	]:
+		var box: AABB = SolidChecks.structure_bounds(
+			HFSpiralStairsBuilderScript.build(_settings(overrides))
+		)
+		assert_almost_eq(box.get_center().y, 0.0, EPS, "off centre for %s" % overrides)
+
+
 func test_turning_the_other_way_mirrors_rather_than_breaks():
 	var clockwise: Array = _treads({"degrees_per_step": -30.0})
 	assert_eq(clockwise.size(), 12)

--- a/tests/test_stairs_builder.gd
+++ b/tests/test_stairs_builder.gd
@@ -73,6 +73,40 @@ func test_the_flight_is_centred_on_its_own_origin():
 	assert_almost_eq(centre.z, 0.0, EPS)
 
 
+func test_an_open_flight_is_centred_on_its_own_origin_too():
+	# An open flight starts at the underside of its first tread, so it does not
+	# span the whole climb. Centring on the climb left it half a tread high.
+	var box: AABB = SolidChecks.structure_bounds(
+		HFStairsBuilderScript.build(_settings({"fill": 1}))
+	)
+	assert_almost_eq(box.get_center().y, 0.0, EPS, "an open flight sat above its placement point")
+
+
+func test_an_open_flight_stays_centred_at_other_rises_and_thicknesses():
+	for overrides in [
+		{"fill": 1, "rise": 24.0, "tread_thickness": 4.0},
+		{"fill": 1, "rise": 12.0, "tread_thickness": 12.0},
+		{"fill": 1, "rise": 10.0, "tread_thickness": 20.0, "steps": 6},
+	]:
+		var box: AABB = SolidChecks.structure_bounds(
+			HFStairsBuilderScript.build(_settings(overrides))
+		)
+		assert_almost_eq(box.get_center().y, 0.0, EPS, "off centre for %s" % overrides)
+
+
+func test_an_open_flight_still_reaches_the_same_top_step():
+	# Centring moves the flight, it does not change how tall it is.
+	var flight: Array = HFStairsBuilderScript.build(_settings({"fill": 1}))
+	var box: AABB = SolidChecks.structure_bounds(flight)
+	var settings := _settings()
+	var rise: float = settings["rise"]
+	var thickness: float = settings["tread_thickness"]
+	var steps: int = settings["steps"]
+	assert_almost_eq(
+		box.size.y, float(steps) * rise - (rise - thickness), EPS, "the flight changed height"
+	)
+
+
 func test_each_step_is_exactly_one_tread_on_and_one_rise_up():
 	var flight: Array = HFStairsBuilderScript.build(
 		_settings({"steps": 6, "rise": 12.0, "tread": 40.0})


### PR DESCRIPTION
Fixes #193

`HFStairsBuilder.build()` and `HFSpiralStairsBuilder.build()` both set `y_shift` from the nominal climb. An open flight spans from the underside of its first tread to the top of its last, which is `rise - tread_thickness` short of the climb, so it sat half that above the placement point. With the defaults, rise 16 and thickness 8, that is the four units the issue measured.

Both now take the lowest and highest Y they actually emit and centre on those. The spiral includes its centre post when it has one, so the post case comes out exactly where it always did.

That also fixed a case the issue did not name: a spiral with a post whose treads are thicker than the rise reaches below the foot of the post, and was off centre the other way. Rise 10 with a thickness of 20 measured minus five. Covered.

Coverage in `tests/test_stairs_builder.gd` and `tests/test_spiral_stairs_builder.gd`: open straight flights and postless spirals at the defaults and at three other rise and thickness combinations, the post case held to the same standard, and a check that centring moved the flight without changing its height. Five fail on `main`, reporting exactly the four unit offset from the issue.