### PR TITLE
Keep commands undoable past five arguments

### DIFF
--- a/addons/hammerforge/undo_helper.gd
+++ b/addons/hammerforge/undo_helper.gd
@@ -7,6 +7,9 @@ extends RefCounted
 ## undo entry, preventing undo-history flooding during drags / nudges.
 const COLLATION_WINDOW_MS := 1000
 
+## How many arguments the hand written add_do_method unroll covers.
+const MAX_UNROLLED_ARGS := 5
+
 ## Tracks the last collation state so we can merge follow-up commits.
 static var _last_collation_tag := ""
 static var _last_collation_time := 0
@@ -47,12 +50,6 @@ static func commit(
 		and not _last_collation_state.is_empty()
 	)
 
-	if args.size() > 5:
-		root.callv(method_name, args)
-		var state: Dictionary = root.capture_full_state() if full_state else root.capture_state()
-		_update_collation(collation_tag, can_collate, full_state, now, state)
-		_fire_history_cb(history_cb, action_name, can_collate)
-		return
 	if not undo_redo:
 		root.callv(method_name, args)
 		# Still maintain collation tracking + history even without undo_redo,
@@ -105,7 +102,11 @@ static func register_action(
 ) -> void:
 	var restore_name := "restore_full_state" if full_state else "restore_state"
 
-	if absolute_redo:
+	# add_do_method takes an object, a method name and varargs. GDScript cannot
+	# spread an array into varargs, so the call below is unrolled by hand and
+	# stops at five. Past that, register the result instead of the call: the do
+	# operation becomes the same kind of state restore the undo already is.
+	if absolute_redo or args.size() > MAX_UNROLLED_ARGS:
 		# Run it here, then register the result rather than the step, and commit
 		# without executing so the work is not done twice.
 		root.callv(method_name, args)

--- a/tests/test_transform_commands.gd
+++ b/tests/test_transform_commands.gd
@@ -135,21 +135,6 @@ func test_level_root_exposes_the_methods_undo_dispatches_by_name():
 		assert_true(root.has_method(method_name), "LevelRoot must expose %s" % method_name)
 
 
