### PR TITLE
Fail the build when a node is placed before it is parented

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,18 @@ jobs:
       - name: Lint
         run: gdlint addons/hammerforge/
 
+      # A world transform assigned to a node that is not in the tree yet writes
+      # the local one instead, and the node lands shifted by its container. That
+      # has been fixed six times, most recently in the baker, where it was
+      # applying the root transform twice to geometry that ships. The selftest
+      # runs first so a detector that has quietly stopped detecting fails loudly
+      # rather than passing everything.
+      - name: Check the placement-order guard still detects
+        run: python3 tools/check_placement_order.py --selftest
+
+      - name: Check placement order
+        run: python3 tools/check_placement_order.py
+
   unit-tests:
     name: GUT Unit Tests
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,27 @@ The format is based on Keep a Changelog, and this project follows semantic versi
     translation would not pass. Four of the seven fail against the old code.
 
 ### Added
+- **A build guard against the mistake that has now been fixed six times.**
+  Assigning `global_position` or `global_transform` to a `Node3D` that is not in
+  the tree yet writes the local transform instead. Nothing errors, and the node
+  lands shifted by its container. It stays invisible while `LevelRoot` sits at
+  the world origin, which is how it usually gets exercised, so each instance was
+  found by someone hitting it. The last one was found by a scan instead, in the
+  baker, applying the root transform twice to geometry that ships.
+  - `tools/check_placement_order.py` fails the build when a `global_*`
+    assignment runs before the node is parented in the same function. It reads
+    `addons/hammerforge/` and `tests/`, since a fixture with the same mistake
+    builds a scene it is not describing and passes without holding the property
+    it names.
+  - It folds wrapped calls onto one line before matching, because gdformat
+    routinely puts `add_child(` and its argument on separate lines. A deliberate
+    case is marked with a `hf-allow-global-before-parent` comment rather than by
+    switching the check off.
+  - `--selftest` runs the detector over a known-bad and a known-good snippet and
+    fails if either answer changed. CI runs it before the scan, so a detector
+    that has quietly stopped detecting fails loudly rather than passing
+    everything. Checked against the four historical bugs: it reports all four at
+    the lines their reports named.
 - **The array section draws its copies, and refuses to describe a hang.** The
   Structure section next to it learned to draw itself two waves ago; this one had
   three layouts, nine numbers between them, and a button that turned them into as

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,14 @@ prompt for what's actually needed to act on them.
 ```
 gdformat --check addons/hammerforge/ tests/
 gdlint addons/hammerforge/
+python tools/check_placement_order.py
 ```
