### PR TITLE
docs: point the roadmap at the tracked Re-hollow warning

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -881,6 +881,9 @@ and run".
 ### Known limits of the live-hollow pass
 - Hand edits to a wall are overwritten by the next Re-hollow with no warning. The
   array section counts its edited copies and asks twice; hollow does not yet.
+  Tracked as [#241](https://github.com/saworbit/hammerforge/issues/241), which
+  also records why the reading is simpler here: the record already keeps where
+  each wall was put.
 - The recorded solid is the solid as it was. Resizing the room means Detach and
   start again, because there is nothing that edits the source through the walls.
 - Only one hollow per set of walls, and hollowing a wall of a hollow makes a
@@ -929,7 +932,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,108 tests across 161 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. The issue tracker is clear as of September 8, 2026. No known limitation is currently untracked and uncovered.
+The current suite covers 3,108 tests across 161 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. One issue is open — [#241](https://github.com/saworbit/hammerforge/issues/241), the Re-hollow overwrite warning — and it is the only known limitation that is not yet either covered or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is


### PR DESCRIPTION
## Increment

Docs only. Live hollow ([#240](https://github.com/saworbit/hammerforge/pull/240)) left one silent loss behind: **Re-hollow** rebuilds over walls that were reworked by hand, where the Duplicate Array section counts them and asks twice. It was written down under that wave's known limits but tracked nowhere, and the *Risk-focused test gaps* section still claimed the issue tracker was clear.

Both lines now name [#241](https://github.com/saworbit/hammerforge/issues/241), which carries the design, the scope, and the two things the array work learned the hard way — that a signature carrying resource identity reports every piece as unique, and that hashing weight-image contents costs 127 ms against 22 ms on an event that fires on every selection change.

## Files

`ROADMAP.md` — two lines.

## Verify

`gdformat --check` reports the file unchanged; nothing executable was touched.