### PR TITLE
Let CI write the published test totals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
   unit-tests:
     name: GUT Unit Tests
     runs-on: ubuntu-latest
+    # Only the push-to-main run writes the totals back; a pull request run has
+    # nothing to push to and leaves the documents alone.
+    permissions:
+      contents: write
     env:
       GODOT_VERSION: "4.7-stable"
     steps:
@@ -56,5 +60,39 @@ jobs:
 
       - name: Run GUT tests
         run: |
-          godot --headless -s res://addons/gut/gut_cmdln.gd --path . 2>&1
-          exit $?
+          set -o pipefail
+          godot --headless -s res://addons/gut/gut_cmdln.gd --path . 2>&1 | tee gut.log
+
+      # The five documents that quote the size of the suite go stale on any pull
+      # request that adds a test. CI has just measured them, so CI writes them
+      # down rather than asking every contributor to.
+      - name: Update published test counts
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: python3 tools/update_test_counts.py --gut-log gut.log --write
+
+      - name: Commit updated counts
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          if git diff --quiet; then
+            echo "Counts already current, nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          # [skip ci] plus the fact that a GITHUB_TOKEN push raises no workflow
+          # event: this cannot start a run that writes the counts again.
+          git commit -m "Update published test counts [skip ci]"
+          # Another merge may have landed while the suite was running, which
+          # would make this push non-fast-forward. Rebase onto whatever main is
+          # now and try once more rather than failing a green build over it.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Push rejected, rebasing onto main (attempt $attempt)."
+            git fetch origin main
+            git rebase origin/main || { git rebase --abort; exit 1; }
+          done
+          echo "Could not push the updated counts after three attempts."
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ prompt for what's actually needed to act on them.
 - Verify behavior claims against current code and tests. Do not copy test totals or source line counts from an older document.
 - Update the README, relevant guide/spec, roadmap status, and `[Unreleased]` changelog together when a change affects users or contributors.
 - Only publish aggregate test totals from a successful full CI run; include the verification date so readers can distinguish a measured snapshot from a permanent guarantee.
