### PR TITLE
Restamp the verification date only when a count moves

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -421,6 +421,10 @@ python tools/update_test_counts.py --gut-log gut.log --check
 number, so rewording one of those sentences makes the tool fail loudly rather
 than leave a stale figure behind — the message names the file to fix.
 
+The verification date moves only when a count moves. A date is a record of when
+the numbers were measured, so restamping one that has not changed would put a
+commit in the history saying nothing.
+
 ### VS Code Integration
 
 The repo includes `.vscode/tasks.json` with pre-configured GUT test tasks and problem matchers that surface failures as clickable file:line links in the Problems panel.

--- a/tools/update_test_counts.py
+++ b/tools/update_test_counts.py
@@ -95,15 +95,19 @@ def parse_gut_log(path: str) -> dict:
     return counts
 
 
-def rewrites(c: dict, date: str) -> list:
-    """One (path, pattern, replacement) per number this owns.
+DATE_PATTERN = r"(?P<date>[A-Z][a-z]+ \d{1,2}, \d{4})"
+
+
+def rewrites(c: dict) -> list:
+    """One (path, pattern, template) per number this owns.
 
     Patterns are anchored on the prose around the number rather than on the
     number itself, so a reworded sentence fails loudly here instead of silently
-    leaving a stale figure behind.
+    leaving a stale figure behind. Where a sentence carries a verification date,
+    the pattern captures it as `date` and the template leaves `{date}` unfilled,
+    so the caller decides whether this rewrite is worth restamping.
     """
     common = {
-        "date": date,
         "tests": grouped(c["tests"]),
         "scripts": grouped(c["scripts"]),
         "passing": grouped(c["passing"]),
@@ -121,37 +125,38 @@ def rewrites(c: dict, date: str) -> list:
         ),
         (
             "docs/features.md",
-            r"The verified Godot 4\.7 suite on .+? contains \*\*[\d,]+ tests across "
+            r"The verified Godot 4\.7 suite on " + DATE_PATTERN + r" contains \*\*[\d,]+ tests across "
             r"[\d,]+ scripts\*\*: \*\*[\d,]+ passing tests\*\*, \w+ intentional "
             r"no-assert safety tests, and \*\*[\d,]+ assertions\*\*\.",
             (
                 "The verified Godot 4.7 suite on {date} contains **{tests} tests "
                 "across {scripts} scripts**: **{passing} passing tests**, {risky} "
                 "intentional no-assert safety tests, and **{asserts} assertions**."
-            ).format(**common),
+            ).format(date="{date}", **common),
         ),
         (
             "DEVELOPMENT.md",
             r"- \*\*GUT unit \+ integration tests\*\* -- [\d,]+ tests across [\d,]+ "
             r"test scripts \([\d,]+ passing plus \w+ intentional no-assert safety "
-            r"tests; [\d,]+ assertions; verified .+?; runs Godot headless\)",
+            r"tests; [\d,]+ assertions; verified in CI on " + DATE_PATTERN
+            + r"; runs Godot headless\)",
             (
                 "- **GUT unit + integration tests** -- {tests} tests across "
                 "{scripts} test scripts ({passing} passing plus {risky} intentional "
                 "no-assert safety tests; {asserts} assertions; verified in CI on "
                 "{date}; runs Godot headless)"
-            ).format(**common),
+            ).format(date="{date}", **common),
         ),
         (
             "HammerForge_SPEC.md",
-            r"Full suite \(verified .+?\): \*\*[\d,]+ tests\*\* across \*\*[\d,]+ "
+            r"Full suite \(verified in CI on " + DATE_PATTERN + r"\): \*\*[\d,]+ tests\*\* across \*\*[\d,]+ "
             r"scripts\*\* \(\*\*[\d,]+ passing\*\* plus \w+ intentional no-assert "
             r"safety tests; \*\*[\d,]+ assertions\*\*\)\.",
             (
                 "Full suite (verified in CI on {date}): **{tests} tests** across "
                 "**{scripts} scripts** (**{passing} passing** plus {risky} "
                 "intentional no-assert safety tests; **{asserts} assertions**)."
-            ).format(**common),
+            ).format(date="{date}", **common),
         ),
         (
             "ROADMAP.md",
@@ -191,21 +196,25 @@ def main() -> int:
     )
 
     stale = []
-    for path, pattern, replacement in rewrites(counts, args.date):
+    for path, pattern, template in rewrites(counts):
         original = io.open(path, encoding="utf-8").read()
-        # A function replacement so nothing in the text is read as a group
-        # reference or an escape.
-        updated, hits = re.subn(pattern, lambda _m: replacement, original, count=1)
-        if hits == 0:
+        found = re.search(pattern, original)
+        if found is None:
             raise SystemExit(
                 "update_test_counts: nothing matched in %s. The sentence this owns "
                 "was reworded or removed; update its pattern in "
                 "tools/update_test_counts.py." % path
             )
-        if updated == original:
+        # Hold the date the file already carries and see whether anything else
+        # differs. A date is a record of when the numbers were measured, so
+        # restamping one that has not moved would commit a change saying nothing.
+        carried = found.groupdict().get("date") or args.date
+        if found.group(0) == template.format(date=carried):
             continue
         stale.append(path)
         if args.write:
+            replacement = template.format(date=args.date)
+            updated = original[: found.start()] + replacement + original[found.end() :]
             io.open(path, "w", encoding="utf-8", newline="\n").write(updated)
 
     if args.check:


### PR DESCRIPTION
Follow-up to #210, fixing a flaw in it before it produces its first stray commit.

**The problem.** `update_test_counts.py` rebuilt each sentence with today's date and rewrote whenever the result differed from the file. The counts were only part of that comparison — the date was too. So the first merge on any day after the counts were last written would rewrite three dates, change nothing else, and commit it:

```
--date "September 9, 2026" --check  →  exit 1
  docs/features.md, DEVELOPMENT.md, HammerForge_SPEC.md
```

One commit per active day, saying nothing. The tool built to stop manual churn would have replaced it with automated churn.

**The fix.** The patterns now capture the date the file already carries, and the drift comparison is made against *that* date rather than today's. Only a real change to the numbers counts as drift. When there is one, the new date is stamped along with it.

A verification date records when the numbers were measured. Moving it while the numbers sit still is not just noise, it is a slightly false claim about how fresh they are.

**Verified**

| | |
|---|---|
| Date rolls, counts unchanged | exit 0, nothing written |
| Counts change | exit 1, all five named |
| Counts change, written | date restamped to the new date in all three files that carry one |
| Wording reverted to "verified locally" | still fails loudly naming the file |

The anchor check matters here because tightening the patterns to capture the date also made them stricter about the surrounding wording — confirmed it still refuses rather than silently skipping.