### PR TITLE
Resolve the next version from the prereleases that exist

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,6 +3,12 @@
 # account; this is the mechanical one, grouped by the labels triage already
 # applies.
 
+# Every release so far is a prerelease. Without this, release-drafter looks
+# for the last full release, finds none, and resolves the next version from
+# 0.0.0 -- which is how the first draft came out as v0.0.1 rather than
+# v0.3.1.
+include-pre-releases: true
+
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 


### PR DESCRIPTION
Caught on the first live run of the automation added in #228.

## Summary

release-drafter named its first draft `v0.0.1`. It resolves `$RESOLVED_VERSION` from the last **full** release, and every release of this project is a prerelease (`v0.1.0`, `v0.2.0`, `v0.3.0`), so it found none and counted up from `0.0.0`.

`include-pre-releases: true` makes it consider them, so the next draft is `v0.3.1`.

## Before / After Behavior

- Before: draft release named `v0.0.1`.
- After: draft release named `v0.3.1`.

The bogus `v0.0.1` draft is deleted separately; it was never published.

## Related Issue

Follows #228.

## Checks

- [x] `gdformat --check addons/hammerforge/ tests/` passes — no GDScript changed; verified by CI
- [x] `gdlint addons/hammerforge/` passes — verified by CI
- [x] `godot --headless -s res://addons/gut/gut_cmdln.gd --path .` passes — verified by CI
- [x] Docs updated together where behavior changed — none needed
- [x] `git diff --check` clean
- [x] No MCP tokens, `user://` settings, verification logs, editor screenshots, or local client overrides committed
- [x] `addons/godot_mcp` left untouched