### PR TITLE
Bring the repository configuration up to what the code already expects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Every path resolves to the same person, so per-area ownership lines would be
+# decoration. What is worth writing down is which directories are not ours to
+# edit: they are upstream snapshots, and a change made here is lost at the next
+# bump. Those lines exist to put a review on the PR that touches them.
+
+*                       @saworbit
+
+# Vendored upstream. Fix these at the source and re-vendor; do not patch here.
+/addons/gut/            @saworbit
+/addons/godot_mcp/      @saworbit
+
+# Break these and the Asset Library ships the wrong tree, or CI stops catching
+# the bug it was written to catch.
+/.github/workflows/     @saworbit
+/tools/                 @saworbit

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,5 @@
 version: 2
 updates:
-  # Godot and GDScript tooling are pinned in ci.yml itself, so only the
-  # Actions themselves are tracked here.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -9,8 +7,25 @@ updates:
     commit-message:
       prefix: "ci"
     labels:
-      - "enhancement"
+      - "ci"
     groups:
       actions:
+        patterns:
+          - "*"
+
+  # Godot itself is pinned in ci.yml and cannot be tracked here, but the Python
+  # tooling can be. It used to be inline `pip install` arguments that nothing
+  # watched; as requirements files, a bump arrives as a pull request that runs
+  # the suite against it before anyone accepts it.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "ci"
+    groups:
+      python-tooling:
         patterns:
           - "*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,116 @@