+- You do not have to update the published totals yourself. CI measures them on every push to `main` and rewrites the five documents that quote them, so a pull request that adds tests can leave those numbers alone. To see what it would write, run `python tools/update_test_counts.py --gut-log <your test log> --check`.
 - Check relative Markdown links and `git diff --check` before submitting documentation-only changes.
 - Describe known limitations plainly and link the tracking issue instead of implying unfinished safety or fidelity work is complete.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -399,7 +399,7 @@ addons/hammerforge/
 The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs on push and PR to `main`:
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
-- **GUT unit + integration tests** -- 2,889 tests across 152 test scripts (2,882 passing plus seven intentional no-assert safety tests; 15,291 assertions; verified locally September 8, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 2,889 tests across 152 test scripts (2,882 passing plus seven intentional no-assert safety tests; 15,291 assertions; verified in CI on September 8, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```
@@ -407,6 +407,19 @@ gdformat --check addons/hammerforge/ tests/
 gdlint addons/hammerforge/
 godot --headless -s res://addons/gut/gut_cmdln.gd --path .
 ```
+
+**Published test totals look after themselves.** Five documents quote the size of
+the suite, and every pull request that adds a test would otherwise invalidate all
+five. The push-to-`main` CI run measures the suite and rewrites them in a
+follow-up commit, so leave those numbers alone in a pull request. To see what CI
+would write, redirect a run and ask:
+```
+godot --headless -s res://addons/gut/gut_cmdln.gd --path . > gut.log 2>&1
+python tools/update_test_counts.py --gut-log gut.log --check
+```
+`--write` applies it. The patterns are anchored on the sentences around each
+number, so rewording one of those sentences makes the tool fail loudly rather
+than leave a stale figure behind — the message names the file to fix.
 
 ### VS Code Integration
 

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -532,6 +532,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 38 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified locally on September 8, 2026): **2,889 tests** across **152 scripts** (**2,882 passing** plus seven intentional no-assert safety tests; **15,291 assertions**).
+Full suite (verified in CI on September 8, 2026): **2,889 tests** across **152 scripts** (**2,882 passing** plus seven intentional no-assert safety tests; **15,291 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/tools/update_test_counts.py
+++ b/tools/update_test_counts.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Keep the published test totals in step with what the suite actually reports.
+
+Five documents quote the size of the test suite. Every pull request that adds a
+test invalidates all five at once, and a number nobody re-measured is worse than
+no number at all -- CONTRIBUTING.md asks for totals from a successful full CI
+run, with the date they were measured.
+
+So CI measures them and this writes them down.
+
+    python tools/update_test_counts.py --gut-log gut.log --write
+    python tools/update_test_counts.py --gut-log gut.log --check
+
+--check changes nothing and exits 1 when a document disagrees with the log,
+naming the ones that do.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import io
+import re
+import sys
+
+MONTHS = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+]
+
+NUMBER_WORDS = {
+    0: "no",
+    1: "one",
+    2: "two",
+    3: "three",
+    4: "four",
+    5: "five",
+    6: "six",
+    7: "seven",
+    8: "eight",
+    9: "nine",
+    10: "ten",
+}
+
+
+def today() -> str:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return "%s %d, %d" % (MONTHS[now.month - 1], now.day, now.year)
+
+
+def word(n: int) -> str:
+    """Small counts read better spelled out, which is how the docs write them."""
+    return NUMBER_WORDS.get(n, str(n))
+
+
+def grouped(n: int) -> str:
+    return "{:,}".format(n)
+
+
+def parse_gut_log(path: str) -> dict:
+    """Pull the totals out of GUT's own summary block."""
+    text = io.open(path, encoding="utf-8", errors="replace").read()
+    required = {
+        "scripts": r"^Scripts\s+(\d+)\s*$",
+        "tests": r"^Tests\s+(\d+)\s*$",
+        "passing": r"^Passing Tests\s+(\d+)\s*$",
+        "asserts": r"^Asserts\s+(\d+)\s*$",
+    }
+    counts = {}
+    for key, pattern in required.items():
+        found = re.findall(pattern, text, re.MULTILINE)
+        if not found:
+            raise SystemExit(
+                "update_test_counts: no '%s' total in %s. This reads GUT's own "
+                "summary block, so the log has to be the full test output." % (key, path)
+            )
+        counts[key] = int(found[-1])
+    # Absent from the summary when there are none of them.
+    for key, pattern in [
+        ("risky", r"^Risky/Pending\s+(\d+)\s*$"),
+        ("failing", r"^Failing Tests\s+(\d+)\s*$"),
+    ]:
+        found = re.findall(pattern, text, re.MULTILINE)
+        counts[key] = int(found[-1]) if found else 0
+    return counts
+
+
+def rewrites(c: dict, date: str) -> list:
+    """One (path, pattern, replacement) per number this owns.
+
+    Patterns are anchored on the prose around the number rather than on the
+    number itself, so a reworded sentence fails loudly here instead of silently
+    leaving a stale figure behind.
+    """
+    common = {
+        "date": date,
+        "tests": grouped(c["tests"]),
+        "scripts": grouped(c["scripts"]),
+        "passing": grouped(c["passing"]),
+        "asserts": grouped(c["asserts"]),
+        "risky": word(c["risky"]),
+    }
+    return [
+        (
+            "README.md",
+            r'Tests-\d+%20passing-brightgreen" alt="\d+ tests passing"',
+            # Plain digits, not grouped: this is a URL path segment.
+            'Tests-{p}%20passing-brightgreen" alt="{p} tests passing"'.format(
+                p=c["passing"]
+            ),
+        ),
+        (
+            "docs/features.md",
+            r"The verified Godot 4\.7 suite on .+? contains \*\*[\d,]+ tests across "
+            r"[\d,]+ scripts\*\*: \*\*[\d,]+ passing tests\*\*, \w+ intentional "
+            r"no-assert safety tests, and \*\*[\d,]+ assertions\*\*\.",
+            (
+                "The verified Godot 4.7 suite on {date} contains **{tests} tests "
+                "across {scripts} scripts**: **{passing} passing tests**, {risky} "
+                "intentional no-assert safety tests, and **{asserts} assertions**."
+            ).format(**common),
+        ),
+        (
+            "DEVELOPMENT.md",
+            r"- \*\*GUT unit \+ integration tests\*\* -- [\d,]+ tests across [\d,]+ "
+            r"test scripts \([\d,]+ passing plus \w+ intentional no-assert safety "
+            r"tests; [\d,]+ assertions; verified .+?; runs Godot headless\)",
+            (
+                "- **GUT unit + integration tests** -- {tests} tests across "
+                "{scripts} test scripts ({passing} passing plus {risky} intentional "
+                "no-assert safety tests; {asserts} assertions; verified in CI on "
+                "{date}; runs Godot headless)"
+            ).format(**common),
+        ),
+        (
+            "HammerForge_SPEC.md",
+            r"Full suite \(verified .+?\): \*\*[\d,]+ tests\*\* across \*\*[\d,]+ "
+            r"scripts\*\* \(\*\*[\d,]+ passing\*\* plus \w+ intentional no-assert "
+            r"safety tests; \*\*[\d,]+ assertions\*\*\)\.",
+            (
+                "Full suite (verified in CI on {date}): **{tests} tests** across "
+                "**{scripts} scripts** (**{passing} passing** plus {risky} "
+                "intentional no-assert safety tests; **{asserts} assertions**)."
+            ).format(**common),
+        ),
+        (
+            "ROADMAP.md",
+            r"The current suite covers [\d,]+ tests across [\d,]+ scripts,",
+            "The current suite covers {tests} tests across {scripts} scripts,".format(
+                **common
+            ),
+        ),
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gut-log", required=True, help="file holding GUT's output")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--write", action="store_true", help="rewrite the documents")
+    mode.add_argument(
+        "--check", action="store_true", help="report drift, change nothing"
+    )
+    parser.add_argument(
+        "--date", default=today(), help="verification date to write (default: today UTC)"
+    )
+    args = parser.parse_args()
+
+    counts = parse_gut_log(args.gut_log)
+    if counts["failing"]:
+        raise SystemExit(
+            "update_test_counts: %d failing tests in the log. A total is only worth "
+            "publishing from a green run." % counts["failing"]
+        )
+
+    summary = "%s tests across %s scripts, %s passing, %s assertions" % (
+        grouped(counts["tests"]),
+        grouped(counts["scripts"]),
+        grouped(counts["passing"]),
+        grouped(counts["asserts"]),
+    )
+
+    stale = []
+    for path, pattern, replacement in rewrites(counts, args.date):
+        original = io.open(path, encoding="utf-8").read()
+        # A function replacement so nothing in the text is read as a group
+        # reference or an escape.
+        updated, hits = re.subn(pattern, lambda _m: replacement, original, count=1)
+        if hits == 0:
+            raise SystemExit(
+                "update_test_counts: nothing matched in %s. The sentence this owns "
+                "was reworded or removed; update its pattern in "
+                "tools/update_test_counts.py." % path
+            )
+        if updated == original:
+            continue
+        stale.append(path)
+        if args.write:
+            io.open(path, "w", encoding="utf-8", newline="\n").write(updated)
+
+    if args.check:
+        if stale:
+            print("Out of date (%s):" % summary)
+            for path in stale:
+                print("  %s" % path)
+            print("Run: python tools/update_test_counts.py --gut-log <log> --write")
+            return 1
+        print("Test counts are current (%s)." % summary)
+        return 0
+
+    if stale:
+        print("Updated to %s:" % summary)
+        for path in stale:
+            print("  %s" % path)
+    else:
+        print("Test counts already current (%s)." % summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Ends the count treadmill. Five documents quote the size of the suite — the README badge, `docs/features.md`, `DEVELOPMENT.md`, `HammerForge_SPEC.md` and `ROADMAP.md` — and any pull request that adds a test invalidates all five. `CONTRIBUTING.md` asks for totals from a successful full CI run with the measurement date, which is precisely what a contributor cannot produce while writing the change that moves them. Four of the pull requests merged today had to touch those numbers by hand.

**How it works.** `tools/update_test_counts.py` reads GUT's own summary block and rewrites the five. The GUT step now tees to `gut.log`; on a push to `main` the workflow runs the tool and commits the result. Pull request runs do not touch the documents, so nothing is pushed to a contributor's branch and a fork PR is unaffected.

**Things that could go wrong, and what happens instead**

- *A sentence gets reworded.* The patterns anchor on the prose around each number, not on the number. Rewording makes the tool exit 1 naming the file, rather than silently leaving a stale figure. Verified by rewording the roadmap sentence and watching it refuse.
- *The run is red.* It refuses to publish a total from a log with failing tests.
- *The log is truncated.* It refuses a log missing any total rather than guessing at it.
- *Another merge lands mid-run.* The push would be non-fast-forward, so it rebases onto `main` and retries up to three times instead of failing a green build.
- *Loop.* A `GITHUB_TOKEN` push raises no workflow event, and the message carries `[skip ci]` as well.
- *The badge.* It emits plain digits there rather than `2,882`, because that is a URL path segment. Caught while testing.

**One thing to check before merging.** The job now declares `permissions: contents: write`. If this repository's Actions setting is *Read repository contents permission*, the push will fail and turn `main` red. Settings → Actions → General → Workflow permissions needs *Read and write*. I cannot see that setting from here, so worth confirming.

Wording follow-on: `DEVELOPMENT.md` and `HammerForge_SPEC.md` said "verified locally", which stops being true once CI writes them. Both now say "verified in CI on <date>", which is what `CONTRIBUTING.md` asked for anyway. `CONTRIBUTING.md` and `DEVELOPMENT.md` tell contributors to leave the numbers alone, and how to preview what CI would write.

No test for the script itself — `tools/` has no Python harness, and adding one is a bigger decision than this change. Verified by hand: check and write modes, idempotency, anchor drift, a red run, a truncated log, and badge formatting.