### PR TITLE
Say plainly how this project uses AI

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -1,0 +1,146 @@
+# On the Use of AI
+
+People ask whether AI helped build HammerForge often enough that it deserves one
+real answer instead of a slightly different half-answer each time.
+
+Yes. Extensively. Here is the whole position, including the parts that flatter it
+less.
+
+## The short version
+
+I use AI assistants throughout this project: writing code, reviewing code I wrote
+by hand, drafting documentation, and arguing through design problems I had not yet
+resolved. I do not take what comes back and ship it. Everything here has been
+read, run, and tested, and a good deal of it has been thrown away and done again.
+
+That is not a confession and it is not a sales pitch. It is how this was made, and
+you should be able to find that out without inferring it from the presence of
+`addons/godot_mcp`.
+
+## A level editor is in no position to object
+
+HammerForge exists because placing every vertex by hand is a poor use of a
+designer's afternoon. That is the entire premise, and it is not original to me —
+it is the premise of Hammer, of TrenchBroom, and of every brush-based editor in
+that lineage. The interesting part of level design is deciding where the room
+goes. The rest is getting the geometry to agree with the decision, and that part
+has been worth automating since 1996.
+
+So a tool built to remove tedium, built using tools that remove tedium, is not a
+contradiction. It is the same conviction applied one level up. I would find it
+strange to spend this long automating the tedious parts of blockout while treating
+the tedious parts of writing the automation as sacred.
+
+Labour saved is not the interesting question. The interesting questions are
+whether the result is any good, and whether somebody is answerable for it.
+
+## What "did you write this?" is actually asking
+
+Underneath that question is a better one: *who do I hold responsible when it
+breaks?*
+
+Me. Without qualification, and without an asterisk pointing at a model.
+
+Every line in this repository is a line I chose to ship. If a brush bakes with
+inverted winding, if a cut corrupts your level file, if an undo step eats your
+work — that is mine. Not partly mine. Not mine-with-context. The provenance of a
+suggestion has no bearing on who owns the decision to accept it, and I have never
+found the distinction between code I typed and code I approved to be as morally
+significant as it is usually made out to be. Both are choices. Both are mine.
+
+This is also why I am relaxed about disclosing it. Authorship, in the sense that
+matters to you as a user, was never about keystrokes. It is about accountability,
+and that has not moved.
+
+## What actually checks it
+
+The claim "I test what it produces" is worth nothing on its own — anyone can write
+that sentence. So instead, here is what runs, all of it in this repository and all
+of it runnable by you:
+
+- **The GUT suite** in `tests/`, several thousand tests, run headless in CI on
+  every pull request and every push to `main`.
+- **`tools/check_placement_order.py`**, a static guard for one specific bug class,
+  with a `--selftest` that runs first so a detector which has quietly stopped
+  detecting fails loudly rather than passing everything.
+- **`gdformat` and `gdlint`** over every line of GDScript.
+- **`ruff`** over the Python tooling, **`actionlint`** and **`zizmor`** over the
+  CI workflows themselves.
+- **A protected `main`** that takes no direct pushes from anyone, including me and
+  including CI. Every change arrives as a pull request with three green checks.
+
+None of that exists because of AI. It exists because I am one person and this is
+more code than one person can hold in their head. But it is the reason I am
+willing to work this way: the verification is the load-bearing part, and it does
+not care where a line came from.
+
+## Where it does not help
+
+This is the section that makes the rest believable, so it is specific.
+
+**It is confidently wrong about Godot.** The engine's API surface moves, and
+assistants will cheerfully call `Image.load()`, which Godot 4 removed, or reach
+for `undo()` on `EditorUndoRedoManager`, which has never had it. Every one of
+those cost me time before it cost me nothing, because I now keep notes.
+
+**It reasons poorly about space.** Face winding is clockwise from outside. A basis
+with a negative determinant inverts that winding invisibly — nothing looks wrong
+until you bake. This is exactly the class of error a model will not catch, and
+frankly one I miss by eye too.
+
+**It repeats mistakes convincingly.** A world transform assigned to a node before
+that node is in the tree writes the local transform instead, and the node lands
+shifted by its container. That bug has been fixed here six times, most recently in
+the baker, where it was applying the root transform twice to geometry that ships.
+Six times. The response was not to try harder; it was to write
+`tools/check_placement_order.py` so the build refuses it. That guard is the honest
+artefact of this whole arrangement — proof that I do not trust the process, mine
+or a model's, without something mechanical standing behind it.
+
+**It does not know when the approach is wrong.** It will help you build the wrong
+thing beautifully. Deciding what not to build is still entirely manual, and it is
+most of the job.
+
+I still write code by hand — often the parts I care most about — and then have it
+reviewed. The traffic goes both ways.
+
+## About the art
+
+**No image models were used anywhere in this project.** This matters more to some
+readers than the code does, so here is precisely how each asset was made:
+
+- **The mark and wordmark** are custom-drawn SVG on a 100-unit grid — kerf 3u,
+  ring 14u — with a compact weight for small sizes. Sources in `docs/brand/svg/`,
+  rasterised by `docs/brand/build.py` and `raster.js`. The geometry is a
+  deliberate reference to the outline HammerForge draws around subtract brushes.
+  See [BRAND.md](docs/brand/BRAND.md).
+- **The 150 prototype textures** are generated by script as SVG, not sampled or
+  synthesised. See [Prototype Textures](docs/HammerForge_Prototype_Textures.md).
+- **Every screenshot and clip** is real editor output. The showcase scene is built
+  by `tools/build_showcase_scene.gd` and captured by `tools/capture_showcase.gd`.
+  The hall on the README is 81 brushes, drawn with the tools it is advertising.
+
+If that ever changes, it will say so here first.
+
+## If you would rather not
+
+Some people want nothing to do with software built this way. That is a coherent
+position, held for reasons ranging from labour to provenance to taste, and I am
+not going to argue you out of it.
+
+What I do think is that you are owed the information without having to dig for it,
+which is why this file exists at the root of the repository rather than in a
+footnote. Read it, decide, and use something else with my genuine good wishes if
+that is where you land.
+
+For what it is worth, my own view is narrower than the argument usually gets: I
+think a tool is worth using if it lets one person hold more of a hard problem at
+once, and worth distrusting to exactly the degree that nothing is checking its
+output. Both halves matter. I have tried to build the second half into this
+repository in a way you can run yourself.
+
+---
+
+**Contributors:** the related question — whether *you* can use AI on a pull
+request — is answered in [CONTRIBUTING.md](CONTRIBUTING.md#ai-assisted-contributions).
+The short version is yes, on the same terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,29 @@ prompt for what's actually needed to act on them.
 - Large changes should start with an issue or discussion before a PR.
 - Keep changes aligned with the current MVP and architecture.
 
+## AI-Assisted Contributions
+
+Yes, you can use them. This project is built with them and it would be strange to
+ask otherwise -- see [AI.md](AI.md) for how and why.
+
+The terms are the same ones I hold myself to:
+
+- **You are the author.** Whatever produced a line, you are the one submitting it
+  and the one answerable for it. That does not change.
+- **Be able to explain it.** If you cannot say why a change is correct, or what it
+  does when the input is empty, it is not ready for review. This is the only rule
+  here that ever actually bites.
+- **Tests must test something.** A test that asserts nothing, or that was written
+  to match the implementation rather than the requirement, is worse than no test.
+  CI counts assertions for a reason.
+- **Run the checks before you open the PR.** They are listed under
+  [Running Checks Locally](#running-checks-locally) and they will catch most of
+  what a review would otherwise spend its time on.
+
+You do not need to disclose per-pull-request whether you used an assistant. I am
+not going to ask, and I would not be able to verify the answer. What gets reviewed
+is the change.
+
 ## How To Contribute
 1. Open an issue describing the problem and proposed fix.
 2. Keep PRs small and limited to one topic.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@
 
 > **Fair warning:** This is a solo hobby project in early alpha. I built it to support another project and it grew from there. It's buggy, rough around the edges, and a bit directionless. If any of this looks useful to you, I'd genuinely appreciate help testing and filing issues. Contributions welcome -- just know you're signing up for an adventure, not a polished product.
 
+> **On AI:** Yes, AI assistants helped build this -- writing code, reviewing
+> code I wrote by hand, drafting docs. Nothing here ships unread or untested,
+> and no image models were used for any art, texture or screenshot. The full
+> position, including where it does not help, is in [AI.md](AI.md).
+
 ---
 
 ## How It Works
@@ -160,6 +165,7 @@ This repository also vendors a project-scoped Godot MCP server in `addons/godot_
 | [Changelog](CHANGELOG.md) | Version history |
 | [Roadmap](ROADMAP.md) | Planned features and priorities |
 | [Brand](docs/brand/BRAND.md) | The mark, palette, and asset generators |
+| [AI Disclosure](AI.md) | How AI is used here, what checks it, and where it does not help |
 | [Contributing](CONTRIBUTING.md) | How to contribute |
 | [Code of Conduct](CODE_OF_CONDUCT.md) | Expected behavior and how to report a problem |
 | [Security Policy](SECURITY.md) | What counts as a vulnerability and how to report one privately |


### PR DESCRIPTION
Answers a question that comes up constantly, in one linkable place, instead of a slightly different half-answer each time.

## Summary

The repository already answers this — badly. `addons/godot_mcp` is 97 tracked files and the README documents a vendored Godot MCP server, so anyone technical browsing this already knows. They just have no account of it. Evidence without explanation is the worst possible arrangement of the two.

Three changes:

- **`AI.md`** at the root, beside `SECURITY.md` and `CODE_OF_CONDUCT.md` — the full position.
- **README** — a short `> **On AI:**` note directly beneath the existing `> **Fair warning:**` blockquote, plus a row in the Documentation table.
- **`CONTRIBUTING.md`** — a short `AI-Assisted Contributions` section answering the question a reader has immediately afterwards.

## What AI.md argues

1. **A level editor is in no position to object.** HammerForge exists because placing every vertex by hand is a poor use of an afternoon — that is the premise of Hammer and TrenchBroom too. A tool built to remove tedium, built with tools that remove tedium, is the same conviction applied one level up.
2. **"Did you write this?" is really "who do I hold responsible?"** Me. Without qualification. Provenance of a suggestion has no bearing on ownership of the decision to accept it.
3. **Verification stated as fact, not claim.** The GUT suite, the placement-order guard and its `--selftest`, gdformat/gdlint, ruff/actionlint/zizmor, and a `main` that takes no direct pushes from anyone including CI. All runnable by the reader.
4. **Where it does not help** — named Godot APIs it gets wrong (`Image.load()`, `undo()` on `EditorUndoRedoManager`), the winding errors it cannot see, and the placement-order bug fixed six times before the answer stopped being "try harder" and became `tools/check_placement_order.py`.
5. **No image models, anywhere** — with the actual provenance of each asset.

## Before / After Behavior

Documentation only. No code changes.

- Before: AI use inferable from `addons/godot_mcp` and the README MCP section, explained nowhere.
- After: stated at the root of the repository, linked from the README and the Documentation table.

## Related Issue

None — raised directly.

## Checks

- [x] `gdformat --check addons/hammerforge/ tests/` passes — no GDScript changed; verified by CI
- [x] `gdlint addons/hammerforge/` passes — verified by CI
- [x] `godot --headless -s res://addons/gut/gut_cmdln.gd --path .` passes — verified by CI
- [x] Docs updated together where behavior changed
- [x] `git diff --check` is clean and relative Markdown links resolve — **checked programmatically**: every relative link and `#anchor` across `AI.md`, `README.md` and `CONTRIBUTING.md` resolves, and every file named in prose exists
- [x] No MCP tokens, `user://` settings, verification logs, editor screenshots, or local client overrides committed
- [x] `addons/godot_mcp` left untouched

### Factual claims verified against the repo

| Claim | Source |
|---|---|
| Kerf 3u, ring 14u on a 100-unit grid | `docs/brand/BRAND.md` |
| 20 SVG brand sources | `ls docs/brand/svg/*.svg` |
| 150 prototype textures | README / `HammerForge_Prototype_Textures.md` |
| Hero hall is 81 brushes | README caption |
| Placement bug fixed six times | comment in `.github/workflows/ci.yml` |

No hard test count is written into `AI.md` on purpose — `tools/update_test_counts.py` rewrites five specific documents, and a number here would go stale outside that set.