### PR TITLE
hf: give the six previews one base instead of six copies of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog, and this project follows semantic versioning.
 
 ## [Unreleased]
+### Changed
+- **The six preview overlays share one base instead of six copies of it.** Hollow,
+  carve, clip, subtract, structure and array each owned a container node, a set of
+  `MeshInstance3D`, a ghost material and a teardown, and each wrote all four out
+  again. Two called the container `_container` and four called it
+  `_preview_container`. That duplication is what let four of them drift into
+  placing their meshes in the wrong space — each was fixed on its own, because
+  there was nowhere to fix it once.
+  - `HFPreviewSystem` extends `HFSystem` and owns the container lifecycle, the
+    mesh pool, `ghost_material()`, `clear()`, `set_enabled()` and `destroy()`.
+    What stays with each preview is what actually differs: what it draws, what
+    colour it draws in, and how it decides there is nothing to draw.
+  - **The third copy of `line_mesh` is gone.** Carve, clip and hollow each carried
+    a private `_lines_mesh()` static identical to `HFOutlineUtil.line_mesh()`.
+  - `_ensure_container()` stays overridable, because clip makes three named meshes
+    rather than an indexed pool — but the base reaches the container through a
+    non-virtual `_build_container()`, so an override that makes meshes cannot be
+    re-entered by the making of them.
+  - Subtract keeps its own `set_enabled()`: it connects and disconnects signals on
+    the way in and out, so unlike the others it has to know it is already enabled.
+  - Six previews: 1,249 lines to 1,006. With the 122-line base, 121 lines fewer
+    overall.
+  - **Behaviour is unchanged**, and the suite reports the same counts either side
+    of the refactor. **Coverage** (`tests/test_preview_system.gd`): 16 tests over
+    the material, the container, the pool, clearing, enabling and teardown,
+    including a drift guard that fails if two previews ever name their container
+    the same thing.
+
 ### Added
 - **An Update to an array now says what it would undo.** A copy can be dragged
   somewhere on purpose; Update put it back without a word, and Detach sat beside

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -400,7 +400,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,056 tests across 159 test scripts (3,049 passing plus seven intentional no-assert safety tests; 15,945 assertions; verified in CI on September 9, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,072 tests across 160 test scripts (3,065 passing plus seven intentional no-assert safety tests; 16,000 assertions; verified in CI on September 9, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -104,6 +104,7 @@ All signals are defined on `LevelRoot`. Subsystems emit them via `root.<signal>.
 | `hf_carve_system.gd` | `HFCarveSystem` | Boolean-subtract carve (progressive-remainder box slicing) |
 | `hf_io_visualizer.gd` | `HFIOVisualizer` | Entity I/O connection lines in viewport (ImmediateMesh) |
 | `hf_io_presets.gd` | `HFIOPresets` | Built-in and user-saved I/O connection presets with target-tag mapping |
+| `hf_preview_system.gd` | `HFPreviewSystem` | Base for the six overlay previews. Owns the container node, the `MeshInstance3D` pool, `ghost_material()`, `clear()`, `set_enabled()` and `destroy()`; each preview keeps only what it draws, what colour, and when there is nothing to draw. `_ensure_container()` is overridable for a preview whose meshes are named rather than indexed, and the base reaches the container through a non-virtual `_build_container()` so such an override cannot be re-entered |
 | `hf_subtract_preview.gd` | `HFSubtractPreview` | Live CSG cut overlay between subtract and additive brushes, with a wireframe AABB fallback (debounced, pooled) |
 | `hf_carve_preview.gd` | `HFCarvePreview` | Green wireframe preview of carve slice pieces before confirmation |
 | `hf_clip_preview.gd` | `HFClipPreview` | Clip-plane and retained-half preview before confirmation |

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -540,6 +540,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 9, 2026): **3,056 tests** across **159 scripts** (**3,049 passing** plus seven intentional no-assert safety tests; **15,945 assertions**).
+Full suite (verified in CI on September 9, 2026): **3,072 tests** across **160 scripts** (**3,065 passing** plus seven intentional no-assert safety tests; **16,000 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3049%20passing-brightgreen" alt="3049 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3065%20passing-brightgreen" alt="3065 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -723,11 +723,8 @@ and run".
   dense dome reads as a mesh of lines rather than a surface.
 - It shows the pieces a rebuild would make, not which existing pieces it would
   replace; the hand-edit count beside it is still what says that.
-- Hollow, carve, clip, subtract, structure and array run six near-identical
-  preview systems, each with its own container, mesh handling and teardown. The
-  duplication is what let four of them drift into placing their meshes in the
-  wrong space; `tests/test_preview_placement.gd` now holds the property they
-  share, but the mechanics are still six copies.
+- **Resolved** by the preview-base wave below: the mechanics are one copy now,
+  in `HFPreviewSystem`.
 
 ## Done (Live Arrays — Changing One After You Have Made It — September 2026)
 - Selecting any piece of an array turns the **Duplicate Array** section into an
@@ -798,6 +795,33 @@ and run".
 - The warning is refreshed when the selection changes, not while a piece stays
   selected and is dragged under it — the same limit the Structure section has.
 
+## Done (One Preview Base — September 2026)
+- Hollow, carve, clip, subtract, structure and array each owned a container node,
+  a set of `MeshInstance3D`, a ghost material and a teardown, and each wrote all
+  four out again. Two called the container `_container` and four called it
+  `_preview_container`. That duplication is what let four of them drift into
+  placing their meshes in the wrong space: each was fixed on its own, because
+  there was nowhere to fix it once.
+- `HFPreviewSystem` (`systems/hf_preview_system.gd`) extends `HFSystem` and owns
+  the container lifecycle, the mesh pool, `ghost_material()`, `clear()`,
+  `set_enabled()` and `destroy()`. What stays with each preview is what actually
+  differs: what it draws, what colour it draws in, and how it decides there is
+  nothing to draw.
+- **The third copy of `line_mesh` is gone.** Carve, clip and hollow each carried a
+  private `_lines_mesh()` static identical to `HFOutlineUtil.line_mesh()`.
+- `_ensure_container()` stays overridable, because clip makes three named meshes
+  rather than an indexed pool — but the base reaches the container through a
+  non-virtual `_build_container()`, so an override that makes meshes cannot be
+  re-entered by the making of them. Getting that wrong the first time was an
+  immediate stack overflow rather than a subtle bug, which is the right failure.
+- Subtract keeps its own `set_enabled()`: it connects and disconnects signals on
+  the way in and out, so unlike the others it has to know it is already enabled.
+- Six previews: 1,249 lines to 1,006. With the 122-line base, 121 lines fewer
+  overall and one definition of each mechanic instead of six.
+- Behaviour is unchanged: the suite reports the same counts either side of the
+  refactor. 16 new tests (`tests/test_preview_system.gd`), including a drift guard
+  that fails if two previews ever name their container the same thing.
+
 ## Future (Wave 3 -- Polish)
 - Multiple simultaneous cordons.
 - Multi-tool presets for common workflows.
@@ -841,7 +865,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,056 tests across 159 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. The issue tracker is clear as of September 8, 2026. No known limitation is currently untracked and uncovered.
+The current suite covers 3,072 tests across 160 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. The issue tracker is clear as of September 8, 2026. No known limitation is currently untracked and uncovered.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/systems/hf_array_preview.gd
+++ b/addons/hammerforge/systems/hf_array_preview.gd
@@ -1,6 +1,6 @@
 @tool
 class_name HFArrayPreview
-extends "hf_system.gd"
+extends "hf_preview_system.gd"
 ## A wireframe of the copies an array would make, before it makes them.
 ##
 ## The Structure section learned to draw itself; the array section next to it did
@@ -19,7 +19,6 @@ const HFOutlineUtil = preload("../hf_outline_util.gd")
 ## something that does.
 const GHOST_COLOR := Color(0.9, 0.95, 1.0, 0.5)
 
-var _container: Node3D
 var _mesh_instance: MeshInstance3D
 var _material: StandardMaterial3D
 var _copy_count: int = 0
@@ -28,11 +27,11 @@ var _copy_count: int = 0
 func _init(p_root: Node3D = null) -> void:
 	super(p_root)
 	_enabled = false
-	_material = StandardMaterial3D.new()
-	_material.albedo_color = GHOST_COLOR
-	_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-	_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-	_material.no_depth_test = true
+	_material = ghost_material(GHOST_COLOR)
+
+
+func _preview_name() -> String:
+	return "ArrayPreview"
 
 
 ## Draw the copies these placements would make of these brushes.
@@ -73,7 +72,7 @@ func show_preview(brush_ids: Array, placements: Array) -> int:
 	# stands somewhere different; the mesh itself carries no placement of its own.
 	_mesh_instance.global_transform = Transform3D.IDENTITY
 	_mesh_instance.visible = true
-	_container.visible = true
+	_preview_container.visible = true
 	_copy_count = placements.size()
 	return _copy_count
 
@@ -85,41 +84,24 @@ func copy_count() -> int:
 
 func clear() -> void:
 	_copy_count = 0
-	_enabled = false
 	if is_instance_valid(_mesh_instance):
-		_mesh_instance.visible = false
 		_mesh_instance.mesh = null
-	if is_instance_valid(_container):
-		_container.visible = false
+	super()
 
 
 func set_enabled(value: bool) -> void:
 	if value:
-		_enabled = true
 		_ensure_nodes()
-	else:
-		clear()
+	super(value)
 
 
 func destroy() -> void:
 	_copy_count = 0
-	_enabled = false
 	_mesh_instance = null
-	if is_instance_valid(_container):
-		if _container.get_parent():
-			_container.get_parent().remove_child(_container)
-		_container.free()
-	_container = null
+	super()
 
 
 func _ensure_nodes() -> void:
-	if not is_instance_valid(_container):
-		_container = Node3D.new()
-		_container.name = "ArrayPreview"
-		root.add_child(_container)
-	_container.visible = true
+	_ensure_container()
 	if not is_instance_valid(_mesh_instance):
-		_mesh_instance = MeshInstance3D.new()
-		_mesh_instance.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-		_mesh_instance.material_override = _material
-		_container.add_child(_mesh_instance)
+		_mesh_instance = _make_mesh(_material)

--- a/addons/hammerforge/systems/hf_carve_preview.gd
+++ b/addons/hammerforge/systems/hf_carve_preview.gd
@@ -1,6 +1,6 @@
 @tool
 class_name HFCarvePreview
-extends "hf_system.gd"
+extends "hf_preview_system.gd"
 ## Real-time wireframe preview showing the resulting slice pieces that would
 ## be created by a carve operation.  Uses the same ImmediateMesh wireframe
 ## pattern as HFSubtractPreview, but draws the 1-6 remaining pieces in green
@@ -9,8 +9,6 @@ extends "hf_system.gd"
 const DraftBrush = preload("../brush_instance.gd")
 const HFOutlineUtil = preload("../hf_outline_util.gd")
 
-var _preview_container: Node3D
-var _mesh_pool: Array = []  # Array[MeshInstance3D]
 var _active_count: int = 0
 var _material: StandardMaterial3D
 
@@ -23,25 +21,7 @@ const MAX_PREVIEWS := 50
 func _init(p_root: Node3D = null) -> void:
 	super(p_root)
 	_enabled = false
-	_material = StandardMaterial3D.new()
-	_material.albedo_color = Color(0.3, 0.9, 0.3, 0.6)
-	_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-	_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-	_material.no_depth_test = true
-
-
-func set_enabled(value: bool) -> void:
-	if value == _enabled:
-		return
-	_enabled = value
-	if _enabled:
-		_ensure_container()
-	else:
-		clear()
-
-
-func is_enabled() -> bool:
-	return _enabled
+	_material = ghost_material(Color(0.3, 0.9, 0.3, 0.6))
 
 
 ## Show preview for a specific carver brush.
@@ -54,24 +34,14 @@ func show_preview(carver_id: String) -> void:
 ## Hide the preview and reset state.
 func clear() -> void:
 	_carver_id = ""
-	for i in _mesh_pool.size():
-		if is_instance_valid(_mesh_pool[i]):
-			_mesh_pool[i].visible = false
 	_active_count = 0
-	if _preview_container and is_instance_valid(_preview_container):
-		_preview_container.visible = false
+	super()
 
 
 ## Free all resources immediately.
 func destroy() -> void:
-	_mesh_pool.clear()
 	_active_count = 0
-	if _preview_container and is_instance_valid(_preview_container):
-		if _preview_container.get_parent():
-			_preview_container.get_parent().remove_child(_preview_container)
-		_preview_container.free()
-	_preview_container = null
-	_enabled = false
+	super()
 
 
 ## Compute and display preview slices for the current carver brush.
@@ -119,48 +89,22 @@ func _rebuild() -> void:
 
 	_ensure_container()
 
-	# Grow pool if needed
-	while _mesh_pool.size() < previews.size():
-		var mi = MeshInstance3D.new()
-		mi.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-		mi.material_override = _material
-		_preview_container.add_child(mi)
-		_mesh_pool.append(mi)
+	_grow_pool(previews.size(), _material)
 
 	# Update active wireframes with the real outline of each resulting piece.
 	for i in previews.size():
 		var mi: MeshInstance3D = _mesh_pool[i]
 		var entry: Dictionary = previews[i]
-		mi.mesh = _lines_mesh(HFOutlineUtil.face_boundary_lines(entry["faces"]))
+		mi.mesh = HFOutlineUtil.line_mesh(HFOutlineUtil.face_boundary_lines(entry["faces"]))
 		# World space: the entry carries the target brush's own global transform.
 		mi.global_transform = entry["transform"]
 		mi.visible = true
 
-	# Hide unused
-	for i in range(previews.size(), _mesh_pool.size()):
-		if is_instance_valid(_mesh_pool[i]):
-			_mesh_pool[i].visible = false
+	_hide_meshes_from(previews.size())
 
 	_active_count = previews.size()
 	_preview_container.visible = _active_count > 0
 
 
-## Wrap a flat list of line-segment endpoints into a drawable mesh.
-static func _lines_mesh(points: PackedVector3Array) -> ArrayMesh:
-	var mesh := ArrayMesh.new()
-	if points.size() < 2:
-		return mesh
-	var arrays := []
-	arrays.resize(Mesh.ARRAY_MAX)
-	arrays[Mesh.ARRAY_VERTEX] = points
-	mesh.add_surface_from_arrays(Mesh.PRIMITIVE_LINES, arrays)
-	return mesh
-
-
-func _ensure_container() -> void:
-	if _preview_container and is_instance_valid(_preview_container):
-		_preview_container.visible = true
-		return
-	_preview_container = Node3D.new()
-	_preview_container.name = "CarvePreview"
-	root.add_child(_preview_container)
+func _preview_name() -> String:
+	return "CarvePreview"

--- a/addons/hammerforge/systems/hf_clip_preview.gd
+++ b/addons/hammerforge/systems/hf_clip_preview.gd
@@ -1,6 +1,6 @@
 @tool
 class_name HFClipPreview
-extends "hf_system.gd"
+extends "hf_preview_system.gd"
 ## Real-time preview showing the two resulting pieces from a clip operation,
 ## plus a translucent split plane.  Wireframe boxes show the two halves;
 ## a quad mesh shows the cut plane itself.
@@ -9,7 +9,6 @@ const DraftBrush = preload("../brush_instance.gd")
 const HFOutlineUtil = preload("../hf_outline_util.gd")
 const HFConvexClip = preload("../hf_convex_clip.gd")
 
-var _preview_container: Node3D
 var _piece_a_mesh: MeshInstance3D
 var _piece_b_mesh: MeshInstance3D
 var _plane_mesh: MeshInstance3D
@@ -26,33 +25,10 @@ func _init(p_root: Node3D = null) -> void:
 	super(p_root)
 	_enabled = false
 	# Wireframe for the two resulting pieces — cyan
-	_wire_material = StandardMaterial3D.new()
-	_wire_material.albedo_color = Color(0.2, 0.8, 1.0, 0.7)
-	_wire_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-	_wire_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-	_wire_material.no_depth_test = true
-
-	# Semi-transparent plane showing the cut surface — orange
-	_plane_material = StandardMaterial3D.new()
-	_plane_material.albedo_color = Color(1.0, 0.6, 0.1, 0.3)
-	_plane_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-	_plane_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-	_plane_material.no_depth_test = true
-	_plane_material.cull_mode = BaseMaterial3D.CULL_DISABLED
-
-
-func set_enabled(value: bool) -> void:
-	if value == _enabled:
-		return
-	_enabled = value
-	if _enabled:
-		_ensure_container()
-	else:
-		clear()
-
-
-func is_enabled() -> bool:
-	return _enabled
+	_wire_material = ghost_material(Color(0.2, 0.8, 1.0, 0.7))
+	# Semi-transparent plane showing the cut surface — orange, and drawn from both
+	# sides because the cut is looked at from whichever side you are standing on.
+	_plane_material = ghost_material(Color(1.0, 0.6, 0.1, 0.3), true)
 
 
 ## Show preview for a clip operation on the given brush.
@@ -74,27 +50,17 @@ func update_split(split_pos: float) -> void:
 ## Hide the preview.
 func clear() -> void:
 	_brush_id = ""
-	if _piece_a_mesh and is_instance_valid(_piece_a_mesh):
-		_piece_a_mesh.visible = false
-	if _piece_b_mesh and is_instance_valid(_piece_b_mesh):
-		_piece_b_mesh.visible = false
-	if _plane_mesh and is_instance_valid(_plane_mesh):
-		_plane_mesh.visible = false
-	if _preview_container and is_instance_valid(_preview_container):
-		_preview_container.visible = false
+	# The three meshes are in the pool like any other preview's, so hiding them is
+	# the base's job even though this one addresses them by name.
+	super()
 
 
 ## Free all resources immediately.
 func destroy() -> void:
-	if _preview_container and is_instance_valid(_preview_container):
-		if _preview_container.get_parent():
-			_preview_container.get_parent().remove_child(_preview_container)
-		_preview_container.free()
-	_preview_container = null
 	_piece_a_mesh = null
 	_piece_b_mesh = null
 	_plane_mesh = null
-	_enabled = false
+	super()
 
 
 func _rebuild() -> void:
@@ -142,10 +108,10 @@ func _rebuild() -> void:
 	# from the brush's own global transform and the plane from world bounds, while
 	# the container hangs off LevelRoot — so a level whose root has been moved or
 	# turned drew the cut a whole root transform away from the brush being cut.
-	_piece_a_mesh.mesh = _lines_mesh(HFOutlineUtil.face_boundary_lines(front))
+	_piece_a_mesh.mesh = HFOutlineUtil.line_mesh(HFOutlineUtil.face_boundary_lines(front))
 	_piece_a_mesh.global_transform = xform
 	_piece_a_mesh.visible = true
-	_piece_b_mesh.mesh = _lines_mesh(HFOutlineUtil.face_boundary_lines(back))
+	_piece_b_mesh.mesh = HFOutlineUtil.line_mesh(HFOutlineUtil.face_boundary_lines(back))
 	_piece_b_mesh.global_transform = xform
 	_piece_b_mesh.visible = true
 
@@ -156,40 +122,19 @@ func _rebuild() -> void:
 	_preview_container.visible = true
 
 
-## Wrap a flat list of line-segment endpoints into a drawable mesh.
-static func _lines_mesh(points: PackedVector3Array) -> ArrayMesh:
-	var mesh := ArrayMesh.new()
-	if points.size() < 2:
-		return mesh
-	var arrays := []
-	arrays.resize(Mesh.ARRAY_MAX)
-	arrays[Mesh.ARRAY_VERTEX] = points
-	mesh.add_surface_from_arrays(Mesh.PRIMITIVE_LINES, arrays)
-	return mesh
+func _preview_name() -> String:
+	return "ClipPreview"
 
 
+## Two wireframe halves and the cut between them, made on first use.
 func _ensure_container() -> void:
-	if _preview_container and is_instance_valid(_preview_container):
-		_preview_container.visible = true
-		return
-	_preview_container = Node3D.new()
-	_preview_container.name = "ClipPreview"
-	root.add_child(_preview_container)
-
-	_piece_a_mesh = MeshInstance3D.new()
-	_piece_a_mesh.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-	_piece_a_mesh.material_override = _wire_material
-	_preview_container.add_child(_piece_a_mesh)
-
-	_piece_b_mesh = MeshInstance3D.new()
-	_piece_b_mesh.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-	_piece_b_mesh.material_override = _wire_material
-	_preview_container.add_child(_piece_b_mesh)
-
-	_plane_mesh = MeshInstance3D.new()
-	_plane_mesh.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-	_plane_mesh.material_override = _plane_material
-	_preview_container.add_child(_plane_mesh)
+	_build_container()
+	if not is_instance_valid(_piece_a_mesh):
+		_piece_a_mesh = _make_mesh(_wire_material)
+	if not is_instance_valid(_piece_b_mesh):
+		_piece_b_mesh = _make_mesh(_wire_material)
+	if not is_instance_valid(_plane_mesh):
+		_plane_mesh = _make_mesh(_plane_material)
 
 
 ## Build a translucent quad representing the split plane.

--- a/addons/hammerforge/systems/hf_hollow_preview.gd
+++ b/addons/hammerforge/systems/hf_hollow_preview.gd
@@ -1,14 +1,12 @@
 @tool
 class_name HFHollowPreview
-extends "hf_system.gd"
+extends "hf_preview_system.gd"
 ## Real-time wireframe preview showing the 6 wall pieces that would result
 ## from a hollow operation.  Drawn in yellow wireframe over the original brush.
 
 const DraftBrush = preload("../brush_instance.gd")
 const HFOutlineUtil = preload("../hf_outline_util.gd")
 
-var _preview_container: Node3D
-var _mesh_pool: Array = []  # Array[MeshInstance3D] — 6 walls max
 var _active_count: int = 0
 var _material: StandardMaterial3D
 
@@ -20,25 +18,7 @@ var _wall_thickness: float = 4.0
 func _init(p_root: Node3D = null) -> void:
 	super(p_root)
 	_enabled = false
-	_material = StandardMaterial3D.new()
-	_material.albedo_color = Color(1.0, 0.85, 0.2, 0.6)
-	_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-	_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-	_material.no_depth_test = true
-
-
-func set_enabled(value: bool) -> void:
-	if value == _enabled:
-		return
-	_enabled = value
-	if _enabled:
-		_ensure_container()
-	else:
-		clear()
-
-
-func is_enabled() -> bool:
-	return _enabled
+	_material = ghost_material(Color(1.0, 0.85, 0.2, 0.6))
 
 
 ## Show preview for a hollow operation on the given brush.
@@ -59,24 +39,14 @@ func update_thickness(wall_thickness: float) -> void:
 ## Hide the preview.
 func clear() -> void:
 	_brush_id = ""
-	for i in _mesh_pool.size():
-		if is_instance_valid(_mesh_pool[i]):
-			_mesh_pool[i].visible = false
 	_active_count = 0
-	if _preview_container and is_instance_valid(_preview_container):
-		_preview_container.visible = false
+	super()
 
 
 ## Free all resources immediately.
 func destroy() -> void:
-	_mesh_pool.clear()
 	_active_count = 0
-	if _preview_container and is_instance_valid(_preview_container):
-		if _preview_container.get_parent():
-			_preview_container.get_parent().remove_child(_preview_container)
-		_preview_container.free()
-	_preview_container = null
-	_enabled = false
+	super()
 
 
 func _rebuild() -> void:
@@ -107,18 +77,12 @@ func _rebuild() -> void:
 
 	_ensure_container()
 
-	# Grow pool if needed
-	while _mesh_pool.size() < walls.size():
-		var mi = MeshInstance3D.new()
-		mi.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-		mi.material_override = _material
-		_preview_container.add_child(mi)
-		_mesh_pool.append(mi)
+	_grow_pool(walls.size(), _material)
 
 	# Update active wireframes with the real outline of each wall.
 	for i in walls.size():
 		var mi: MeshInstance3D = _mesh_pool[i]
-		mi.mesh = _lines_mesh(HFOutlineUtil.face_boundary_lines(walls[i]))
+		mi.mesh = HFOutlineUtil.line_mesh(HFOutlineUtil.face_boundary_lines(walls[i]))
 		# Placed in world space, not the container's. The outlines come from the
 		# brush's own global transform, and the container hangs off LevelRoot — so
 		# a level whose root has been moved or turned drew this a whole root
@@ -126,31 +90,11 @@ func _rebuild() -> void:
 		mi.global_transform = xform
 		mi.visible = true
 
-	# Hide unused
-	for i in range(walls.size(), _mesh_pool.size()):
-		if is_instance_valid(_mesh_pool[i]):
-			_mesh_pool[i].visible = false
+	_hide_meshes_from(walls.size())
 
 	_active_count = walls.size()
 	_preview_container.visible = _active_count > 0
 
 
-## Wrap a flat list of line-segment endpoints into a drawable mesh.
-static func _lines_mesh(points: PackedVector3Array) -> ArrayMesh:
-	var mesh := ArrayMesh.new()
-	if points.size() < 2:
-		return mesh
-	var arrays := []
-	arrays.resize(Mesh.ARRAY_MAX)
-	arrays[Mesh.ARRAY_VERTEX] = points
-	mesh.add_surface_from_arrays(Mesh.PRIMITIVE_LINES, arrays)
-	return mesh
-
-
-func _ensure_container() -> void:
-	if _preview_container and is_instance_valid(_preview_container):
-		_preview_container.visible = true
-		return
-	_preview_container = Node3D.new()
-	_preview_container.name = "HollowPreview"
-	root.add_child(_preview_container)
+func _preview_name() -> String:
+	return "HollowPreview"

--- a/addons/hammerforge/systems/hf_preview_system.gd
+++ b/addons/hammerforge/systems/hf_preview_system.gd
@@ -1,0 +1,122 @@
+@tool
+class_name HFPreviewSystem
+extends "hf_system.gd"
+## Shared mechanics for the overlays that show geometry before it exists.
+##
+## Six previews — hollow, carve, clip, subtract, structure and array — each owned
+## a container node, a set of `MeshInstance3D`, a ghost material and a teardown,
+## and each wrote all four out again. Two of them even called the container by a
+## different name from the other four.
+##
+## That duplication is what let four of them drift into placing their meshes in
+## the wrong space: each was fixed on its own, because there was nowhere to fix
+## it once. `tests/test_preview_placement.gd` holds the property they share; this
+## holds the mechanics, so the next preview inherits them rather than copying
+## them.
+##
+## What stays with each preview is what actually differs: what it draws, what
+## colour it draws in, and how it decides there is nothing to draw.
+
+var _preview_container: Node3D
+## Every `MeshInstance3D` this preview has made, whether it addresses them by
+## index or keeps named references alongside. Hiding and freeing go through the
+## pool, so a preview cannot leave one of its own meshes on screen.
+var _mesh_pool: Array = []
+
+
+## The name the container carries in the scene tree, so the tree still says which
+## overlay a node belongs to. Overridden by each preview.
+func _preview_name() -> String:
+	return "Preview"
+
+
+## A pale, unshaded, always-on-top material for geometry that does not exist yet.
+##
+## Depth testing is off in every one of them on purpose: a ghost you cannot see
+## because the solid it is about to replace is in front of it is not a preview.
+static func ghost_material(color: Color, double_sided: bool = false) -> StandardMaterial3D:
+	var material := StandardMaterial3D.new()
+	material.albedo_color = color
+	material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+	material.no_depth_test = true
+	if double_sided:
+		material.cull_mode = BaseMaterial3D.CULL_DISABLED
+	return material
+
+
+## The container, made on first use and shown.
+##
+## Overridable, because a preview whose meshes are named rather than indexed makes
+## them here. Anything the base needs the container for goes through
+## `_build_container()` instead, so an override that makes meshes cannot be
+## re-entered by the making of them.
+func _ensure_container() -> void:
+	_build_container()
+
+
+func _build_container() -> void:
+	if is_instance_valid(_preview_container):
+		_preview_container.visible = true
+		return
+	if not is_instance_valid(root):
+		return
+	_preview_container = Node3D.new()
+	_preview_container.name = _preview_name()
+	root.add_child(_preview_container)
+
+
+## One more mesh under the container, remembered in the pool.
+func _make_mesh(material: Material) -> MeshInstance3D:
+	_build_container()
+	var mesh_instance := MeshInstance3D.new()
+	mesh_instance.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	mesh_instance.material_override = material
+	if is_instance_valid(_preview_container):
+		_preview_container.add_child(mesh_instance)
+	_mesh_pool.append(mesh_instance)
+	return mesh_instance
+
+
+## Grow the pool to `count` meshes, all sharing one material.
+func _grow_pool(count: int, material: Material) -> void:
+	while _mesh_pool.size() < count:
+		_make_mesh(material)
+
+
+## Hide every mesh from `index` on, which is how a preview that drew fewer pieces
+## this time puts the leftovers away without freeing them.
+func _hide_meshes_from(index: int) -> void:
+	for i in range(maxi(0, index), _mesh_pool.size()):
+		if is_instance_valid(_mesh_pool[i]):
+			_mesh_pool[i].visible = false
+
+
+func clear() -> void:
+	_enabled = false
+	_hide_meshes_from(0)
+	if is_instance_valid(_preview_container):
+		_preview_container.visible = false
+
+
+func set_enabled(value: bool) -> void:
+	if value:
+		_enabled = true
+		_ensure_container()
+	else:
+		clear()
+
+
+## Free the container and everything under it.
+##
+## `remove_child()` before `free()`, and `free()` rather than `queue_free()`:
+## teardown can be the last thing that happens to this tree, and a frame that
+## never arrives cannot collect a queued node.
+func destroy() -> void:
+	_enabled = false
+	_mesh_pool.clear()
+	if is_instance_valid(_preview_container):
+		if _preview_container.get_parent():
+			_preview_container.get_parent().remove_child(_preview_container)
+		_preview_container.free()
+	_preview_container = null

--- a/addons/hammerforge/systems/hf_preview_system.gd.uid
+++ b/addons/hammerforge/systems/hf_preview_system.gd.uid
@@ -1,0 +1,1 @@
+uid://ceb0gn8agwjla

--- a/addons/hammerforge/systems/hf_structure_preview.gd
+++ b/addons/hammerforge/systems/hf_structure_preview.gd
@@ -1,6 +1,6 @@
 @tool
 class_name HFStructurePreview
-extends "hf_system.gd"
+extends "hf_preview_system.gd"
 ## A wireframe of the structure the Structure section would build, before it builds it.
 ##
 ## Every other way of making geometry in HammerForge shows you the shape while you
@@ -26,7 +26,6 @@ const HFOutlineUtil = preload("../hf_outline_util.gd")
 ## yellow hollow walls, green carve pieces, cyan clip wires, red subtract volumes.
 const GHOST_COLOR := Color(0.9, 0.95, 1.0, 0.5)
 
-var _container: Node3D
 var _mesh_instance: MeshInstance3D
 var _material: StandardMaterial3D
 var _piece_count: int = 0
@@ -35,11 +34,11 @@ var _piece_count: int = 0
 func _init(p_root: Node3D = null) -> void:
 	super(p_root)
 	_enabled = false
-	_material = StandardMaterial3D.new()
-	_material.albedo_color = GHOST_COLOR
-	_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-	_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-	_material.no_depth_test = true
+	_material = ghost_material(GHOST_COLOR)
+
+
+func _preview_name() -> String:
+	return "StructurePreview"
 
 
 ## Draw what these settings would build, at the placement they would build at.
@@ -77,7 +76,7 @@ func show_preview(type: String, settings: Dictionary, placement: Transform3D) ->
 	# from the same face sets is given.
 	_mesh_instance.global_transform = placement
 	_mesh_instance.visible = true
-	_container.visible = true
+	_preview_container.visible = true
 	_piece_count = drawn
 	return drawn
 
@@ -89,41 +88,24 @@ func piece_count() -> int:
 
 func clear() -> void:
 	_piece_count = 0
-	_enabled = false
 	if is_instance_valid(_mesh_instance):
-		_mesh_instance.visible = false
 		_mesh_instance.mesh = null
-	if is_instance_valid(_container):
-		_container.visible = false
+	super()
 
 
 func set_enabled(value: bool) -> void:
 	if value:
-		_enabled = true
 		_ensure_nodes()
-	else:
-		clear()
+	super(value)
 
 
 func destroy() -> void:
 	_piece_count = 0
-	_enabled = false
 	_mesh_instance = null
-	if is_instance_valid(_container):
-		if _container.get_parent():
-			_container.get_parent().remove_child(_container)
-		_container.free()
-	_container = null
+	super()
 
 
 func _ensure_nodes() -> void:
-	if not is_instance_valid(_container):
-		_container = Node3D.new()
-		_container.name = "StructurePreview"
-		root.add_child(_container)
-	_container.visible = true
+	_ensure_container()
 	if not is_instance_valid(_mesh_instance):
-		_mesh_instance = MeshInstance3D.new()
-		_mesh_instance.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-		_mesh_instance.material_override = _material
-		_container.add_child(_mesh_instance)
+		_mesh_instance = _make_mesh(_material)

--- a/addons/hammerforge/systems/hf_subtract_preview.gd
+++ b/addons/hammerforge/systems/hf_subtract_preview.gd
@@ -1,6 +1,6 @@
 @tool
 class_name HFSubtractPreview
-extends "hf_system.gd"
+extends "hf_preview_system.gd"
 ## Live subtract overlay. Broad-phase AABB finds overlapping additive/subtract
 ## DraftBrushes, then CSG intersection shows the actual cut volume. AABB
 ## wireframes stay as a fallback when CSG is pending, capped, or empty.
@@ -8,8 +8,6 @@ extends "hf_system.gd"
 const DraftBrush = preload("../brush_instance.gd")
 const HFOutlineUtil = preload("../hf_outline_util.gd")
 
-var _preview_container: Node3D
-var _mesh_pool: Array = []  # Array[MeshInstance3D]
 var _active_count: int = 0
 var _needs_rebuild: bool = false
 var _debounce: float = 0.0
@@ -28,34 +26,24 @@ const CSG_WAIT_FRAMES := 2
 func _init(p_root: Node3D = null) -> void:
 	super(p_root)
 	_enabled = false
-	_material = StandardMaterial3D.new()
-	_material.albedo_color = Color(1.0, 0.3, 0.3, 0.45)
-	_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-	_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-	_material.no_depth_test = true
-	_csg_material = StandardMaterial3D.new()
-	_csg_material.albedo_color = Color(1.0, 0.2, 0.15, 0.55)
-	_csg_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-	_csg_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-	_csg_material.cull_mode = BaseMaterial3D.CULL_DISABLED
-	_csg_material.no_depth_test = true
+	_material = ghost_material(Color(1.0, 0.3, 0.3, 0.45))
+	# The CSG result is a solid rather than a wireframe, so it is drawn from both
+	# sides: the cut volume is looked into as often as it is looked at.
+	_csg_material = ghost_material(Color(1.0, 0.2, 0.15, 0.55), true)
 
 
+## Signals are connected only on the way in and disconnected only on the way out,
+## so unlike the other previews this one has to know it is already enabled.
 func set_enabled(value: bool) -> void:
 	if value == _enabled:
 		return
-	_enabled = value
-	if _enabled:
-		_ensure_container()
+	if value:
+		super(value)
 		_connect_signals()
 		request_update()
 	else:
 		_disconnect_signals()
-		clear()
-
-
-func is_enabled() -> bool:
-	return _enabled
+		super(value)
 
 
 func request_update() -> void:
@@ -80,12 +68,8 @@ func process(delta: float) -> void:
 func clear() -> void:
 	_free_csg_scratch()
 	_csg_result_count = 0
-	for i in _mesh_pool.size():
-		if is_instance_valid(_mesh_pool[i]):
-			_mesh_pool[i].visible = false
 	_active_count = 0
-	if _preview_container and is_instance_valid(_preview_container):
-		_preview_container.visible = false
+	super()
 
 
 ## Free all pooled meshes and the container node.  Call when the preview
@@ -95,24 +79,13 @@ func clear() -> void:
 func destroy() -> void:
 	_disconnect_signals()
 	_free_csg_scratch()
-	_mesh_pool.clear()
 	_active_count = 0
 	_csg_result_count = 0
-	if _preview_container and is_instance_valid(_preview_container):
-		if _preview_container.get_parent():
-			_preview_container.get_parent().remove_child(_preview_container)
-		_preview_container.free()
-	_preview_container = null
-	_enabled = false
+	super()
 
 
-func _ensure_container() -> void:
-	if _preview_container and is_instance_valid(_preview_container):
-		_preview_container.visible = true
-		return
-	_preview_container = Node3D.new()
-	_preview_container.name = "SubtractPreview"
-	root.add_child(_preview_container)
+func _preview_name() -> String:
+	return "SubtractPreview"
 
 
 func _connect_signals() -> void:
@@ -203,12 +176,7 @@ static func collect_cut_groups(subtractive: Array, additive: Array) -> Array:
 
 
 func _show_aabb_wireframes(intersections: Array) -> void:
-	while _mesh_pool.size() < intersections.size():
-		var mi = MeshInstance3D.new()
-		mi.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-		mi.material_override = _material
-		_preview_container.add_child(mi)
-		_mesh_pool.append(mi)
+	_grow_pool(intersections.size(), _material)
 
 	for i in intersections.size():
 		var mi: MeshInstance3D = _mesh_pool[i]
@@ -220,9 +188,7 @@ func _show_aabb_wireframes(intersections: Array) -> void:
 		mi.material_override = _material
 		mi.visible = true
 
-	for i in range(intersections.size(), _mesh_pool.size()):
-		if is_instance_valid(_mesh_pool[i]):
-			_mesh_pool[i].visible = false
+	_hide_meshes_from(intersections.size())
 
 	_active_count = intersections.size()
 	_csg_result_count = 0
@@ -288,11 +254,7 @@ func _capture_csg_results() -> void:
 		return
 	_ensure_container()
 	var needed := result_meshes.size()
-	while _mesh_pool.size() < needed:
-		var mi = MeshInstance3D.new()
-		mi.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-		_preview_container.add_child(mi)
-		_mesh_pool.append(mi)
+	_grow_pool(needed, _csg_material)
 	for i in needed:
 		var item: Dictionary = result_meshes[i]
 		var mi: MeshInstance3D = _mesh_pool[i]
@@ -300,9 +262,7 @@ func _capture_csg_results() -> void:
 		mi.transform = item.get("transform", Transform3D.IDENTITY)
 		mi.material_override = _csg_material
 		mi.visible = true
-	for i in range(needed, _mesh_pool.size()):
-		if is_instance_valid(_mesh_pool[i]):
-			_mesh_pool[i].visible = false
+	_hide_meshes_from(needed)
 	_active_count = needed
 	_csg_result_count = needed
 	_preview_container.visible = needed > 0

--- a/docs/features.md
+++ b/docs/features.md
@@ -373,7 +373,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 9, 2026 contains **3,056 tests across 159 scripts**: **3,049 passing tests**, seven intentional no-assert safety tests, and **15,945 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 9, 2026 contains **3,072 tests across 160 scripts**: **3,065 passing tests**, seven intentional no-assert safety tests, and **16,000 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_array_preview.gd
+++ b/tests/test_array_preview.gd
@@ -343,7 +343,7 @@ func test_the_ghost_leaves_with_the_level_it_was_drawn_in():
 
 	root.get_parent().remove_child(root)
 
-	assert_null(root.array_preview._container, "the overlay went with the level")
+	assert_null(root.array_preview._preview_container, "the overlay went with the level")
 
 
 func test_a_dock_with_no_level_draws_nothing_rather_than_erroring():

--- a/tests/test_preview_system.gd
+++ b/tests/test_preview_system.gd
@@ -1,0 +1,227 @@
+extends GutTest
+
+## The mechanics the six previews used to each own a copy of.
+##
+## Hollow, carve, clip, subtract, structure and array each wrote out a container
+## node, a set of `MeshInstance3D`, a ghost material and a teardown. Two of them
+## even called the container by a different name from the other four. That
+## duplication is what let four of them drift into placing their meshes in the
+## wrong space — each was fixed on its own, because there was nowhere to fix it
+## once.
+##
+## `tests/test_preview_placement.gd` holds the property they share. This holds the
+## mechanics.
+
+var root: LevelRoot
+
+
+func before_each() -> void:
+	root = LevelRoot.new()
+	root.auto_spawn_player = false
+	root.commit_freeze = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func after_each() -> void:
+	root = null
+
+
+func _preview() -> HFPreviewSystem:
+	return HFPreviewSystem.new(root)
+
+
+# ===========================================================================
+# The ghost material
+# ===========================================================================
+
+
+func test_a_ghost_is_unshaded_transparent_and_always_on_top():
+	var material := HFPreviewSystem.ghost_material(Color(1, 0, 0, 0.5))
+	assert_eq(material.albedo_color, Color(1, 0, 0, 0.5))
+	assert_eq(material.shading_mode, BaseMaterial3D.SHADING_MODE_UNSHADED)
+	assert_eq(material.transparency, BaseMaterial3D.TRANSPARENCY_ALPHA)
+	assert_true(
+		material.no_depth_test,
+		"a ghost hidden behind the solid it is about to replace is not a preview"
+	)
+
+
+func test_a_ghost_is_one_sided_unless_it_asks_not_to_be():
+	assert_ne(HFPreviewSystem.ghost_material(Color.RED).cull_mode, BaseMaterial3D.CULL_DISABLED)
+	assert_eq(
+		HFPreviewSystem.ghost_material(Color.RED, true).cull_mode, BaseMaterial3D.CULL_DISABLED
+	)
+
+
+# ===========================================================================
+# The container
+# ===========================================================================
+
+
+func test_the_container_is_made_on_first_use_and_hangs_off_the_root():
+	var preview := _preview()
+	assert_null(preview._preview_container, "nothing is made before it is needed")
+	preview._ensure_container()
+	assert_not_null(preview._preview_container)
+	assert_eq(preview._preview_container.get_parent(), root)
+	preview.destroy()
+
+
+func test_the_container_carries_the_name_the_preview_gives_it():
+	var preview := _preview()
+	preview._ensure_container()
+	assert_eq(str(preview._preview_container.name), preview._preview_name())
+	preview.destroy()
+
+
+func test_asking_twice_does_not_make_a_second_container():
+	var preview := _preview()
+	# The LevelRoot has containers of its own, so the count that matters is how
+	# many more children it has than it started with.
+	var before := root.get_child_count()
+	preview._ensure_container()
+	var first := preview._preview_container
+	preview._ensure_container()
+	assert_eq(preview._preview_container, first)
+	assert_eq(root.get_child_count(), before + 1, "one container, not two")
+	preview.destroy()
+
+
+func test_every_preview_names_its_container_differently():
+	# Two of them used to be called `_container` and four `_preview_container`,
+	# which is how a shared mechanic drifts into six of them. The scene tree still
+	# has to say which overlay a node belongs to.
+	var names: Array = []
+	for preview in [
+		HFArrayPreview.new(root),
+		HFCarvePreview.new(root),
+		HFClipPreview.new(root),
+		HFHollowPreview.new(root),
+		HFStructurePreview.new(root),
+		HFSubtractPreview.new(root),
+	]:
+		var preview_name: String = preview._preview_name()
+		assert_false(names.has(preview_name), "'%s' is used twice" % preview_name)
+		assert_ne(preview_name, "Preview", "every preview overrides the default name")
+		names.append(preview_name)
+	assert_eq(names.size(), 6)
+
+
+# ===========================================================================
+# The meshes
+# ===========================================================================
+
+
+func test_a_made_mesh_goes_under_the_container_and_into_the_pool():
+	var preview := _preview()
+	var material := HFPreviewSystem.ghost_material(Color.RED)
+	var mesh_instance := preview._make_mesh(material)
+	assert_eq(mesh_instance.get_parent(), preview._preview_container)
+	assert_eq(mesh_instance.material_override, material)
+	assert_eq(
+		mesh_instance.cast_shadow,
+		GeometryInstance3D.SHADOW_CASTING_SETTING_OFF,
+		"a ghost does not cast a shadow"
+	)
+	assert_eq(preview._mesh_pool.size(), 1)
+	preview.destroy()
+
+
+func test_making_a_mesh_makes_the_container_it_needs():
+	var preview := _preview()
+	preview._make_mesh(HFPreviewSystem.ghost_material(Color.RED))
+	assert_not_null(preview._preview_container, "a mesh has to hang off something")
+	preview.destroy()
+
+
+func test_the_pool_grows_to_the_count_asked_for_and_no_further():
+	var preview := _preview()
+	var material := HFPreviewSystem.ghost_material(Color.RED)
+	preview._grow_pool(3, material)
+	assert_eq(preview._mesh_pool.size(), 3)
+	preview._grow_pool(5, material)
+	assert_eq(preview._mesh_pool.size(), 5)
+	# A preview that drew fewer pieces this time hides the leftovers rather than
+	# freeing them, so the pool never shrinks.
+	preview._grow_pool(2, material)
+	assert_eq(preview._mesh_pool.size(), 5)
+	preview.destroy()
+
+
+func test_hiding_from_an_index_leaves_the_ones_before_it_showing():
+	var preview := _preview()
+	preview._grow_pool(4, HFPreviewSystem.ghost_material(Color.RED))
+	for mesh_instance in preview._mesh_pool:
+		mesh_instance.visible = true
+	preview._hide_meshes_from(2)
+	assert_true(preview._mesh_pool[0].visible)
+	assert_true(preview._mesh_pool[1].visible)
+	assert_false(preview._mesh_pool[2].visible)
+	assert_false(preview._mesh_pool[3].visible)
+	preview.destroy()
+
+
+# ===========================================================================
+# Clearing, enabling and teardown
+# ===========================================================================
+
+
+func test_clearing_hides_every_mesh_and_the_container():
+	var preview := _preview()
+	preview._grow_pool(3, HFPreviewSystem.ghost_material(Color.RED))
+	for mesh_instance in preview._mesh_pool:
+		mesh_instance.visible = true
+	preview.set_enabled(true)
+	preview.clear()
+	for mesh_instance in preview._mesh_pool:
+		assert_false(mesh_instance.visible)
+	assert_false(preview._preview_container.visible)
+	assert_false(preview.is_enabled(), "a cleared preview is not an enabled one")
+	preview.destroy()
+
+
+func test_enabling_makes_the_container_and_disabling_clears():
+	var preview := _preview()
+	preview.set_enabled(true)
+	assert_true(preview.is_enabled())
+	assert_not_null(preview._preview_container)
+	assert_true(preview._preview_container.visible)
+	preview.set_enabled(false)
+	assert_false(preview.is_enabled())
+	assert_false(preview._preview_container.visible)
+	preview.destroy()
+
+
+func test_destroy_takes_the_container_out_of_the_tree_and_frees_it():
+	var preview := _preview()
+	var before := root.get_child_count()
+	preview._grow_pool(2, HFPreviewSystem.ghost_material(Color.RED))
+	var preview_name := preview._preview_name()
+	preview.destroy()
+	assert_null(preview._preview_container)
+	assert_eq(preview._mesh_pool.size(), 0)
+	assert_null(root.get_node_or_null(preview_name), "the overlay went with the level")
+	assert_eq(root.get_child_count(), before)
+	assert_false(preview.is_enabled())
+
+
+func test_destroy_is_safe_with_nothing_made():
+	var preview := _preview()
+	preview.destroy()
+	assert_null(preview._preview_container)
+
+
+func test_destroy_twice_is_safe():
+	var preview := _preview()
+	preview._make_mesh(HFPreviewSystem.ghost_material(Color.RED))
+	preview.destroy()
+	preview.destroy()
+	assert_null(preview._preview_container)
+
+
+func test_a_preview_with_no_root_makes_nothing_rather_than_failing():
+	var orphan := HFPreviewSystem.new(null)
+	orphan._ensure_container()
+	assert_null(orphan._preview_container)
+	orphan.destroy()

--- a/tests/test_preview_system.gd.uid
+++ b/tests/test_preview_system.gd.uid
@@ -1,0 +1,1 @@
+uid://btyd8h5bj3x8k

--- a/tests/test_structure_preview.gd
+++ b/tests/test_structure_preview.gd
@@ -124,7 +124,7 @@ func test_clearing_hides_the_ghost_and_forgets_the_count():
 	root.clear_structure_preview()
 
 	assert_eq(root.structure_preview_pieces(), 0)
-	assert_false(root.structure_preview._container.visible, "the container goes with it")
+	assert_false(root.structure_preview._preview_container.visible, "the container goes with it")
 
 
 func test_a_destroyed_preview_can_be_used_again():
@@ -388,4 +388,4 @@ func test_the_ghost_leaves_with_the_level_it_was_drawn_in():
 
 	root.get_parent().remove_child(root)
 
-	assert_null(root.structure_preview._container, "the overlay went with the level")
+	assert_null(root.structure_preview._preview_container, "the overlay went with the level")


### PR DESCRIPTION
## Increment

Hollow, carve, clip, subtract, structure and array each owned a container node, a set of `MeshInstance3D`, a ghost material and a teardown, and each wrote all four out again. Two called the container `_container` and four called it `_preview_container`.

That duplication is what let four of them drift into placing their meshes in the wrong space — each was found and fixed on its own, because there was nowhere to fix it once. `tests/test_preview_placement.gd` holds the property they share; `HFPreviewSystem` now holds the mechanics.

Closes the last item under *Known limits of the structure preview* on the roadmap.

## Decision

- **The base owns the mechanics, not the drawing.** Container lifecycle, mesh pool, `ghost_material()`, `clear()`, `set_enabled()`, `destroy()`. What stays with each preview is what actually differs: what it draws, what colour, and how it decides there is nothing to draw. Nothing was forced into a shared mould that did not fit — clip keeps its three *named* meshes, subtract keeps its CSG scratch.
- **`_ensure_container()` stays overridable, but the base does not call it.** Clip makes its three meshes there, and `_make_mesh()` calling the virtual re-entered the override — an immediate stack overflow rather than a subtle bug. The base reaches the container through a non-virtual `_build_container()` instead.
- **Subtract keeps its own `set_enabled()`.** It connects and disconnects signals on the way in and out, so unlike the others it genuinely has to know it is already enabled; the override calls `super()` in the right half of each branch so ordering is preserved exactly.
- **The third copy of `line_mesh` goes too.** Carve, clip and hollow each carried a private `_lines_mesh()` static identical to `HFOutlineUtil.line_mesh()`.
- **`_container` renamed to `_preview_container`** in array and structure. Two names for one thing is the drift itself; the two tests that reached for the old name were updated.

## Files

- `addons/hammerforge/systems/hf_preview_system.gd` *(new, 122 lines)*
- `addons/hammerforge/systems/hf_{array,carve,clip,hollow,structure,subtract}_preview.gd`
- `tests/test_preview_system.gd` *(new, 16 tests)*, `tests/test_array_preview.gd`, `tests/test_structure_preview.gd`
- `CHANGELOG.md`, `ROADMAP.md`, `HammerForge_SPEC.md`, `docs/features.md`

Six previews: **1,249 lines to 1,006**. With the base, 121 lines fewer overall and one definition of each mechanic instead of six.

## Yellow / Red / Purple

- **Yellow**: extract the base, migrate the two single-mesh previews, then the two pooled ones, then clip and subtract.
- **Red**: the clip migration recursed `_make_mesh` → `_ensure_container` → `_make_mesh` and blew the stack on the full suite — fixed by the non-virtual `_build_container()`. Also checked: subtract's signal connect/disconnect ordering, the `if value == _enabled` guard that only subtract actually needs, teardown with nothing made, teardown twice, and a preview with no root.
- **Purple**: a drift guard that fails if two previews ever name their container the same thing, plus SPEC, changelog and roadmap.

## Verify

```
gdformat --check addons/hammerforge/ tests/     # 330 files unchanged
gdlint addons/hammerforge/                      # no problems found
godot --headless -s res://addons/gut/gut_cmdln.gd --path . -gexit
```

**Behaviour is unchanged, and that is the claim under test**: the suite reported 3,056 tests / 3,049 passing / 0 failing immediately before the refactor and again immediately after it, on the same 159 scripts. Adding `tests/test_preview_system.gd` takes it to **3,072 tests across 160 scripts — 3,065 passing, 7 intentional no-assert, 0 failing**, 227.5s.

No user-facing behaviour changed, so there are no new smoke-checklist steps; the existing preview steps (§7c-3b and the error-prevention section) cover it.

## Intuition

Nothing changes for the user — this is the change that makes the next preview inherit its mechanics instead of copying them, and the reason four of them once drew a thousand units from the brush they claimed to preview.