### PR TITLE
Take the entity wiring overlay down with the level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,15 @@ The format is based on Keep a Changelog, and this project follows semantic versi
     copy, undo, and what survives a state restore.
 
 ### Fixed
+- **The entity wiring overlay stayed behind when the level left the tree.**
+  `HFIOVisualizer` hangs a `MeshInstance3D` and its pulse overlays off the
+  `LevelRoot`, and `cleanup()` was written to take them down, but
+  `LevelRoot._exit_tree()` never called it. Closing a scene or reloading the
+  plugin left the mesh behind, once per reload. Every other overlay in that
+  teardown was already accounted for.
+  - **Coverage** (`tests/test_io_visualizer_enhanced.gd`): a real `LevelRoot`
+    with the wiring drawn, taken out of the tree, asserting the mesh is gone and
+    left no node behind. It fails against the old code.
 - **Tilted brushes imported from `.map` as loose triangles.** A `.map` face line
   names three points on an infinite plane, not the corners of a face. Import read
   them as corners, so every brush that was not an axis-aligned box arrived as a

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -400,7 +400,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,115 tests across 161 test scripts (3,108 passing plus seven intentional no-assert safety tests; 16,226 assertions; verified in CI on September 9, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,116 tests across 161 test scripts (3,109 passing plus seven intentional no-assert safety tests; 16,229 assertions; verified in CI on September 9, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -540,6 +540,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 9, 2026): **3,115 tests** across **161 scripts** (**3,108 passing** plus seven intentional no-assert safety tests; **16,226 assertions**).
+Full suite (verified in CI on September 9, 2026): **3,116 tests** across **161 scripts** (**3,109 passing** plus seven intentional no-assert safety tests; **16,229 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3108%20passing-brightgreen" alt="3108 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3109%20passing-brightgreen" alt="3109 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -932,7 +932,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,115 tests across 161 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. One issue is open — [#241](https://github.com/saworbit/hammerforge/issues/241), the Re-hollow overwrite warning — and it is the only known limitation that is not yet either covered or written down beside the wave that introduced it.
+The current suite covers 3,116 tests across 161 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. One issue is open — [#241](https://github.com/saworbit/hammerforge/issues/241), the Re-hollow overwrite warning — and it is the only known limitation that is not yet either covered or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -611,6 +611,8 @@ func _exit_tree() -> void:
 		structure_preview.destroy()
 	if array_preview:
 		array_preview.destroy()
+	if io_visualizer:
+		io_visualizer.cleanup()
 	# Cancel any in-flight tool previews so their nodes don't outlive the tree
 	if extrude_tool:
 		extrude_tool.cancel_extrude()

--- a/docs/features.md
+++ b/docs/features.md
@@ -373,7 +373,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 9, 2026 contains **3,115 tests across 161 scripts**: **3,108 passing tests**, seven intentional no-assert safety tests, and **16,226 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 9, 2026 contains **3,116 tests across 161 scripts**: **3,109 passing tests**, seven intentional no-assert safety tests, and **16,229 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_io_visualizer_enhanced.gd
+++ b/tests/test_io_visualizer_enhanced.gd
@@ -2,6 +2,7 @@ extends GutTest
 
 const HFEntitySystem = preload("res://addons/hammerforge/systems/hf_entity_system.gd")
 const HFIOVisualizer = preload("res://addons/hammerforge/systems/hf_io_visualizer.gd")
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
 
 var root: Node3D
 var sys: HFEntitySystem
@@ -288,3 +289,23 @@ func test_cleanup():
 	viz.cleanup()
 	assert_eq(viz._highlight_overlays.size(), 0)
 	assert_null(viz._immediate_mesh)
+
+
+func test_the_wiring_overlay_leaves_with_the_level_it_was_drawn_in():
+	# Closing the scene or reloading the plugin takes the LevelRoot out of the
+	# tree, and the wiring lines hang off it. An overlay that outlived it would be
+	# a mesh with no owner, left behind on every scene reload.
+	var level: Node3D = LevelRootType.new()
+	level.auto_spawn_player = false
+	level.commit_freeze = false
+	level.hflevel_autosave_enabled = false
+	add_child_autoqfree(level)
+	level.io_visualizer.set_enabled(true)
+	level.io_visualizer.refresh()
+	var overlay: Node = level.io_visualizer._mesh_instance
+	assert_not_null(overlay, "there is something to lose")
+
+	level.get_parent().remove_child(level)
+
+	assert_null(level.io_visualizer._mesh_instance, "the overlay went with the level")
+	assert_false(is_instance_valid(overlay) and overlay.get_parent() != null, "and left the tree")


### PR DESCRIPTION
Fixes #245

`HFIOVisualizer` hangs a `MeshInstance3D` and its pulse overlays off the `LevelRoot`. `cleanup()` was written to take them down, and `LevelRoot._exit_tree()` never called it, so closing a scene or reloading the plugin left the mesh behind, once per reload. Every other overlay in that teardown was already accounted for.

Test: a real `LevelRoot` with the wiring drawn, taken out of the tree, asserting the mesh is gone and left no node behind. It fails against the old code.

Docs: CHANGELOG.