### PR TITLE
Find rotated brushes where they actually reach, and stop claiming Hollow refuses them

### DIFF
--- a/addons/hammerforge/plugin_edit_actions.gd
+++ b/addons/hammerforge/plugin_edit_actions.gd
@@ -605,8 +605,10 @@ static func flip_selected(plugin: Object, root: Node) -> bool:
 	return true
 
 
-## Clear rotation on the selected brushes. This is the way back to hollow, clip,
-## and carve, all three of which refuse a rotated brush.
+## Clear rotation on the selected brushes, keeping their position and size.
+##
+## Hollow, clip and carve all work in the brush's own frame now, so this is a
+## tidying command rather than the way back to any of them.
 static func reset_rotation_selected(plugin: Object, root: Node) -> bool:
 	if not root:
 		return false

--- a/addons/hammerforge/systems/hf_carve_system.gd
+++ b/addons/hammerforge/systems/hf_carve_system.gd
@@ -168,8 +168,14 @@ static func _brush_id_of(brush: Node) -> String:
 	return bid
 
 
-## Find all DraftBrush nodes whose AABB overlaps the given AABB,
+## Find all DraftBrush nodes whose world bounds overlap the given AABB,
 ## excluding the brush with the given ID.
+##
+## The bounds come from `world_bounds_of()` rather than from `position` and
+## `size`, because those two describe the brush before it was turned. A rotated
+## brush reaches outside that box, and a rejection that reads the wrong box is
+## not a cheap rejection, it is a wrong answer: the carve reported no overlapping
+## brushes and did nothing.
 func _find_overlapping_brushes(exclude_id: String, aabb: AABB) -> Array:
 	var result: Array = []
 	for node in root._iter_pick_nodes():
@@ -178,10 +184,7 @@ func _find_overlapping_brushes(exclude_id: String, aabb: AABB) -> Array:
 		var draft := node as DraftBrush
 		if _brush_id_of(draft) == exclude_id:
 			continue
-		var node_pos: Vector3 = draft.global_position
-		var node_size: Vector3 = draft.size
-		var node_aabb := AABB(node_pos - node_size * 0.5, node_size)
-		if aabb.intersects(node_aabb):
+		if aabb.intersects(root.brush_system.world_bounds_of(draft)):
 			result.append(draft)
 	return result
 

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -393,10 +393,8 @@ cut leaves a few pieces and a slot driven right through leaves two.
 A carver that would swallow a brush entirely leaves that brush alone rather than
 deleting it — nothing vanishes without a preview showing it first.
 
-> Hollow (`Ctrl+H`) is the one cutting-adjacent tool that still needs an unrotated
-> box. It builds walls by insetting every face inward off the brush's width, height
-> and depth, which only describe the brush while it is unrotated. Use **Reset
-> Rotation** (`Alt+R`) first.
+> Hollow (`Ctrl+H`) handles rotation too. It shells a brush against its own face
+> planes, so a turned box gives you six turned walls. See [Hollow](#hollow).
 
 ## Rotating and Mirroring
 
@@ -429,15 +427,14 @@ brush turns underneath them. Turn it off if you want the texture to ride along.
 
 Clip and Carve both handle rotation — they cut the real geometry wherever it is.
 
-**Hollow is the one that will refuse a rotated brush.** It measures a brush's
-extent straight off its size along the world axes, which is only true while the
-brush is unrotated, and hollowing anyway would build the walls in the wrong place.
-It will tell you so, and **Reset Rotation** (`Alt+R`) is the way back.
+Hollow handles it as well. It shells a brush against its own face planes, so a
+turned box gives you six turned walls rather than a refusal.
 
-Reset Rotation does not move your geometry. If you turned a brush by exactly 90°,
-it folds that quarter turn into the brush's dimensions instead of snapping the
-brush back to its old footprint, so the brush stays exactly where it looks like it
-is and Hollow works again.
+So **Reset Rotation** (`Alt+R`) is there for when you want a brush square again,
+not because anything has stopped working on it. It does not move your geometry: if
+you turned a brush by exactly 90°, it folds that quarter turn into the brush's
+dimensions instead of snapping the brush back to its old footprint, so the brush
+stays exactly where it looks like it is.
 
 ### Flip
 

--- a/tests/test_carve_tool.gd
+++ b/tests/test_carve_tool.gd
@@ -352,6 +352,30 @@ func test_a_rotated_target_is_carved():
 		assert_eq(_open_edge_count(piece), 0)
 
 
+func test_a_rotated_target_is_found_where_it_actually_reaches():
+	# The broad phase used to build the candidate box from position and size,
+	# which describe a brush before it was turned. A long brush at 45 degrees
+	# reaches well outside that box, and carve reported no overlapping brushes.
+	var target := _make_brush(Vector3.ZERO, Vector3(400, 64, 32), "target")
+	target.rotation_degrees = Vector3(0, 45, 0)
+	target.rebuild_preview()
+	var naive := AABB(target.global_position - target.size * 0.5, target.size)
+	# A yaw of 45 sends local +X to (0.707, 0, -0.707), so the far end of the
+	# target is out along +X and -Z. That is solid geometry, not an empty corner
+	# of its bounding box.
+	var carver := _make_brush(Vector3(130, 0, -130), Vector3(48, 200, 48), "carver")
+	assert_false(
+		naive.intersects(AABB(carver.global_position - carver.size * 0.5, carver.size)),
+		"the fixture only means something while the unturned boxes miss each other"
+	)
+
+	var result = carve.carve_with_brush("carver")
+
+	assert_true(result.ok, "the turned end of the target is real geometry: %s" % result.message)
+	for piece in _pieces():
+		assert_eq(_open_edge_count(piece), 0)
+
+
 func test_a_cylinder_carver_carves():
 	_make_brush(Vector3.ZERO, Vector3(64, 64, 64), "target")
 	_make_brush(Vector3(0, 0, 0), Vector3(24, 200, 24), "carver", DraftBrush.BrushShape.CYLINDER)


### PR DESCRIPTION
No issue. Found in a triage pass over the tracker after it was cleared; both of these predate the recent cutting and transform work.

**Carve missed rotated targets (`hf_carve_system.gd`).** `_find_overlapping_brushes()` built each candidate's box from `global_position` and `size`. Those describe the brush before it was turned, so a rotated brush reaches outside it. Measured on `main` with a 400x64x32 box yawed 45 degrees:

```
true world bounds = P(-152.7, -32, -152.7)  S(305.5, 64, 305.5)
broad phase box   = P(-200,   -32,  -16)    S(400,   64,  32)
carve -> "Carve: no overlapping brushes found"
```

The carver was sitting on solid geometry at the far end of the target and the cut silently did not happen. It reads `world_bounds_of()` now, which is what the narrow phase two lines later already used. `precision-cutting-design.md` called the broad phase "a cheap rejection, not a correctness assumption" — for a rotated target that was the one thing it was not.

**Three stale claims that Hollow refuses rotation.** It stopped refusing when it moved to shelling a brush against its own face planes. `can_hollow_brush()` on a brush yawed 37 degrees returns ok and produces six walls. Corrected in the doc comment on `reset_rotation_selected()`, in the callout at the end of the cutting section, and in **After you rotate**, which sent the reader to Reset Rotation as the way back from a problem that no longer exists. The guide already described the current behaviour correctly under **Hollow** itself, so it was contradicting itself two sections apart.

`test_a_rotated_target_is_found_where_it_actually_reaches` fails on `main` with the exact message above. It asserts up front that the two unturned boxes miss each other, so the fixture cannot quietly stop testing what it is for.