+
+The last one refuses a `global_position` or `global_transform` written to a node
+that is not in the tree yet. Godot writes the local transform in that case
+without complaining, and the node lands shifted by whatever its container's
+transform is, so parent it first and place it second. See DEVELOPMENT.md if you
+need the deliberate-case escape hatch.
 
 ### Unit Tests (GUT)
 Tests live in `tests/` and use the [GUT](https://github.com/bitwes/Gut) framework (installed in `addons/gut/`).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -399,14 +399,36 @@ addons/hammerforge/
 The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs on push and PR to `main`:
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
+- `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
 - **GUT unit + integration tests** -- 3,004 tests across 157 test scripts (2,997 passing plus seven intentional no-assert safety tests; 15,707 assertions; verified in CI on September 9, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```
 gdformat --check addons/hammerforge/ tests/
 gdlint addons/hammerforge/
+python tools/check_placement_order.py
 godot --headless -s res://addons/gut/gut_cmdln.gd --path .
 ```
+
+**Parent the node, then place it.** A `Node3D` outside the scene tree has no
+parent to measure against, so assigning `global_position` or `global_transform`
+writes the local transform instead. Nothing errors. The node lands wherever its
+container puts it, shifted by that container's own transform, and none of it
+shows while `LevelRoot` sits at the world origin, which is how it usually gets
+exercised. That has been fixed six times: the draw path, the entity restore, the
+map import and the baker, where it was applying the root transform twice to
+geometry that ships.
+
+`tools/check_placement_order.py` fails the build when a `global_*` assignment
+runs before the node is parented in the same function. It reads the four
+historical bugs correctly, which is the test that it works. A deliberate case
+says so on the assignment line or the one above it:
+```
+# hf-allow-global-before-parent: <why>
+```
+`--selftest` runs the detector over a known-bad and a known-good snippet and
+fails if either answer changed. CI runs that first, so a detector that has
+quietly stopped detecting fails loudly rather than passing everything.
 
 **Published test totals look after themselves.** Five documents quote the size of
 the suite, and every pull request that adds a test would otherwise invalidate all

--- a/tools/check_placement_order.py
+++ b/tools/check_placement_order.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Refuse a world transform written to a node that is not in the tree yet.
+
+A Node3D outside the scene tree has no parent to measure against, so assigning
+global_position or global_transform writes the local transform instead. Nothing
+errors. The node simply lands wherever its container puts it, shifted by that
+container's own transform, and the whole thing is invisible while LevelRoot sits
+at the world origin -- which is how it usually gets exercised.
+
+That mistake has been fixed six times now, in the draw path, the entity restore,
+the map import and the baker, each time after someone hit it. The baker was the
+worst: it was applying the root transform twice to geometry that ships. It was
+found by a scan much like this one rather than by a bug report, which is the
+argument for keeping the scan.
+
+    python tools/check_placement_order.py
+
+Exits 1 and names file, line and variable for every place a global_* assignment
+runs before the node is parented in the same function.
+
+A deliberate case can say so on the assignment line, or the line above it:
+
+    # hf-allow-global-before-parent: <why>
+
+--selftest checks the detector still catches a known-bad snippet and still
+passes a known-good one, because a guard that cannot fail is not a guard.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+# tests/ is in scope as well as the addon. A fixture that places a node before
+# parenting it builds the scene it is not describing, so the test passes without
+# holding the property it names.
+SCAN_ROOTS = ["addons/hammerforge", "tests"]
+
+ALLOW_MARKER = "hf-allow-global-before-parent"
+
+# Assigning any of these on an orphan writes the local transform instead.
+WORLD_WRITE = re.compile(
+    r"\b(?P<var>[A-Za-z_]\w*)\.global_"
+    r"(?:position|transform|basis|rotation|rotation_degrees)\s*=(?!=)"
+)
+
+# The calls that put a node into the tree. add_entity, _add_brush_to_draft and
+# _add_pending_cut are HammerForge's own wrappers around add_child.
+PARENTED = (
+    r"(?:add_child|add_sibling|add_entity|_add_brush_to_draft|_add_pending_cut)"
+    r"\(\s*(?P<var>[A-Za-z_]\w*)\s*[,)]"
+)
+PARENT_CALL = re.compile(PARENTED)
+
+FUNC_SPLIT = re.compile(r"\n(?=(?:static )?func )")
+FUNC_NAME = re.compile(r"(?:static )?func ([A-Za-z_]\w*)")
+DECLARED = re.compile(r"\bvar\s+(?P<var>[A-Za-z_]\w*)\b")
+
+
+def strip_comment(line: str) -> str:
+    """Drop a trailing comment, leaving anything inside a string alone."""
+    quote = ""
+    for i, ch in enumerate(line):
+        if quote:
+            if ch == "\\":
+                continue
+            if ch == quote:
+                quote = ""
+        elif ch in "\"'":
+            quote = ch
+        elif ch == "#":
+            return line[:i]
+    return line
+
+
+def logical_lines(source: str) -> list:
+    """Fold wrapped calls onto one line, keeping the line number they start on.
+
+    gdformat wraps a long call across several lines, so `add_child(` and the
+    node it is given are routinely not on the same physical line.
+    """
+    out = []
+    buf = ""
+    start = 0
+    depth = 0
+    for number, raw in enumerate(source.split("\n"), start=1):
+        text = strip_comment(raw)
+        if not buf:
+            start = number
+        buf = buf + " " + text.strip() if buf else text.strip()
+        depth += text.count("(") + text.count("[") - text.count(")") - text.count("]")
+        if depth <= 0:
+            out.append((start, buf))
+            buf = ""
+            depth = 0
+    if buf:
+        out.append((start, buf))
+    return out
+
+
+def allowed_lines(source: str) -> set:
+    """Line numbers covered by an allow marker, on the line or the one above."""
+    covered = set()
+    for number, raw in enumerate(source.split("\n"), start=1):
+        if ALLOW_MARKER in raw:
+            covered.add(number)
+            covered.add(number + 1)
+    return covered
+
+
+def violations_in_source(source: str, path: str = "<memory>") -> list:
+    """Every global_* write that runs before its node is parented."""
+    found = []
+    allow = allowed_lines(source)
+    offset = 0
+    for chunk in FUNC_SPLIT.split(source):
+        name = FUNC_NAME.match(chunk)
+        # Line number this chunk starts on, so reports point at the real file.
+        base = offset
+        offset += chunk.count("\n") + 1
+        if not name:
+            continue
+        lines = logical_lines(chunk)
+        declared = set()
+        writes = {}
+        parents = {}
+        for index, (line_no, text) in enumerate(lines):
+            for m in DECLARED.finditer(text):
+                declared.add(m.group("var"))
+            for m in WORLD_WRITE.finditer(text):
+                writes.setdefault(m.group("var"), (index, line_no))
+            for m in PARENT_CALL.finditer(text):
+                parents.setdefault(m.group("var"), index)
+        for var, (write_index, write_line) in writes.items():
+            if var not in declared or var not in parents:
+                continue
+            if write_index >= parents[var]:
+                continue
+            absolute = base + write_line
+            if absolute in allow:
+                continue
+            found.append((path, absolute, name.group(1), var))
+    return found
+
+
+def gd_files(roots: list) -> list:
+    files = []
+    for root in roots:
+        files.extend(glob.glob(os.path.join(root, "**", "*.gd"), recursive=True))
+    return sorted(f.replace("\\", "/") for f in files)
+
+
+BAD_SNIPPET = """
+func append_brush_list_to_csg(brushes: Array, target: CSGCombiner3D) -> void:
+\tfor child in brushes:
+\t\tvar csg_shape = PrefabFactory.create_prefab(child.shape)
+\t\tcsg_shape.global_transform = child.global_transform
+\t\ttarget.add_child(csg_shape)
+"""
+
+GOOD_SNIPPET = """
+func place_brush(size: Vector3) -> void:
+\tvar brush = _create_brush(size)
+\t_add_brush_to_draft(brush)
+\tbrush.global_position = Vector3.ZERO
+
+func restore_entity_from_info(info: Dictionary) -> Node3D:
+\tvar entity = DraftEntity.new()
+\troot.entities_node.add_child(entity)
+\tentity.global_transform = info["transform"]
+\treturn entity
+
+func wrapped_call(info: Dictionary) -> void:
+\tvar entity = DraftEntity.new()
+\troot.entities_node.add_child(
+\t\tentity
+\t)
+\tentity.global_transform = info["transform"]
+
+func deliberate(info: Dictionary) -> void:
+\tvar node = Node3D.new()
+\t# hf-allow-global-before-parent: measured against the parent on purpose
+\tnode.global_transform = info["transform"]
+\tadd_child(node)
+
+func moves_a_node_already_in_the_tree(node: Node3D, offset: Vector3) -> void:
+\tnode.global_position += offset
+"""
+
+
+def selftest() -> int:
+    bad = violations_in_source(BAD_SNIPPET, "bad.gd")
+    good = violations_in_source(GOOD_SNIPPET, "good.gd")
+    ok = True
+    if len(bad) != 1 or bad[0][3] != "csg_shape":
+        print("selftest: the detector no longer catches the known-bad snippet")
+        print("  got: %r" % (bad,))
+        ok = False
+    if good:
+        print("selftest: the detector flags the known-good snippet")
+        for path, line, func, var in good:
+            print("  %s:%d %s() %s" % (path, line, func, var))
+        ok = False
+    if ok:
+        print("selftest: detector catches the bad snippet and passes the good one.")
+        return 0
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--selftest",
+        action="store_true",
+        help="check the detector still works, then exit",
+    )
+    parser.add_argument("paths", nargs="*", default=None, help="files or roots to scan")
+    args = parser.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    roots = args.paths if args.paths else SCAN_ROOTS
+    files = []
+    for entry in roots:
+        if os.path.isdir(entry):
+            files.extend(gd_files([entry]))
+        elif entry.endswith(".gd"):
+            files.append(entry.replace("\\", "/"))
+
+    found = []
+    for path in files:
+        with open(path, encoding="utf-8", errors="ignore") as handle:
+            found.extend(violations_in_source(handle.read(), path))
+
+    if not found:
+        print("Placement order is clean across %d files." % len(files))
+        return 0
+
+    print("A world transform is written before the node is in the tree.")
+    print("Assigning global_* to a node outside the tree writes its local")
+    print("transform, so it lands shifted by its container once parented.")
+    print("Parent it first, or say why with a %s comment.\n" % ALLOW_MARKER)
+    for path, line, func, var in found:
+        print("  %s:%d  %s()  %s" % (path, line, func, var))
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A `Node3D` outside the scene tree has no parent to measure against, so assigning `global_position` or `global_transform` writes the local transform instead. Nothing errors. The node lands wherever its container puts it, shifted by that container's transform, and none of it shows while `LevelRoot` sits at the world origin, which is how it usually gets exercised.

That has now been fixed six times, across the draw path, the entity restore, the map import and the baker. The baker (#226) was the only one found by scanning rather than by someone hitting it, and it was the worst of them: it applied the root transform twice to geometry that ships. That is the argument for keeping the scan.

**What it does**

`tools/check_placement_order.py` reports every `global_*` assignment that runs before its node is parented in the same function, and exits 1.

- Scans `addons/hammerforge/` and `tests/`. Tests are in scope because a fixture with this mistake builds a scene it is not describing, so the test passes without holding the property it names.
- Folds wrapped calls onto one line before matching. gdformat routinely puts `add_child(` and its argument on separate lines, and a guard that misses those is a guard people stop trusting.
- Knows HammerForge's own parenting wrappers (`add_entity`, `_add_brush_to_draft`, `_add_pending_cut`) as well as `add_child` and `add_sibling`.
- A deliberate case is marked with a `# hf-allow-global-before-parent: <why>` comment on the assignment or the line above, so the escape hatch is a line of justification rather than deleting the check.

**Proof it works**

- `--selftest` runs the detector over a known-bad and a known-good snippet and fails if either answer changed. The good snippet includes the wrapped-call and allow-marker cases and a function that moves a node already in the tree, which must not be flagged.
- Checked against the four historical bugs by scanning the pre-fix files out of git. It reports all four, at the lines their issue reports named: `hf_brush_system.gd:64`, `hf_entity_system.gd:108` and `:163`, `hf_bake_system.gd:1360`.
- Current tree is clean across 326 files.

**CI**: two steps in the existing `GDScript Lint & Format` job, which already has Python. The selftest runs first, so a detector that has quietly stopped detecting fails loudly rather than passing everything.

**Docs**: DEVELOPMENT.md gets the rule, the tool and the escape hatch. CONTRIBUTING.md gets it in the local checks block. CHANGELOG entry under Added.

No `.gd` files are touched.