### PR TITLE
Build imported .map face polygons from the brush planes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,33 @@ The format is based on Keep a Changelog, and this project follows semantic versi
     copy, undo, and what survives a state restore.
 
 ### Fixed
+- **Tilted brushes imported from `.map` as loose triangles.** A `.map` face line
+  names three points on an infinite plane, not the corners of a face. Import read
+  them as corners, so every brush that was not an axis-aligned box arrived as a
+  handful of disconnected 3-point triangles standing wherever the file happened to
+  put its plane references. A cylinder, a ramp, a wedge or a turned box from
+  TrenchBroom or Hammer came in deformed and not watertight.
+  - The solid is the intersection of the half spaces behind its planes, so each
+    face is now worked out: a square laid on the plane, clipped by every other
+    plane of the brush, and wound clockwise from outside like the rest of the
+    codebase. `HFConvexClip` already had the clipping and the winding.
+  - The brush's size and centre came from the same misread points and are now
+    taken from the hull, which also settles the axis-aligned box path: a box
+    written with plane references off in a corner used to import the wrong size.
+  - **Planes that close nothing still import.** Two planes bound no solid, and a
+    file can hold that. A face whose square still reaches its own rim means the
+    solid is open on that side, and the old reading of the points as corners is
+    the only thing left; it gives the wrong hull, but it gives one, and the brush
+    is still on screen to be fixed.
+  - **The whole set is retried flipped**, because the order of the three points
+    settles which side is solid and editors do not agree on it. The intersection
+    of the outside half spaces of a closed solid is empty, so the wrong
+    orientation cannot pass by accident.
+  - **Coverage** (`tests/test_map_export.gd`): a box turned on every axis written
+    out with plane references 20 units clear of its own corners, asserting six
+    quads whose corners land on the box and a size that matches the hull; a wedge
+    coming back as two triangle ends and three quad sides; and an open plane pair
+    still importing. The first three fail against the old code.
 - **Cutters exported to `.map` as solid brushes, filling the holes they made.**
   A `.map` worldspawn holds additive convex solids and nothing else — the format
   has no negative brush — so every subtraction brush written into one arrives as

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -400,7 +400,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,111 tests across 161 test scripts (3,104 passing plus seven intentional no-assert safety tests; 16,182 assertions; verified in CI on September 9, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,115 tests across 161 test scripts (3,108 passing plus seven intentional no-assert safety tests; 16,226 assertions; verified in CI on September 9, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -540,6 +540,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 9, 2026): **3,111 tests** across **161 scripts** (**3,104 passing** plus seven intentional no-assert safety tests; **16,182 assertions**).
+Full suite (verified in CI on September 9, 2026): **3,115 tests** across **161 scripts** (**3,108 passing** plus seven intentional no-assert safety tests; **16,226 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3104%20passing-brightgreen" alt="3104 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3108%20passing-brightgreen" alt="3108 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -932,7 +932,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,111 tests across 161 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. One issue is open — [#241](https://github.com/saworbit/hammerforge/issues/241), the Re-hollow overwrite warning — and it is the only known limitation that is not yet either covered or written down beside the wave that introduced it.
+The current suite covers 3,115 tests across 161 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. One issue is open — [#241](https://github.com/saworbit/hammerforge/issues/241), the Re-hollow overwrite warning — and it is the only known limitation that is not yet either covered or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/map_io.gd
+++ b/addons/hammerforge/map_io.gd
@@ -7,6 +7,7 @@ const DraftBrush = preload("brush_instance.gd")
 const DraftEntity = preload("draft_entity.gd")
 const HFMapAdapterType = preload("map_adapters/hf_map_adapter.gd")
 const HFMapQuakeType = preload("map_adapters/hf_map_quake.gd")
+const HFConvexClip = preload("hf_convex_clip.gd")
 
 const DEFAULT_TEXTURE := "__default"
 const AXIS_THRESHOLD := 0.98
@@ -220,11 +221,24 @@ static func _entity_to_map_lines(
 	return lines
 
 
+## Read one parsed brush into a brush record.
+##
+## A `.map` face line names three points on an infinite plane, not the corners of
+## a face. The solid is the intersection of the half spaces behind those planes,
+## and each face is the part of its own plane left over once every other plane has
+## cut it. So the corners are worked out here rather than read off the line.
+##
+## Ill-formed brushes still import. Two planes do not bound anything, and neither
+## does a set left open on one side, but a file can hold either and the old
+## reading of the plane points as corners is the only thing left to fall back on.
+## It gives the wrong hull; it gives one, and the brush is still there to fix.
 static func _brush_from_faces(faces: Array) -> Dictionary:
 	if faces.is_empty():
 		return {}
 	var points: Array = []
+	var planes: Array = []
 	var axis_aligned = true
+	var planes_usable = true
 	for face in faces:
 		var face_points: Array = face.get("points", [])
 		if face_points.size() < 3:
@@ -234,21 +248,24 @@ static func _brush_from_faces(faces: Array) -> Dictionary:
 		var normal = _face_normal(face_points)
 		if _axis_from_normal(normal) == Vector3.ZERO:
 			axis_aligned = false
+		if normal == Vector3.ZERO:
+			planes_usable = false
+		else:
+			planes.append(Plane(normal, normal.dot(face_points[0])))
 	if points.is_empty():
 		return {}
-	var min_pt = Vector3(INF, INF, INF)
-	var max_pt = Vector3(-INF, -INF, -INF)
-	for p in points:
-		min_pt.x = min(min_pt.x, p.x)
-		min_pt.y = min(min_pt.y, p.y)
-		min_pt.z = min(min_pt.z, p.z)
-		max_pt.x = max(max_pt.x, p.x)
-		max_pt.y = max(max_pt.y, p.y)
-		max_pt.z = max(max_pt.z, p.z)
-	var size = max_pt - min_pt
+	var bounds := _bounds_of(points)
+	var hull: Array = _hull_polygons(planes, bounds) if planes_usable else []
+	if not hull.is_empty():
+		var corners: Array = []
+		for entry in hull:
+			for vertex in entry["verts"]:
+				corners.append(vertex)
+		bounds = _bounds_of(corners)
+	var size = bounds.size
 	if size.length() <= 0.001:
 		return {}
-	var center = (min_pt + max_pt) * 0.5
+	var center = bounds.get_center()
 	if axis_aligned and faces.size() <= 8:
 		return {
 			"shape": LevelRoot.BrushShape.BOX,
@@ -256,17 +273,24 @@ static func _brush_from_faces(faces: Array) -> Dictionary:
 			"center": center,
 			"operation": CSGShape3D.OPERATION_UNION
 		}
+	var rings: Array = []
+	if hull.is_empty():
+		for face in faces:
+			var face_points: Array = face.get("points", [])
+			if face_points.size() < 3:
+				continue
+			# Mirror of the export: undo the .map plane order so the stored face
+			# keeps FaceData's clockwise-from-outside winding.
+			var wound: Array = face_points.duplicate()
+			wound.reverse()
+			rings.append(wound)
+	else:
+		for entry in hull:
+			rings.append(entry["verts"])
 	var serialized_faces: Array = []
-	for face in faces:
-		var face_points: Array = face.get("points", [])
-		if face_points.size() < 3:
-			continue
+	for ring in rings:
 		var local_verts: Array = []
-		# Mirror of the export: undo the .map plane order so the stored face keeps
-		# FaceData's clockwise-from-outside winding.
-		var wound: Array = face_points.duplicate()
-		wound.reverse()
-		for p in wound:
+		for p in ring:
 			var pt: Vector3 = p
 			local_verts.append([pt.x - center.x, pt.y - center.y, pt.z - center.z])
 		serialized_faces.append({"local_verts": local_verts, "winding_version": 1})
@@ -277,6 +301,97 @@ static func _brush_from_faces(faces: Array) -> Dictionary:
 		"faces": serialized_faces,
 		"operation": CSGShape3D.OPERATION_UNION
 	}
+
+
+## The box that contains every point.
+static func _bounds_of(points: Array) -> AABB:
+	var min_pt = Vector3(INF, INF, INF)
+	var max_pt = Vector3(-INF, -INF, -INF)
+	for p in points:
+		min_pt.x = min(min_pt.x, p.x)
+		min_pt.y = min(min_pt.y, p.y)
+		min_pt.z = min(min_pt.z, p.z)
+		max_pt.x = max(max_pt.x, p.x)
+		max_pt.y = max(max_pt.y, p.y)
+		max_pt.z = max(max_pt.z, p.z)
+	return AABB(min_pt, max_pt - min_pt)
+
+
+## The corner ring each plane contributes to the solid its planes bound, or an
+## empty array when they bound nothing.
+##
+## Returns `{"index": int, "verts": PackedVector3Array}` per plane that reaches
+## the surface, in plane order, wound clockwise from outside like every other
+## face in the codebase.
+##
+## Two things are tried before giving up. A face starts as a square that has to
+## be wider than the solid, and a solid can reach well past the points that
+## defined its planes, so a pass whose faces still touch the rim of their square
+## is retried wider before it is believed. And the whole set is retried flipped,
+## because the order of the three points on a face line settles which side is
+## solid and editors do not agree on it; the intersection of the outside half
+## spaces of a closed solid is empty, so the wrong orientation cannot pass.
+static func _hull_polygons(planes: Array, bounds: AABB) -> Array:
+	if planes.size() < HFConvexClip.MIN_SOLID_FACES:
+		return []
+	var radius := maxf(bounds.size.length() * 0.5, 1.0)
+	var flipped: Array = []
+	for plane in planes:
+		flipped.append(Plane(-plane.normal, -plane.d))
+	for candidate in [planes, flipped]:
+		for half in [radius * 4.0, radius * 64.0]:
+			var rings := _clip_planes(candidate, bounds.get_center(), half)
+			if not rings.is_empty():
+				return rings
+	return []
+
+
+## One clipping pass at a given starting square size.
+##
+## Empty when a face still reaches the rim of its square, which means the planes
+## leave the solid open on that side, or that the square started too small to
+## tell the difference.
+static func _clip_planes(planes: Array, centre: Vector3, half: float) -> Array:
+	var out: Array = []
+	var rim := half - HFConvexClip.DEFAULT_EPSILON
+	for i in range(planes.size()):
+		var plane: Plane = planes[i]
+		var origin: Vector3 = centre - plane.normal * plane.distance_to(centre)
+		var axes := _plane_axes(plane)
+		var u: Vector3 = axes[0]
+		var v: Vector3 = axes[1]
+		var poly := PackedVector3Array(
+			[
+				origin - u * half - v * half,
+				origin + u * half - v * half,
+				origin + u * half + v * half,
+				origin - u * half + v * half,
+			]
+		)
+		for j in range(planes.size()):
+			if j == i:
+				continue
+			poly = HFConvexClip.clip_polygon(poly, PackedVector2Array(), planes[j], false)["verts"]
+			if poly.size() < 3:
+				break
+		if poly.size() < 3:
+			continue
+		for point in poly:
+			var offset: Vector3 = point - origin
+			if absf(offset.dot(u)) >= rim or absf(offset.dot(v)) >= rim:
+				return []
+		var ring := HFConvexClip.cap_polygon(poly, plane.normal)
+		if ring.size() >= 3:
+			out.append({"index": i, "verts": ring})
+	return out if out.size() >= HFConvexClip.MIN_SOLID_FACES else []
+
+
+## Two unit vectors spanning a plane, for laying a square on it.
+static func _plane_axes(plane: Plane) -> Array:
+	var normal := plane.normal.normalized()
+	var reference := Vector3.UP if absf(normal.dot(Vector3.UP)) < 0.99 else Vector3.RIGHT
+	var u := normal.cross(reference).normalized()
+	return [u, normal.cross(u)]
 
 
 static func _face_normal(face_points: Array) -> Vector3:

--- a/docs/HammerForge_Data_Portability.md
+++ b/docs/HammerForge_Data_Portability.md
@@ -32,6 +32,7 @@ This document describes how to move data in and out of HammerForge safely.
 ## `.map` Import / Export
 - Use `.map` to exchange basic brush layouts with other editors.
 - Axis-aligned boxes use the optimized primitive path; tilted, clipped, and other non-axis-aligned convex brushes import and export as CUSTOM face geometry.
+- Import works the face polygons out rather than reading them off the file. A `.map` face line names three points on an infinite plane, not the corners of a face, and the solid is the intersection of the half spaces behind its planes. A set of planes that closes nothing still imports, on the old reading of the points as corners, so an ill-formed brush arrives wrong rather than not at all.
 - Point-entity key/value properties and brush entity classes round-trip through the supported Classic Quake and Valve 220 adapters.
 - Per-face materials and HammerForge surface-paint layers are not preserved, so `.hflevel` remains the editable source of truth.
 - Treat `.map` as a blockout exchange format, not a full fidelity export.

--- a/docs/features.md
+++ b/docs/features.md
@@ -373,7 +373,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 9, 2026 contains **3,111 tests across 161 scripts**: **3,104 passing tests**, seven intentional no-assert safety tests, and **16,182 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 9, 2026 contains **3,115 tests across 161 scripts**: **3,108 passing tests**, seven intentional no-assert safety tests, and **16,226 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_map_export.gd
+++ b/tests/test_map_export.gd
@@ -644,6 +644,162 @@ func test_tilted_hull_round_trip_keeps_face_winding():
 
 
 # ===========================================================================
+# Face polygons are worked out, not read off the plane line (#244)
+# ===========================================================================
+
+
+## A `.map` face line whose three points sit on the plane but nowhere near the
+## face polygon, which is all a plane definition ever promised to be. Reading
+## these three back as corners is the bug.
+func _plane_line(plane: Plane, spread: float) -> String:
+	var normal := plane.normal.normalized()
+	var reference := Vector3.UP if absf(normal.dot(Vector3.UP)) < 0.9 else Vector3.RIGHT
+	var u := normal.cross(reference).normalized()
+	# u cross v is the normal, and the reader takes (p1 - p0) cross (p2 - p0),
+	# so these three points name the plane facing outward.
+	var v := normal.cross(u)
+	var origin := normal * plane.d
+	return HFMapQuake.new().format_face_line(
+		origin, origin + u * spread, origin + v * spread, "brick", null
+	)
+
+
+func _face_lines_for_planes(planes: Array, spread: float) -> Array[String]:
+	var lines: Array[String] = []
+	for plane in planes:
+		lines.append(_plane_line(plane, spread))
+	return lines
+
+
+## The six outward planes of a box brush, in world space.
+func _box_planes(brush: DraftBrush) -> Array:
+	var planes: Array = []
+	var half := [brush.size.x * 0.5, brush.size.y * 0.5, brush.size.z * 0.5]
+	var placement := brush.global_transform
+	var axes := [placement.basis.x, placement.basis.y, placement.basis.z]
+	for axis in range(3):
+		var normal: Vector3 = (axes[axis] as Vector3).normalized()
+		var reach: float = half[axis]
+		planes.append(Plane(normal, normal.dot(placement.origin + normal * reach)))
+		planes.append(Plane(-normal, -normal.dot(placement.origin - normal * reach)))
+	return planes
+
+
+func _box_corners(brush: DraftBrush) -> PackedVector3Array:
+	var half: Vector3 = brush.size * 0.5
+	var corners := PackedVector3Array()
+	for x in [-half.x, half.x]:
+		for y in [-half.y, half.y]:
+			for z in [-half.z, half.z]:
+				corners.append(brush.global_transform * Vector3(x, y, z))
+	return corners
+
+
+func _face_world_verts(face: Dictionary, center: Vector3) -> PackedVector3Array:
+	var out := PackedVector3Array()
+	for entry in face["local_verts"]:
+		out.append(Vector3(entry[0], entry[1], entry[2]) + center)
+	return out
+
+
+func _nearest_distance(point: Vector3, candidates: PackedVector3Array) -> float:
+	var best := INF
+	for candidate in candidates:
+		best = minf(best, point.distance_to(candidate))
+	return best
+
+
+## A box turned off every axis, written out as plane definitions that are not its
+## corners, then read back.
+func _import_tilted_box(brush: DraftBrush) -> Dictionary:
+	brush.shape = LevelRoot.BrushShape.BOX
+	brush.size = Vector3(8, 8, 8)
+	brush.rotation = Vector3(deg_to_rad(15), deg_to_rad(30), deg_to_rad(20))
+	var parsed: Dictionary = MapIO.parse_map_text(
+		_wrap_worldspawn(_face_lines_for_planes(_box_planes(brush), 20.0))
+	)
+	assert_eq(parsed.get("errors", []), [], "Well formed planes parse clean")
+	var brushes: Array = parsed.get("brushes", [])
+	assert_eq(brushes.size(), 1, "Six planes are one brush")
+	return brushes[0] if brushes.size() == 1 else {}
+
+
+func test_tilted_brush_faces_come_back_as_polygons_not_plane_points():
+	var brush := DraftBrush.new()
+	add_child_autoqfree(brush)
+	var imported := _import_tilted_box(brush)
+	assert_eq(int(imported["shape"]), LevelRoot.BrushShape.CUSTOM)
+
+	var corners := _box_corners(brush)
+	var center: Vector3 = imported["center"]
+	var faces: Array = imported["faces"]
+	assert_eq(faces.size(), 6, "A box has six faces")
+	for i in range(faces.size()):
+		var verts := _face_world_verts(faces[i], center)
+		assert_eq(
+			verts.size(), 4, "Face %d is a quad, not the three points that named its plane" % i
+		)
+		for vertex in verts:
+			assert_lt(
+				_nearest_distance(vertex, corners), 0.02, "Face %d has a corner off the box" % i
+			)
+
+
+func test_tilted_brush_size_comes_from_the_hull_not_the_plane_points():
+	var brush := DraftBrush.new()
+	add_child_autoqfree(brush)
+	var imported := _import_tilted_box(brush)
+
+	var corners := _box_corners(brush)
+	var low := corners[0]
+	var high := corners[0]
+	for corner in corners:
+		low = Vector3(minf(low.x, corner.x), minf(low.y, corner.y), minf(low.z, corner.z))
+		high = Vector3(maxf(high.x, corner.x), maxf(high.y, corner.y), maxf(high.z, corner.z))
+	var size: Vector3 = imported["size"]
+	assert_lt(
+		size.distance_to(high - low), 0.02, "The brush is as big as its hull, not as its planes"
+	)
+
+
+func test_wedge_imports_with_triangle_ends_and_quad_sides():
+	# x >= 0, z >= 0, x + z <= 10, extruded along y from -4 to 4.
+	var diagonal := Vector3(1, 0, 1).normalized()
+	var planes := [
+		Plane(Vector3(-1, 0, 0), 0.0),
+		Plane(Vector3(0, 0, -1), 0.0),
+		Plane(diagonal, diagonal.dot(Vector3(10, 0, 0))),
+		Plane(Vector3(0, 1, 0), 4.0),
+		Plane(Vector3(0, -1, 0), 4.0),
+	]
+	var parsed: Dictionary = MapIO.parse_map_text(
+		_wrap_worldspawn(_face_lines_for_planes(planes, 20.0))
+	)
+
+	assert_eq(parsed.get("errors", []), [], "Well formed planes parse clean")
+	var brushes: Array = parsed.get("brushes", [])
+	assert_eq(brushes.size(), 1)
+	assert_eq(int(brushes[0]["shape"]), LevelRoot.BrushShape.CUSTOM)
+	var counts: Array = []
+	for face in brushes[0]["faces"]:
+		counts.append((face["local_verts"] as Array).size())
+	assert_eq(counts.size(), 5, "Five planes, five faces")
+	assert_eq(counts.count(3), 2, "The two ends are triangles")
+	assert_eq(counts.count(4), 3, "The three sides are quads")
+
+
+func test_planes_that_close_nothing_still_import():
+	# Two planes bound no solid. The old reading of the plane points as corners is
+	# all there is to fall back on, and losing the brush would be worse.
+	var lines: Array[String] = [
+		"( 0 0 0 ) ( 4 0 0 ) ( 4 4 0 ) brick 0 0 0 1 1",
+		"( 0 0 8 ) ( 4 4 8 ) ( 4 0 8 ) brick 0 0 0 1 1",
+	]
+	var parsed: Dictionary = MapIO.parse_map_text(_wrap_worldspawn(lines))
+	assert_eq((parsed.get("brushes", []) as Array).size(), 1, "The brush survives an open hull")
+
+
+# ===========================================================================
 # Malformed map input (#174)
 # ===========================================================================
 


### PR DESCRIPTION
Fixes #244

A `.map` face line names three points on an infinite plane, not the corners of a face. Import read them as corners, so every brush that was not an axis-aligned box arrived as disconnected 3-point triangles standing wherever the file put its plane references. A cylinder, ramp, wedge or turned box from TrenchBroom or Hammer came in deformed and not watertight.

- Each face is now worked out the way the format defines it: a square laid on the plane, clipped by every other plane of the brush, wound clockwise from outside. `HFConvexClip` already had the clipping and the winding.
- Size and centre came from the same misread points and now come from the hull. That also fixes the axis-aligned box path, where plane references off in a corner used to give the wrong size.
- Planes that close nothing still import on the old reading. Two planes bound no solid and a file can hold that, so an ill-formed brush arrives wrong rather than not at all.
- The set is retried flipped, because the order of the three points settles which side is solid and editors do not agree on it. The intersection of the outside half spaces of a closed solid is empty, so the wrong orientation cannot pass by accident.

Tests: a box turned on every axis, written out with plane references 20 units clear of its own corners, asserting six quads whose corners land on the box and a size matching the hull; a wedge coming back as two triangle ends and three quad sides; and an open plane pair still importing. The first three fail against the old code.

Docs: CHANGELOG, and the `.map` section of `docs/HammerForge_Data_Portability.md`.