+# Applies the area: labels this repository already uses, so triage does not
+# depend on remembering to. Paths follow the layout in docs/architecture: the
+# plugin_*.gd modules sit beside plugin.gd, the RefCounted subsystems live in
+# addons/hammerforge/systems/.
+#
+# A file that maps to nothing is deliberate, not an oversight: level file I/O
+# (map_io.gd, hflevel_io.gd) has no area label, and inventing one to make the
+# mapping look complete would put a wrong label on real PRs.
+
+"area: build":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "addons/hammerforge/brush_*.gd"
+          - "addons/hammerforge/face_*.gd"
+          - "addons/hammerforge/hf_*_builder.gd"
+          - "addons/hammerforge/hf_generator*.gd"
+          - "addons/hammerforge/hf_convex_clip.gd"
+          - "addons/hammerforge/hf_extrude_tool.gd"
+          - "addons/hammerforge/hf_polygon_tool.gd"
+          - "addons/hammerforge/hf_path_tool.gd"
+          - "addons/hammerforge/hf_duplicator.gd"
+          - "addons/hammerforge/hf_snap_system.gd"
+          - "addons/hammerforge/plugin_vertex_*.gd"
+          - "addons/hammerforge/plugin_edit_actions.gd"
+          - "addons/hammerforge/dock_brush_handler.gd"
+          - "addons/hammerforge/systems/hf_brush_system.gd"
+          - "addons/hammerforge/systems/hf_carve_*.gd"
+          - "addons/hammerforge/systems/hf_bevel_system.gd"
+          - "addons/hammerforge/systems/hf_clip_preview.gd"
+          - "addons/hammerforge/systems/hf_drag_system.gd"
+          - "addons/hammerforge/systems/hf_hollow_preview.gd"
+          - "addons/hammerforge/systems/hf_array_preview.gd"
+          - "addons/hammerforge/systems/hf_generator_system.gd"
+          - "addons/hammerforge/systems/hf_grid_system.gd"
+
+"area: paint":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "addons/hammerforge/paint/**"
+          - "addons/hammerforge/surface_paint.gd"
+          - "addons/hammerforge/material_manager.gd"
+          - "addons/hammerforge/displacement_data.gd"
+          - "addons/hammerforge/hf_material_atlas.gd"
+          - "addons/hammerforge/hf_prototype_textures.gd"
+          - "addons/hammerforge/hf_decal_tool.gd"
+          - "addons/hammerforge/uv_editor.*"
+          - "addons/hammerforge/plugin_paint_input.gd"
+          - "addons/hammerforge/plugin_material_commands.gd"
+          - "addons/hammerforge/dock_paint_handler.gd"
+          - "addons/hammerforge/systems/hf_paint_system.gd"
+          - "addons/hammerforge/systems/hf_displacement_system.gd"
+          - "materials/**"
+          - "addons/hammerforge/textures/**"
+
+"area: objects":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "addons/hammerforge/entities.json"
+          - "addons/hammerforge/draft_entity.gd"
+          - "addons/hammerforge/hf_entity_def.gd"
+          - "addons/hammerforge/hf_prefab.gd"
+          - "addons/hammerforge/hf_io_runtime.gd"
+          - "addons/hammerforge/prefab_factory.gd"
+          - "addons/hammerforge/plugin_prefab_commands.gd"
+          - "addons/hammerforge/dock_entity_handler.gd"
+          - "addons/hammerforge/dock_connections.gd"
+          - "addons/hammerforge/presets/**"
+          - "addons/hammerforge/systems/hf_entity_system.gd"
+          - "addons/hammerforge/systems/hf_prefab_system.gd"
+          - "addons/hammerforge/systems/hf_spawn_system.gd"
+          - "addons/hammerforge/systems/hf_io_*.gd"
+
+"area: test":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "addons/hammerforge/baker.gd"
+          - "addons/hammerforge/hf_validation.gd"
+          - "addons/hammerforge/playtest_fps.gd"
+          - "addons/hammerforge/plugin_bake_preview.gd"
+          - "addons/hammerforge/systems/hf_bake_system.gd"
+
+"area: architecture":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "addons/hammerforge/plugin.gd"
+          - "addons/hammerforge/level_root.gd"
+          - "addons/hammerforge/hf_tool_registry.gd"
+          - "addons/hammerforge/hf_editor_tool.gd"
+          - "addons/hammerforge/hf_op_result.gd"
+          - "addons/hammerforge/hf_log.gd"
+          - "addons/hammerforge/undo_helper.gd"
+          - "addons/hammerforge/systems/hf_state_system.gd"
+
+"area: docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "overrides/**"
+          - "mkdocs.yml"
+          - "*.md"
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tests/**"
+          - ".gutconfig.json"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "tools/**"
+          - "requirements-*.txt"
+          - "pyproject.toml"
+          - ".gdlintrc"
+          - ".editorconfig"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,51 @@
+# Assembles the next release's notes as PRs merge, so tagging publishes
+# something already written. CHANGELOG.md stays the hand-written, curated
+# account; this is the mechanical one, grouped by the labels triage already
+# applies.
+
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+categories:
+  - title: "Build tools"
+    labels: ["area: build"]
+  - title: "Paint and materials"
+    labels: ["area: paint"]
+  - title: "Entities and prefabs"
+    labels: ["area: objects"]
+  - title: "Bake, validation and playtest"
+    labels: ["area: test"]
+  - title: "Performance"
+    labels: ["performance"]
+  - title: "Fixes"
+    labels: ["bug"]
+  - title: "Architecture"
+    labels: ["area: architecture"]
+  - title: "Documentation"
+    labels: ["area: docs", "documentation"]
+  - title: "Tests and tooling"
+    labels: ["tests", "ci"]
+
+exclude-labels:
+  - "duplicate"
+  - "invalid"
+  - "wontfix"
+
+# Nothing here is 1.0 yet, so a feature does not move the major. A PR carrying
+# no version label lands as a patch bump.
+version-resolver:
+  minor:
+    labels: ["enhancement"]
+  default: patch
+
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+no-changes-template: "- No user-facing changes."
+
+template: |
+  $CHANGES
+
+  **Full changelog:** https://github.com/saworbit/hammerforge/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+  Installing: download the zip below, or point the Godot Asset Library at the
+  `release` branch. See [CHANGELOG.md](https://github.com/saworbit/hammerforge/blob/main/CHANGELOG.md)
+  for the curated account of this release.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,17 @@ name: CI
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  GDTOOLKIT_VERSION: "4.*"
 
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+
+# Read is what this workflow needs. The one job that writes declares it itself,
+# next to the reason.
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,16 +23,20 @@ jobs:
     name: GDScript Lint & Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.x"
+          cache: pip
+          cache-dependency-path: requirements-ci.txt
 
       - name: Install gdtoolkit
         run: |
           python -m pip install --upgrade setuptools
-          python -m pip install "gdtoolkit==${GDTOOLKIT_VERSION}"
+          python -m pip install -r requirements-ci.txt
 
       - name: Check formatting
         run: gdformat --check addons/hammerforge/ tests/
@@ -48,6 +56,49 @@ jobs:
       - name: Check placement order
         run: python3 tools/check_placement_order.py
 
+  tooling-checks:
+    name: Workflow & Tooling Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-ci.txt
+
+      - name: Install tooling
+        run: python -m pip install -r requirements-ci.txt
+
+      # tools/ is small but two of its scripts decide whether a build passes,
+      # and until now nothing checked them at all.
+      - name: Lint tools/
+        run: ruff check tools/
+
+      - name: Check tools/ formatting
+        run: ruff format --check tools/
+
+      # Workflow syntax, expression errors, and shellcheck over every run block.
+      - name: Lint workflow syntax
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+        run: |
+          curl -fsSL -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          tar -xzf actionlint.tar.gz actionlint
+          ./actionlint -color
+
+      # Token scope, credential persistence, expression injection into run
+      # blocks, and actions with known advisories. Needs the token only to look
+      # advisories up.
+      - name: Audit workflows for supply-chain risk
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: zizmor .github/workflows/
+
   unit-tests:
     name: GUT Unit Tests
     runs-on: ubuntu-latest
@@ -58,13 +109,15 @@ jobs:
     env:
       GODOT_VERSION: "4.7-stable"
     steps:
-      - uses: actions/checkout@v7
+      # persist-credentials stays on here, unlike the other jobs: the counts
+      # step below pushes with this token.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 # zizmor: ignore[artipacked]
 
       - name: Download Godot
         run: |
           wget -q "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_linux.x86_64.zip" -O godot.zip
           unzip -q godot.zip
-          mv Godot_v${GODOT_VERSION}_linux.x86_64 /usr/local/bin/godot
+          mv "Godot_v${GODOT_VERSION}_linux.x86_64" /usr/local/bin/godot
           chmod +x /usr/local/bin/godot
 
       - name: Import project
@@ -85,13 +138,17 @@ jobs:
       - name: Commit updated counts
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          if git diff --quiet; then
+          # Scoped to exactly the documents update_test_counts.py rewrites. This
+          # was `git add -A`, which in c121f50 swept the 73 MB Godot download
+          # still sitting in the workspace into a commit on main.
+          DOCS=(README.md docs/features.md DEVELOPMENT.md HammerForge_SPEC.md ROADMAP.md)
+          if git diff --quiet -- "${DOCS[@]}"; then
             echo "Counts already current, nothing to commit."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
+          git add -- "${DOCS[@]}"
           # [skip ci] plus the fact that a GITHUB_TOKEN push raises no workflow
           # event: this cannot start a run that writes the counts again.
           git commit -m "Update published test counts [skip ci]"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot auto-merge
+
+# Patch and minor bumps that pass CI merge themselves. A major bump waits for a
+# human, because that is the one where reading the changelog is the work.
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  auto-merge:
+    name: Auto-merge patch and minor bumps
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Read the bump metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Queue the merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        # --auto queues behind the required status checks rather than merging
+        # now, so a bump that breaks the suite never lands.
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,10 +14,10 @@ on:
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
+# Scoped per job rather than granting the whole workflow write access to
+# Pages: only the deploy job publishes anything.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -26,15 +26,23 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # configure-pages only reads the Pages settings; it does not enable them.
+      pages: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
-      - run: pip install mkdocs-material
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+      - run: pip install -r requirements-docs.txt
       - run: mkdocs build --strict
-      - uses: actions/configure-pages@v6
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           # Must track site_dir in mkdocs.yml, which is .site so Godot does not
           # scan the built site and report UID collisions against docs/.
@@ -43,9 +51,12 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,24 @@
+name: Labeler
+
+# pull_request_target rather than pull_request so the token can still write
+# labels on a pull request opened from a fork. It is safe here for the reason
+# the trigger is usually unsafe does not apply: this job never checks out the
+# pull request's code, and runs nothing from it. It calls one API.
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    name: Apply area labels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
+        with:
+          sync-labels: true

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,31 @@
+name: Release Drafter
+
+# Runs only on merges to main. Deliberately not on pull_request: that variant
+# needs write access on a run triggered by a fork's branch, and drafting notes
+# is not worth that.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-drafter
+  cancel-in-progress: false
+
+jobs:
+  draft:
+    name: Update the draft release
+    runs-on: ubuntu-latest
+    permissions:
+      # Writes the draft release itself.
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: release
@@ -29,9 +29,16 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Pushes the release branch and uploads the zip to the GitHub Release.
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      # Every step below authenticates with an explicit GH_TOKEN, so the
+      # checkout does not need the token left behind in .git/config.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,8 @@ jobs:
         # Printed rather than submitted: the Asset Library has no API for
         # updating an entry, so the hash has to be pasted into the form by hand.
         run: |
-          echo "### Asset Library" >> "$GITHUB_STEP_SUMMARY"
-          echo "Update the Download Commit to \`$RELEASE_COMMIT\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "at https://godotengine.org/asset-library/asset/edit" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Asset Library"
+            echo "Update the Download Commit to \`$RELEASE_COMMIT\`"
+            echo "at https://godotengine.org/asset-library/asset/edit"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,46 @@
+name: Stale
+
+on:
+  schedule:
+    # 03:30 UTC daily, well away from the hour when everyone else's cron runs.
+    - cron: "30 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    name: Mark and close inactive threads
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
+        with:
+          days-before-stale: 60
+          days-before-close: 30
+          # A draft is someone's parked work, not an abandoned thread.
+          exempt-draft-pr: true
+          exempt-issue-labels: "pinned,help wanted,good first issue,enhancement"
+          exempt-pr-labels: "pinned,help wanted"
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+          stale-issue-message: >
+            No activity here for 60 days. This is a solo hobby project, so a
+            quiet thread usually means it is queued rather than rejected —
+            a comment saying it still matters is enough to keep it open.
+            Otherwise it closes in 30 days, and reopening is always fine.
+          stale-pr-message: >
+            No activity on this pull request for 60 days. Comment or push if
+            it is still live; otherwise it closes in 30 days. Closing is not a
+            rejection and reopening is always fine.
+          close-issue-message: >
+            Closing after 90 days without activity. Reopen or file a fresh
+            issue if it comes back.
+          close-pr-message: >
+            Closing after 90 days without activity. Reopen whenever you want
+            to pick it back up.
+          # Keeps the daily run inside a slice of the API budget.
+          operations-per-run: 60

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ docs/brand/svg/*.import
 # MkDocs build output
 .site/
 .docshot-backup/
+
+# CI downloads the Godot build to this name in the workspace root. It was once
+# swept into a commit by an unscoped `git add -A` in the test-count step.
+/godot.zip

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/saworbit/hammerforge/actions/workflows/ci.yml"><img src="https://github.com/saworbit/hammerforge/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+# The plugin is GDScript; Python here is contributor tooling only. It still gets
+# linted, because two of the five scripts in tools/ decide whether a build
+# passes: check_placement_order.py fails CI on a world transform assigned before
+# a node is parented, and build_release_tree.py decides what ships to the Godot
+# Asset Library. A silent break in either is worse than a broken addon.
+
+[tool.ruff]
+line-length = 88
+target-version = "py312"
+# Nothing outside tools/ is Python.
+include = ["tools/*.py"]
+
+[tool.ruff.lint]
+# Defects, not restyling. pyupgrade (UP) is deliberately absent: it wants 28
+# `"%s" % x` prints rewritten as f-strings across scripts that work, which is a
+# separate change from adding a gate. E501 is absent because the formatter owns
+# line length and the two disagree at the margins.
+select = [
+  "E4",  # imports
+  "E7",  # statement-level mistakes
+  "E9",  # syntax and IO errors
+  "F",   # pyflakes: undefined names, unused imports, broken f-strings
+  "I",   # import order
+  "B",   # bugbear: mutable defaults, loop-variable capture, silent except
+  "SIM", # simplify: unclosed handles, redundant branches
+  "RUF",
+]

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,13 @@
+# Pinned exactly rather than loosely so a green CI run stays reproducible and
+# Dependabot has something concrete to bump. These were inline `pip install`
+# arguments in ci.yml, where nothing watched them.
+
+# gdformat --check and gdlint over addons/hammerforge/ and tests/.
+gdtoolkit==4.5.0
+
+# Static analysis of this repository's own workflows: token scope, injection
+# through ${{ }} into run blocks, unpinned third-party actions.
+zizmor==1.30.0
+
+# Lint and format check for tools/*.py.
+ruff==0.16.6

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,4 @@
+# Builds the site published to https://saworbit.github.io/hammerforge/.
+# Split from requirements-ci.txt so a docs-only bump cannot turn the test
+# suite red, and so the Pages job installs nothing it does not use.
+mkdocs-material==9.7.7

--- a/tools/build_release_tree.py
+++ b/tools/build_release_tree.py
@@ -13,6 +13,7 @@ What ships is the list below and nothing that is not on it. The default is
 exclude: a new folder added to the repository does not reach users until
 somebody puts it here deliberately.
 """
+
 from __future__ import annotations
 
 import shutil
@@ -105,7 +106,10 @@ def tracked(path: str) -> list[str]:
     """
     out = subprocess.run(
         ["git", "ls-files", "-z", "--", path],
-        cwd=REPO, capture_output=True, text=True, check=True,
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout
     return [f for f in out.split("\0") if f]
 

--- a/tools/capture_ui.py
+++ b/tools/capture_ui.py
@@ -22,6 +22,7 @@ This script makes the swap recoverable rather than merely careful:
 
 Nothing here is Windows-specific except the default Godot path.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -90,14 +91,14 @@ def prepare() -> None:
     text = proj.read_text(encoding="utf-8")
     text = text.replace(', "res://addons/godot_mcp/plugin.cfg"', "")
     text = "\n".join(
-        l for l in text.split("\n") if not l.startswith("MCPRuntimeProbe=")
+        line for line in text.split("\n") if not line.startswith("MCPRuntimeProbe=")
     )
     # Enable the capture plugin for this run only. It is deliberately not
     # shipped enabled: an EditorPlugin that reads an environment variable and
     # can call get_tree().quit() should not load during a contributor's normal
     # session, where a stray HF_DOCSHOT=1 would close their editor mid-work.
     text, enabled_count = re.subn(
-        r'(?m)^(enabled=PackedStringArray\((?!.*hf_docshot).*?)\)$',
+        r"(?m)^(enabled=PackedStringArray\((?!.*hf_docshot).*?)\)$",
         r'\1, "res://addons/hf_docshot/plugin.cfg")',
         text,
         count=1,
@@ -113,14 +114,14 @@ def prepare() -> None:
         s = re.sub(
             r"^open_scenes=.*$", "open_scenes=PackedStringArray()", s, flags=re.M
         )
-        s = re.sub(r'^current_scene=.*$', 'current_scene=""', s, flags=re.M)
+        s = re.sub(r"^current_scene=.*$", 'current_scene=""', s, flags=re.M)
         # Pin the window geometry. Without this the editor restores its saved
         # position *after* anything else moves it, so a capture that measures
         # the window and then acts on those coordinates ends up pointing at
         # wherever the window used to be -- possibly another monitor. It also
         # makes output dimensions reproducible instead of depending on which
         # display the editor was last maximised on.
-        s = re.sub(r'^mode=.*$', 'mode="windowed"', s, flags=re.M)
+        s = re.sub(r"^mode=.*$", 'mode="windowed"', s, flags=re.M)
         s = re.sub(r"^position=Vector2i.*$", "position=Vector2i(0, 0)", s, flags=re.M)
         s = re.sub(r"^size=Vector2i.*$", "size=Vector2i(1920, 1080)", s, flags=re.M)
         layout.write_text(s, encoding="utf-8", newline="\n")
@@ -132,10 +133,16 @@ def main() -> int:
     # The video harness drives its own editor lifecycle (it has to interleave
     # OBS and mouse control), but must not duplicate the environment swap --
     # duplicating it means duplicating the crash-safety, and one copy would rot.
-    ap.add_argument("--prepare-only", action="store_true",
-                    help="apply the environment swap and exit (for other harnesses)")
-    ap.add_argument("--restore-only", action="store_true",
-                    help="undo a previous --prepare-only and exit")
+    ap.add_argument(
+        "--prepare-only",
+        action="store_true",
+        help="apply the environment swap and exit (for other harnesses)",
+    )
+    ap.add_argument(
+        "--restore-only",
+        action="store_true",
+        help="undo a previous --prepare-only and exit",
+    )
     args = ap.parse_args()
 
     if args.restore_only:
@@ -149,17 +156,32 @@ def main() -> int:
 
     dirty = [str(r) for r in TARGETS if is_dirty(r)]
     if dirty:
-        print("Refusing to run: these tracked files already have changes:", file=sys.stderr)
+        print(
+            "Refusing to run: these tracked files already have changes:",
+            file=sys.stderr,
+        )
         for d in dirty:
             print(f"  {d}", file=sys.stderr)
-        print("Commit or stash them first, or the swap cannot be undone cleanly.", file=sys.stderr)
+        print(
+            "Commit or stash them first, or the swap cannot be undone cleanly.",
+            file=sys.stderr,
+        )
         return 2
 
     # Suppress the onboarding card, which otherwise fills the top of the dock.
     subprocess.run(
-        [args.godot, "--headless", "-s", "res://tools/prepare_editor_smoke.gd",
-         "--path", ".", "--", "--show-welcome=false"],
-        cwd=REPO, check=False,
+        [
+            args.godot,
+            "--headless",
+            "-s",
+            "res://tools/prepare_editor_smoke.gd",
+            "--path",
+            ".",
+            "--",
+            "--show-welcome=false",
+        ],
+        cwd=REPO,
+        check=False,
     )
 
     prepare()

--- a/tools/obs_ctl.py
+++ b/tools/obs_ctl.py
@@ -23,6 +23,7 @@ Diagnostics, for when a capture is not showing what it should:
                               what was asked for
     shot <scene> <path>       write a PNG of what the source is capturing now
 """
+
 import base64
 import hashlib
 import json
@@ -60,8 +61,14 @@ def connect():
 
 def request(ws, kind, data=None):
     rid = str(uuid.uuid4())
-    ws.send(json.dumps({"op": 6, "d": {
-        "requestType": kind, "requestId": rid, "requestData": data or {}}}))
+    ws.send(
+        json.dumps(
+            {
+                "op": 6,
+                "d": {"requestType": kind, "requestId": rid, "requestData": data or {}},
+            }
+        )
+    )
     while True:
         msg = json.loads(ws.recv())
         if msg.get("op") == 7 and msg["d"]["requestId"] == rid:
@@ -78,19 +85,28 @@ def _fit_to_canvas(ws, scene, name):
     playtest window would sit in the top-left corner of a 1920x1080 canvas with
     black around two sides. SCALE_INNER fits it without cropping or distorting.
     """
-    item = request(ws, "GetSceneItemId", {
-        "sceneName": scene, "sourceName": name})["sceneItemId"]
+    item = request(ws, "GetSceneItemId", {"sceneName": scene, "sourceName": name})[
+        "sceneItemId"
+    ]
     video = request(ws, "GetVideoSettings")
     cw, ch = video["baseWidth"], video["baseHeight"]
-    request(ws, "SetSceneItemTransform", {
-        "sceneName": scene, "sceneItemId": item,
-        "sceneItemTransform": {
-            "positionX": cw / 2.0, "positionY": ch / 2.0,
-            "alignment": 0,  # centred on the position, rather than anchored
-            "boundsType": "OBS_BOUNDS_SCALE_INNER",
-            "boundsAlignment": 0,
-            "boundsWidth": float(cw), "boundsHeight": float(ch),
-        }})
+    request(
+        ws,
+        "SetSceneItemTransform",
+        {
+            "sceneName": scene,
+            "sceneItemId": item,
+            "sceneItemTransform": {
+                "positionX": cw / 2.0,
+                "positionY": ch / 2.0,
+                "alignment": 0,  # centred on the position, rather than anchored
+                "boundsType": "OBS_BOUNDS_SCALE_INNER",
+                "boundsAlignment": 0,
+                "boundsWidth": float(cw),
+                "boundsHeight": float(ch),
+            },
+        },
+    )
 
 
 def main():
@@ -111,8 +127,11 @@ def main():
         # Lists what OBS can see, in the order it offers them -- which is the
         # order `capture` picks from when two windows share a title.
         name = sys.argv[2] if len(sys.argv) > 2 else "HF HammerForgeDemo source"
-        items = request(ws, "GetInputPropertiesListPropertyItems",
-                        {"inputName": name, "propertyName": "window"})
+        items = request(
+            ws,
+            "GetInputPropertiesListPropertyItems",
+            {"inputName": name, "propertyName": "window"},
+        )
         for it in items["propertyItems"]:
             print(it["itemValue"])
     elif cmd == "capture":
@@ -143,19 +162,31 @@ def main():
             request(ws, "CreateScene", {"sceneName": scene})
         inputs = [i["inputName"] for i in request(ws, "GetInputList")["inputs"]]
         if name not in inputs:
-            request(ws, "CreateInput", {
-                "sceneName": scene, "inputName": name,
-                "inputKind": "window_capture",
-                "inputSettings": {"method": 2, "cursor": True}})
-        items = request(ws, "GetInputPropertiesListPropertyItems",
-                        {"inputName": name, "propertyName": "window"})
+            request(
+                ws,
+                "CreateInput",
+                {
+                    "sceneName": scene,
+                    "inputName": name,
+                    "inputKind": "window_capture",
+                    "inputSettings": {"method": 2, "cursor": True},
+                },
+            )
+        items = request(
+            ws,
+            "GetInputPropertiesListPropertyItems",
+            {"inputName": name, "propertyName": "window"},
+        )
         # A launched Godot game shows up twice under one identical
         # "title:class:exe" string, and only one of the two survives -- capture
         # the wrong one and the picture goes black a few seconds in. The string
         # cannot tell them apart, so --index picks by position and the last
         # match is the fallback.
-        hits = [it["itemValue"] for it in items["propertyItems"]
-                if all(w in str(it["itemValue"]).lower() for w in wanted)]
+        hits = [
+            it["itemValue"]
+            for it in items["propertyItems"]
+            if all(w in str(it["itemValue"]).lower() for w in wanted)
+        ]
         if not hits:
             raise SystemExit("no window matching all of %r" % wanted)
         if index >= len(hits):
@@ -164,10 +195,15 @@ def main():
         match = hits[index]
         if len(hits) > 1:
             print("  %d identical matches; took #%d" % (len(hits), index))
-        request(ws, "SetInputSettings", {
-            "inputName": name,
-            "inputSettings": {"window": match, "method": 2, "cursor": True},
-            "overlay": True})
+        request(
+            ws,
+            "SetInputSettings",
+            {
+                "inputName": name,
+                "inputSettings": {"window": match, "method": 2, "cursor": True},
+                "overlay": True,
+            },
+        )
         _fit_to_canvas(ws, scene, name)
         request(ws, "SetCurrentProgramScene", {"sceneName": scene})
         print("capturing:", match, "in", scene)
@@ -176,8 +212,7 @@ def main():
         # it could not honour is not reported as an error, it just quietly
         # produces black once the window is no longer on top.
         scene = sys.argv[2] if len(sys.argv) > 2 else "HammerForgeDemo"
-        got = request(ws, "GetInputSettings",
-                      {"inputName": "HF %s source" % scene})
+        got = request(ws, "GetInputSettings", {"inputName": "HF %s source" % scene})
         for k, v in sorted(got.get("inputSettings", {}).items()):
             print("  %s = %r" % (k, v))
     elif cmd == "shot":
@@ -185,9 +220,15 @@ def main():
         # silently re-matched something else looks fine in every log line and
         # only shows up in the picture.
         scene, path = sys.argv[2], sys.argv[3]
-        request(ws, "SaveSourceScreenshot", {
-            "sourceName": "HF %s source" % scene,
-            "imageFormat": "png", "imageFilePath": path})
+        request(
+            ws,
+            "SaveSourceScreenshot",
+            {
+                "sourceName": "HF %s source" % scene,
+                "imageFormat": "png",
+                "imageFilePath": path,
+            },
+        )
         print("shot:", path)
     elif cmd == "scene":
         request(ws, "SetCurrentProgramScene", {"sceneName": sys.argv[2]})

--- a/tools/update_test_counts.py
+++ b/tools/update_test_counts.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import argparse
 import datetime
-import io
 import re
 import sys
 
@@ -69,7 +68,8 @@ def grouped(n: int) -> str:
 
 def parse_gut_log(path: str) -> dict:
     """Pull the totals out of GUT's own summary block."""
-    text = io.open(path, encoding="utf-8", errors="replace").read()
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        text = handle.read()
     required = {
         "scripts": r"^Scripts\s+(\d+)\s*$",
         "tests": r"^Tests\s+(\d+)\s*$",
@@ -82,7 +82,8 @@ def parse_gut_log(path: str) -> dict:
         if not found:
             raise SystemExit(
                 "update_test_counts: no '%s' total in %s. This reads GUT's own "
-                "summary block, so the log has to be the full test output." % (key, path)
+                "summary block, so the log has to be the full test output."
+                % (key, path)
             )
         counts[key] = int(found[-1])
     # Absent from the summary when there are none of them.
@@ -125,7 +126,9 @@ def rewrites(c: dict) -> list:
         ),
         (
             "docs/features.md",
-            r"The verified Godot 4\.7 suite on " + DATE_PATTERN + r" contains \*\*[\d,]+ tests across "
+            r"The verified Godot 4\.7 suite on "
+            + DATE_PATTERN
+            + r" contains \*\*[\d,]+ tests across "
             r"[\d,]+ scripts\*\*: \*\*[\d,]+ passing tests\*\*, \w+ intentional "
             r"no-assert safety tests, and \*\*[\d,]+ assertions\*\*\.",
             (
@@ -138,7 +141,8 @@ def rewrites(c: dict) -> list:
             "DEVELOPMENT.md",
             r"- \*\*GUT unit \+ integration tests\*\* -- [\d,]+ tests across [\d,]+ "
             r"test scripts \([\d,]+ passing plus \w+ intentional no-assert safety "
-            r"tests; [\d,]+ assertions; verified in CI on " + DATE_PATTERN
+            r"tests; [\d,]+ assertions; verified in CI on "
+            + DATE_PATTERN
             + r"; runs Godot headless\)",
             (
                 "- **GUT unit + integration tests** -- {tests} tests across "
@@ -149,7 +153,9 @@ def rewrites(c: dict) -> list:
         ),
         (
             "HammerForge_SPEC.md",
-            r"Full suite \(verified in CI on " + DATE_PATTERN + r"\): \*\*[\d,]+ tests\*\* across \*\*[\d,]+ "
+            r"Full suite \(verified in CI on "
+            + DATE_PATTERN
+            + r"\): \*\*[\d,]+ tests\*\* across \*\*[\d,]+ "
             r"scripts\*\* \(\*\*[\d,]+ passing\*\* plus \w+ intentional no-assert "
             r"safety tests; \*\*[\d,]+ assertions\*\*\)\.",
             (
@@ -177,7 +183,9 @@ def main() -> int:
         "--check", action="store_true", help="report drift, change nothing"
     )
     parser.add_argument(
-        "--date", default=today(), help="verification date to write (default: today UTC)"
+        "--date",
+        default=today(),
+        help="verification date to write (default: today UTC)",
     )
     args = parser.parse_args()
 
@@ -197,7 +205,8 @@ def main() -> int:
 
     stale = []
     for path, pattern, template in rewrites(counts):
-        original = io.open(path, encoding="utf-8").read()
+        with open(path, encoding="utf-8") as handle:
+            original = handle.read()
         found = re.search(pattern, original)
         if found is None:
             raise SystemExit(
@@ -215,7 +224,8 @@ def main() -> int:
         if args.write:
             replacement = template.format(date=args.date)
             updated = original[: found.start()] + replacement + original[found.end() :]
-            io.open(path, "w", encoding="utf-8", newline="\n").write(updated)
+            with open(path, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write(updated)
 
     if args.check:
         if stale:


### PR DESCRIPTION
## Summary

Repository hygiene pass. The finding that started it: **CI committed its own Godot download.** The test-count step ran `git add -A` over a workspace still holding the 75 MB zip it had just unpacked, and in `c121f50` that landed on `main` — two thirds of every clone since.

Everything else came from pointing two auditors at this repo for the first time. `zizmor` found 25 issues, `ruff` found 4 real ones in `tools/`.

## Before / After Behavior

No user-visible change to the plugin. All of it is repository and CI behaviour.

- **Before:** every action floated on a tag, so a retagged upstream would run here silently. Two workflows had no `permissions` block and inherited the default. `tools/` — including the placement-order guard and the release-tree builder — was unlinted. Pip pins lived as inline `pip install` arguments nothing watched. Triage, release notes, and dependency bumps were all manual.
- **After:** all eleven action references pinned to commit SHAs. Every workflow declares `contents: read` at the top and `write` only on the job that needs it, with the reason beside it. Checkouts that never use the token no longer leave it in `.git/config` — with one documented exception, the unit-test job, which pushes. A new **Workflow & Tooling Lint** job runs `ruff`, `actionlint` and `zizmor`, so the next drift fails a PR instead of surviving for years.

### Also here

- `godot.zip` untracked and ignored; the `git add` scoped to the five documents `update_test_counts.py` actually rewrites. The blob stays in history — removing it there is a force-push and a separate decision.
- Three unclosed file handles in `update_test_counts.py`, one of them the **write** that rewrites the five docs, flushing on garbage collection rather than on close.
- Pins moved to `requirements-ci.txt` / `requirements-docs.txt`, split so a docs bump cannot turn the suite red. Dependabot now tracks them alongside the actions.
- `labeler` applies the `area:` labels this repo already defines; `release-drafter` accumulates notes as PRs merge; a stale bot sweeps at 60 days and closes at 90; Dependabot patch and minor bumps merge themselves once green.
- `CODEOWNERS`, which mainly exists to put a review on the vendored upstream directories.
- A live CI badge on the README, replacing nothing — there wasn't one.

New labels created for the automation: `ci`, `tests`, `pinned`, `stale`.

## Related Issue

None — maintenance.

## Checks

- [x] `gdformat --check addons/hammerforge/ tests/` passes — untouched by this PR, verified by CI
- [x] `gdlint addons/hammerforge/` passes — untouched by this PR, verified by CI
- [x] `godot --headless -s res://addons/gut/gut_cmdln.gd --path .` passes — no GDScript changed; verified by CI
- [x] Docs updated together where behavior changed (README badge; no behaviour change to document)
- [x] `git diff --check` is clean and relative Markdown links resolve
- [x] No MCP tokens, `user://` settings, verification logs, editor screenshots, or local client overrides committed — this PR *removes* a stray 75 MB artifact
- [x] `addons/godot_mcp` left untouched

### Verified locally before pushing

```
ruff check tools/                       All checks passed!
ruff format --check tools/              clean
actionlint                              clean
zizmor .github/workflows/               No findings to report (1 documented ignore)
check_placement_order.py --selftest     detector catches the bad snippet
check_placement_order.py                clean across 326 files
build_release_tree.plugin_version()     0.3.0
update_test_counts.py --check           all five document patterns still match
```
