### PR TITLE
Stop exporting cutters as solid worldspawn brushes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,24 @@ The format is based on Keep a Changelog, and this project follows semantic versi
     copy, undo, and what survives a state restore.
 
 ### Fixed
+- **Cutters exported to `.map` as solid brushes, filling the holes they made.**
+  A `.map` worldspawn holds additive convex solids and nothing else — the format
+  has no negative brush — so every subtraction brush written into one arrives as
+  matter. A doorway carved into a wall exported as a wall with a solid block
+  standing in the doorway, and nothing said so until the map was opened in
+  TrenchBroom or compiled.
+  - `export_map_from_level()` reached into `CommittedCuts` on purpose and added
+    its children to the same list as the solids, and a subtraction brush sitting
+    in `DraftBrushes` went the same way. Only `PendingCuts` was filtered.
+  - All three are now read as one question, `_is_cutter()`, because a cutter is
+    not one state: pending, committed and frozen, or plainly subtractive. The
+    operation alone misses the frozen one, which keeps whatever operation it had
+    when it was stashed; the container alone misses the other two.
+  - Carved shapes therefore leave uncut rather than leaving wrong. `.map` is a
+    blockout exchange format, not a bake.
+  - **Coverage** (`tests/test_map_export.gd`): a committed cutter, a subtraction
+    brush and a pending cutter, each asserting the export carries the solid's six
+    planes and only those. The first two fail against the old code.
 - **Baking with the LevelRoot away from the origin put the geometry somewhere
   else.** Found by sweeping for the rest of the ordering bug below rather than
   by hitting it, and it is the worst of the family: the others were the editor

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -400,7 +400,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,108 tests across 161 test scripts (3,101 passing plus seven intentional no-assert safety tests; 16,176 assertions; verified in CI on September 9, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,111 tests across 161 test scripts (3,104 passing plus seven intentional no-assert safety tests; 16,182 assertions; verified in CI on September 9, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -540,6 +540,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 9, 2026): **3,108 tests** across **161 scripts** (**3,101 passing** plus seven intentional no-assert safety tests; **16,176 assertions**).
+Full suite (verified in CI on September 9, 2026): **3,111 tests** across **161 scripts** (**3,104 passing** plus seven intentional no-assert safety tests; **16,182 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3101%20passing-brightgreen" alt="3101 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3104%20passing-brightgreen" alt="3104 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -932,7 +932,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,108 tests across 161 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. One issue is open — [#241](https://github.com/saworbit/hammerforge/issues/241), the Re-hollow overwrite warning — and it is the only known limitation that is not yet either covered or written down beside the wave that introduced it.
+The current suite covers 3,111 tests across 161 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. One issue is open — [#241](https://github.com/saworbit/hammerforge/issues/241), the Re-hollow overwrite warning — and it is the only known limitation that is not yet either covered or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/map_io.gd
+++ b/addons/hammerforge/map_io.gd
@@ -115,6 +115,14 @@ static func parse_map_text(text: String) -> Dictionary:
 	return {"entities": entity_points, "brushes": brushes, "errors": errors}
 
 
+## Write the level out as `.map` text.
+##
+## Cutters are left out. Every brush inside a `.map` worldspawn is an additive
+## convex solid — the format has no negative brush — so a subtraction brush
+## written here does not carve the hole it was made for, it fills it. A doorway
+## exported as a solid block is worse than a doorway that is missing, and it is
+## silent. Carved shapes therefore leave here uncut; `.map` is a blockout
+## exchange format, not a bake.
 static func export_map_from_level(level_root: Node, adapter: HFMapAdapterType = null) -> String:
 	if not level_root:
 		return ""
@@ -126,16 +134,13 @@ static func export_map_from_level(level_root: Node, adapter: HFMapAdapterType = 
 	var brush_nodes: Array = []
 	if level_root.has_method("_iter_pick_nodes"):
 		brush_nodes.append_array(level_root.call("_iter_pick_nodes"))
-	var committed = level_root.get_node_or_null("CommittedCuts")
-	if committed:
-		brush_nodes.append_array(committed.get_children())
 	var entity_brush_blocks: Array = []
 	for node in brush_nodes:
 		if not (node is DraftBrush):
 			continue
 		if level_root.has_method("is_entity_node") and level_root.is_entity_node(node):
 			continue
-		if node.get_parent() and node.get_parent().name == "PendingCuts":
+		if _is_cutter(node):
 			continue
 		var brush_lines = _brush_to_map_lines(node, adapter)
 		if brush_lines.is_empty():
@@ -164,6 +169,22 @@ static func export_map_from_level(level_root: Node, adapter: HFMapAdapterType = 
 				continue
 			lines.append_array(ent_lines)
 	return "\n".join(lines)
+
+
+## True when a brush cuts geometry away rather than adding it.
+##
+## Three ways to be a cutter, because a cutter is not one state. A pending cut is
+## still being aimed, a committed cut has been frozen out of sight under
+## `CommittedCuts` and keeps whatever operation it had when it was stashed, and a
+## plain subtraction brush is neither. Reading only the operation misses the
+## frozen one; reading only the container misses the other two.
+static func _is_cutter(node: DraftBrush) -> bool:
+	if node.operation == CSGShape3D.OPERATION_SUBTRACTION:
+		return true
+	if bool(node.get_meta("committed_cut", false)):
+		return true
+	var parent: Node = node.get_parent()
+	return parent != null and parent.name in ["PendingCuts", "CommittedCuts"]
 
 
 static func _entity_to_map_lines(

--- a/docs/HammerForge_Data_Portability.md
+++ b/docs/HammerForge_Data_Portability.md
@@ -35,6 +35,7 @@ This document describes how to move data in and out of HammerForge safely.
 - Point-entity key/value properties and brush entity classes round-trip through the supported Classic Quake and Valve 220 adapters.
 - Per-face materials and HammerForge surface-paint layers are not preserved, so `.hflevel` remains the editable source of truth.
 - Treat `.map` as a blockout exchange format, not a full fidelity export.
+- Cutters are not exported. A `.map` worldspawn holds additive solids only, so a subtraction brush written into one would fill the hole it was made for instead of cutting it. Carved shapes export uncut; bake or export `.glb` when the carve has to come with them.
 - Face planes are written in `.map` winding, which is the reverse of the clockwise-from-outside order `FaceData` stores, so exported hulls are the right way out for compilers and other editors. Import applies the same conversion in reverse.
 - A file that does not parse is refused before the level is touched. Unbalanced braces, face lines that are not three points, and text outside any block are reported, the current level is left alone, and no undo entry is created.
 - Multi-format export: **Classic Quake** and **Valve 220** format adapters are available via the format selector in the dock File section. Valve 220 includes UV texture axes from FaceData.

--- a/docs/features.md
+++ b/docs/features.md
@@ -373,7 +373,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 9, 2026 contains **3,108 tests across 161 scripts**: **3,101 passing tests**, seven intentional no-assert safety tests, and **16,176 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 9, 2026 contains **3,111 tests across 161 scripts**: **3,104 passing tests**, seven intentional no-assert safety tests, and **16,182 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_map_export.gd
+++ b/tests/test_map_export.gd
@@ -428,6 +428,95 @@ func test_export_writes_func_detail_as_own_entity_block():
 
 
 # ===========================================================================
+# Cutters must not export as solid worldspawn brushes (#243)
+# ===========================================================================
+
+
+## A root shaped like LevelRoot's containers: picking sees draft and pending
+## brushes, and committed cutters are reachable only by name, exactly as the real
+## one arranges them.
+func _make_container_root() -> Node3D:
+	var script := GDScript.new()
+	script.source_code = """
+extends Node3D
+func _iter_pick_nodes():
+	var nodes := []
+	for container_name in ["DraftBrushes", "PendingCuts"]:
+		var container = get_node_or_null(container_name)
+		if container:
+			nodes.append_array(container.get_children())
+	return nodes
+func is_entity_node(_n):
+	return false
+"""
+	script.reload()
+	var root := Node3D.new()
+	root.set_script(script)
+	add_child_autoqfree(root)
+	for container_name in ["DraftBrushes", "PendingCuts", "CommittedCuts"]:
+		var container := Node3D.new()
+		container.name = container_name
+		root.add_child(container)
+	return root
+
+
+func _add_box(root: Node3D, container_name: String, extent: float) -> DraftBrush:
+	var brush := DraftBrush.new()
+	brush.shape = LevelRoot.BrushShape.BOX
+	brush.size = Vector3(extent, extent, extent) * 2.0
+	root.get_node(container_name).add_child(brush)
+	return brush
+
+
+## The furthest any exported plane point sits from the origin on any axis. A box
+## written at the origin reaches exactly its own half extent, so this says which
+## brush the planes came from.
+func _plane_point_reach(text: String) -> float:
+	var reach := 0.0
+	for line in _plane_lines(text):
+		for point in _plane_points(line):
+			var p: Vector3 = point
+			reach = maxf(reach, maxf(absf(p.x), maxf(absf(p.y), absf(p.z))))
+	return reach
+
+
+func test_committed_cutter_is_not_exported_as_a_solid_brush():
+	var root := _make_container_root()
+	_add_box(root, "DraftBrushes", 5.0)
+	var cutter := _add_box(root, "CommittedCuts", 1.0)
+	cutter.set_meta("committed_cut", true)
+
+	var text := MapIO.export_map_from_level(root)
+
+	assert_eq(_plane_lines(text).size(), 6, "Only the solid may be written")
+	assert_almost_eq(_plane_point_reach(text), 5.0, 0.001, "The planes are the solid's")
+
+
+func test_subtraction_brush_is_not_exported_as_a_solid_brush():
+	var root := _make_container_root()
+	_add_box(root, "DraftBrushes", 5.0)
+	var cutter := _add_box(root, "DraftBrushes", 1.0)
+	cutter.operation = CSGShape3D.OPERATION_SUBTRACTION
+
+	var text := MapIO.export_map_from_level(root)
+
+	assert_eq(_plane_lines(text).size(), 6, "Only the solid may be written")
+	assert_almost_eq(_plane_point_reach(text), 5.0, 0.001, "The planes are the solid's")
+
+
+func test_pending_cutter_is_not_exported_as_a_solid_brush():
+	var root := _make_container_root()
+	_add_box(root, "DraftBrushes", 5.0)
+	# Left on union on purpose: being in PendingCuts is what makes it a cutter.
+	_add_box(root, "PendingCuts", 1.0)
+
+	var text := MapIO.export_map_from_level(root)
+
+	assert_eq(_plane_lines(text).size(), 6, "Only the solid may be written")
+	assert_almost_eq(_plane_point_reach(text), 5.0, 0.001, "The planes are the solid's")
+
+
+# ===========================================================================
 # Face plane winding (#148)
 # ===========================================================================
 


### PR DESCRIPTION
Fixes #243

A `.map` worldspawn holds additive convex solids and nothing else. Every subtraction brush written into one arrives as matter, so a carved doorway exported as a wall with a solid block standing in the doorway.

- `export_map_from_level()` no longer reaches into `CommittedCuts`, and skips subtraction brushes wherever they sit.
- `_is_cutter()` reads pending, committed and plainly subtractive as one question. A committed cut keeps whatever operation it had when it was stashed, so the operation alone is not enough; the container alone misses the other two.
- Carved shapes now export uncut rather than wrong.

Tests: a committed cutter, a subtraction brush and a pending cutter, each asserting the export carries the solid's six planes and only those. The first two fail against the old code.

Docs: CHANGELOG, and the `.map` section of `docs/HammerForge_Data_Portability.md`.