-func test_transform_undo_methods_stay_within_the_helper_argument_limit():
-	# HFUndoHelper falls back to a direct, non-undoable call past five arguments.
-	var source := FileAccess.get_file_as_string("res://addons/hammerforge/level_root.gd")
-	for method_name in ["rotate_managed_nodes", "flip_managed_nodes", "reset_managed_rotation"]:
-		var start := source.find("func %s(" % method_name)
-		assert_gt(start, -1, "%s must exist" % method_name)
-		var finish := source.find(") -> void:", start)
-		var signature := source.substr(start, finish - start)
-		assert_lt(
-			signature.count(",") + 1,
-			6,
-			"%s would drop off the undoable path with six arguments" % method_name
-		)
-
-
 func test_edit_actions_commit_through_the_undo_helper():
 	var source := FileAccess.get_file_as_string("res://addons/hammerforge/plugin_edit_actions.gd")
 	for pair in [

--- a/tests/test_undo_collation.gd
+++ b/tests/test_undo_collation.gd
@@ -397,3 +397,78 @@ func test_the_tag_changes_with_the_target_and_the_inputs():
 	assert_ne(base, HFPluginEditActions.collation_tag("rotate", ["a"], [], [1]), "command")
 	assert_ne(base, HFPluginEditActions.collation_tag("nudge", ["a"], ["e"], [1]), "entities")
 	assert_eq(base, HFPluginEditActions.collation_tag("nudge", ["a"], [], [1]), "same press")
+
+
+# ===========================================================================
+# A command with more arguments than the unroll covers
+# ===========================================================================
+
+
+func _brush_count() -> int:
+	var total := 0
+	for node in root._iter_pick_nodes():
+		if node is DraftBrush:
+			total += 1
+	return total
+
+
+## create_radial_array takes six arguments. The unrolled add_do_method stops at
+## five, so this used to run the command and register nothing at all: Ctrl+Z
+## reached past it and undid whatever came before.
+func test_a_six_argument_command_still_registers_an_undo_entry():
+	var brush := _make_brush(Vector3.ZERO)
+	var undo_redo := FakeUndoRedo.new()
+	var before := root.capture_state()
+
+	HFUndoHelper.register_action(
+		undo_redo,
+		root,
+		"Create Radial Array",
+		MERGE_DISABLE,
+		"create_radial_array",
+		[PackedStringArray([_brush_id(brush)]), 4, 1, 90.0, Vector3.ZERO, 0.0],
+		before
+	)
+
+	assert_eq(undo_redo.entries.size(), 1, "six arguments must still reach the undo manager")
+	assert_false(
+		undo_redo.entries[0]["do"].is_empty(), "an entry with no do operation cannot be redone"
+	)
+	assert_gt(_brush_count(), 1, "the array copies are in the level")
+
+
+func test_undoing_a_radial_array_removes_the_copies():
+	var brush := _make_brush(Vector3.ZERO)
+	var undo_redo := FakeUndoRedo.new()
+	var before := root.capture_state()
+
+	HFUndoHelper.register_action(
+		undo_redo,
+		root,
+		"Create Radial Array",
+		MERGE_DISABLE,
+		"create_radial_array",
+		[PackedStringArray([_brush_id(brush)]), 4, 1, 90.0, Vector3.ZERO, 0.0],
+		before
+	)
+	var with_array := _brush_count()
+	assert_gt(with_array, 1, "the array has to exist before undo can mean anything")
+
+	undo_redo.undo()
+	assert_eq(_brush_count(), 1, "undo takes the array copies back out")
+
+	undo_redo.redo()
+	assert_eq(_brush_count(), with_array, "redo puts the whole array back")
+
+
+## MAX_UNROLLED_ARGS decides when register_action stops naming the method and
+## starts registering a snapshot. If it drifts below what the unroll covers, a
+## call quietly loses its do operation again.
+func test_the_unroll_covers_every_argument_count_below_the_snapshot_cutoff():
+	var source := FileAccess.get_file_as_string("res://addons/hammerforge/undo_helper.gd")
+	for count in range(HFUndoHelper.MAX_UNROLLED_ARGS + 1):
+		assert_gt(
+			source.find("\t\t%d:" % count),
+			-1,
+			"register_action must unroll add_do_method for %d arguments" % count
+		)


### PR DESCRIPTION
`EditorUndoRedoManager.add_do_method` takes an object, a method name and varargs. GDScript cannot spread an array into varargs, so `register_action` unrolls the call by hand and stops at five arguments. Past that the `match` fell through and added no do operation at all, and `commit()` returned even earlier with a plain `callv`.

Create Radial Array passes six. It ran, registered nothing, and Ctrl+Z reached past it to undo whatever came before.

Past the unroll, register the result instead of the call: run the method, snapshot the state, and make that snapshot the do operation. That is the same kind of restore the undo side already uses, so redo has the same fidelity as undo, and it is the path stepping commands like rotate and nudge already take. No limit is raised, so the next six argument command works too.

`create_radial_array` is the only command over the limit today. I checked all 43 method names dispatched through the commit sites against their LevelRoot signatures.

Tests:

- A six argument command registers an entry that has a do operation.
- Creating a radial array, undoing it, and redoing it. The undo test asserts the array exists first, so it cannot pass by the array never being built.
- A guard that `MAX_UNROLLED_ARGS` does not drift below what the unroll covers.
- `test_transform_undo_methods_stay_within_the_helper_argument_limit` is removed. It guarded the ceiling this change removes, and asserting `create_radial_array` has fewer than six arguments would contradict the fix. The rename check it shared is already done by `test_level_root_exposes_the_methods_undo_dispatches_by_name` in the same file, `create_radial_array` included.

Fixes #220