### PR TITLE
Parent nodes before setting their world transform

### DIFF
--- a/addons/hammerforge/systems/hf_brush_system.gd
+++ b/addons/hammerforge/systems/hf_brush_system.gd
@@ -61,7 +61,6 @@ func place_brush(
 
 	var snapped = root._snap_point(hit.position)
 	var brush = _create_brush(shape, size, operation, sides)
-	brush.global_position = snapped + Vector3(0, size.y * 0.5, 0)
 	var brush_id = _next_brush_id()
 	brush.brush_id = str(brush_id)
 	brush.set_meta("brush_id", str(brush_id))
@@ -71,6 +70,7 @@ func place_brush(
 		_add_pending_cut(brush)
 	else:
 		_add_brush_to_draft(brush)
+	brush.global_position = snapped + Vector3(0, size.y * 0.5, 0)
 	_legacy_manager_add(brush)
 	root._record_last_brush(brush.global_position)
 	return true

--- a/addons/hammerforge/systems/hf_entity_system.gd
+++ b/addons/hammerforge/systems/hf_entity_system.gd
@@ -103,10 +103,10 @@ func create_entity_from_map(info: Dictionary) -> DraftEntity:
 		data.erase("classname")
 		data.erase("origin")
 		entity.entity_data = data
+	add_entity(entity)
 	var origin = info.get("origin", Vector3.ZERO)
 	if origin is Vector3:
 		entity.global_position = origin
-	add_entity(entity)
 	return entity
 
 
@@ -159,8 +159,6 @@ func restore_entity_from_info(info: Dictionary) -> DraftEntity:
 	var props = info.get("properties", {})
 	if props is Dictionary:
 		entity.entity_data = props.duplicate(true)
-	if info.has("transform"):
-		entity.global_transform = info["transform"]
 	var io_outputs = info.get("io_outputs", [])
 	if not io_outputs.is_empty():
 		entity.set_meta("entity_io_outputs", io_outputs.duplicate(true))
@@ -175,6 +173,8 @@ func restore_entity_from_info(info: Dictionary) -> DraftEntity:
 	entity.set_meta("is_entity", true)
 	root.entities_node.add_child(entity)
 	root._assign_owner(entity)
+	if info.has("transform"):
+		entity.global_transform = info["transform"]
 	_emit_entity_signal("entity_added", entity)
 	return entity
 

--- a/tests/test_brush_system.gd
+++ b/tests/test_brush_system.gd
@@ -46,6 +46,8 @@ var brush_manager = null
 var texture_lock: bool = false
 var drag_size_default: Vector3 = Vector3(32, 32, 32)
 var dirty_brush_ids: Array[String] = []
+var raycast_position: Vector3 = Vector3.ZERO
+var last_brush_position: Vector3 = Vector3.INF
 
 enum BrushShape { BOX, CYLINDER, SPHERE, CONE, WEDGE, PYRAMID, PRISM_TRI, PRISM_PENT, ELLIPSOID, CAPSULE, TORUS, TETRAHEDRON, OCTAHEDRON, DODECAHEDRON, ICOSAHEDRON, CUSTOM }
 
@@ -64,8 +66,14 @@ func _log(_msg: String) -> void:
 func _assign_owner(_node: Node) -> void:
 	pass
 
-func _record_last_brush(_pos: Vector3) -> void:
-	pass
+func _raycast(_camera, _mouse_pos) -> Dictionary:
+	return {"position": raycast_position}
+
+func _snap_point(point: Vector3) -> Vector3:
+	return point
+
+func _record_last_brush(pos: Vector3) -> void:
+	last_brush_position = pos
 
 func tag_brush_dirty(brush_id: String) -> void:
 	dirty_brush_ids.append(brush_id)
@@ -118,6 +126,31 @@ func test_cache_is_authority_when_legacy_manager_exists():
 	sys.delete_brush_by_id("cached")
 	assert_eq(sys.get_cached_brush_count(), 0)
 	assert_eq(manager.brushes, [])
+
+
+func test_place_brush_uses_world_space_when_root_is_offset():
+	root.position = Vector3(50, 0, 50)
+	root.raycast_position = Vector3.ZERO
+	var camera := Camera3D.new()
+	add_child_autoqfree(camera)
+	var placed = sys.place_brush(
+		Vector2.ZERO, CSGShape3D.OPERATION_UNION, Vector3(16, 16, 16), camera
+	)
+	assert_true(placed, "A hit under the cursor places a brush")
+	assert_eq(root.draft_brushes_node.get_child_count(), 1)
+	var brush = root.draft_brushes_node.get_child(0)
+	assert_almost_eq(
+		brush.global_position,
+		Vector3(0, 8, 0),
+		Vector3(0.001, 0.001, 0.001),
+		"The brush sits on the point the ray hit, not that point plus the root offset"
+	)
+	assert_almost_eq(
+		root.last_brush_position,
+		Vector3(0, 8, 0),
+		Vector3(0.001, 0.001, 0.001),
+		"The recorded last brush position is the world position too"
+	)
 
 
 class _FakeManager:

--- a/tests/test_entity_props.gd
+++ b/tests/test_entity_props.gd
@@ -256,3 +256,43 @@ func test_missing_property_uses_default():
 	assert_true(e.entity_data.has("speed"), "speed should be populated by defaults")
 	assert_almost_eq(float(e.entity_data.get("speed", 0.0)), 200.0, 0.01)
 	assert_eq(e.entity_data.get("locked"), false)
+
+
+# ===========================================================================
+# World placement with an offset LevelRoot
+# ===========================================================================
+
+
+func test_restore_entity_from_info_keeps_world_transform_when_root_is_offset():
+	root.position = Vector3(100, 0, 100)
+	var restored = (
+		sys
+		. restore_entity_from_info(
+			{
+				"name": "OffsetLight",
+				"entity_type": "light_point",
+				"transform": Transform3D(Basis.IDENTITY, Vector3(10, 0, 0)),
+			}
+		)
+	)
+	assert_not_null(restored)
+	assert_almost_eq(
+		restored.global_position,
+		Vector3(10, 0, 0),
+		Vector3(0.001, 0.001, 0.001),
+		"A restored entity keeps the world position it was captured at"
+	)
+
+
+func test_create_entity_from_map_keeps_world_origin_when_root_is_offset():
+	root.position = Vector3(100, 0, 100)
+	var entity = sys.create_entity_from_map(
+		{"classname": "light_point", "origin": Vector3(10, 0, 0)}
+	)
+	assert_not_null(entity)
+	assert_almost_eq(
+		entity.global_position,
+		Vector3(10, 0, 0),
+		Vector3(0.001, 0.001, 0.001),
+		"Map origins are world coordinates, not offsets from the level root"
+	)


### PR DESCRIPTION
Setting `global_position` or `global_transform` on a Node3D that is not in the tree only writes the local transform. The node then lands offset by whatever transform its container has. With LevelRoot away from the origin, brushes and entities appear in the wrong place.

Moves the assignment after `add_child` in three spots.

- `place_brush` sets the position after the brush enters the draft or pending container. The brush lands on the ray hit, and `_record_last_brush` stores that point instead of the shifted one.
- `restore_entity_from_info` applies the captured transform after parenting and before it emits `entity_added`, so listeners see the entity where it belongs.
- `create_entity_from_map` sets the map origin after `add_entity`.

This matches the order `create_brush_from_info` and `create_default_spawn` already use.

Tests: three new ones covering a LevelRoot translated away from origin. Each fails on the old code with the exact coordinates from the reports.

Fixes #221
Fixes #222