### PR TITLE
Document the checks CI now runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,8 +145,27 @@ If you get "class_names not imported", run `godot --headless --import --path .` 
 - Keep tests focused: one behavior per test function.
 - For negative-path tests that trigger runtime warnings, use `HFLog.warn()` in production code and `HFLog.begin_test_capture()` / `end_test_capture()` in tests. This prevents expected warnings from polluting the test output. See `test_bevel.gd` for the pattern.
 
+### Python and Workflow Checks
+Only relevant if you touch `tools/` or `.github/workflows/`. CI runs these and
+will fail the build on them.
+```
+pip install -r requirements-ci.txt
+ruff check tools/
+ruff format --check tools/
+zizmor .github/workflows/
+```
+
+`actionlint` is downloaded by the workflow rather than pinned in the requirements
+file, so grab the release binary if you want it locally. It runs shellcheck over
+every `run:` block, which is usually what catches things.
+
 ### CI
-All checks (format, lint, unit tests) run automatically on push/PR to `main` via GitHub Actions.
+Three jobs run on every push and pull request to `main`: **GDScript Lint and
+Format**, **Workflow and Tooling Lint**, and **GUT Unit Tests**. All three have to
+pass before anything can merge, and `main` takes no direct pushes from anyone.
+
+You do not need to update the published test counts by hand. CI measures the
+suite on your pull request and commits the numbers to your branch.
 
 ## Communication
 - Be clear about tradeoffs and known limitations.


### PR DESCRIPTION
CI gained `ruff`, `actionlint` and `zizmor` in #228 but `Running Checks Locally` was never updated, so a contributor can run everything listed and still fail the build.

Adds a Python and Workflow Checks section, and corrects the CI section, which still described three jobs as "format, lint, unit tests" and did not mention that `main` is protected or that CI writes the test counts for you.

## Checks

- [x] `gdformat --check addons/hammerforge/ tests/` passes, verified by CI
- [x] `gdlint addons/hammerforge/` passes, verified by CI
- [x] `godot --headless -s res://addons/gut/gut_cmdln.gd --path .` passes, verified by CI
- [x] Docs updated together where behavior changed
- [x] `git diff --check` clean, links resolve
- [x] No MCP tokens, `user://` settings, verification logs, editor screenshots, or local client overrides committed
- [x] `addons/godot_mcp` left untouched