### PR TITLE
Keep a point entity's authored name through capture and restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,23 @@ The format is based on Keep a Changelog, and this project follows semantic versi
     copy, undo, and what survives a state restore.
 
 ### Fixed
+- **A point entity's authored name was thrown away by every save, undo and
+  duplicate.** The authored name is not the node name: it is what an I/O output
+  targets and what `find_entities_by_name()` looks up. `capture_entity_info()`
+  never read the `entity_name` meta and `restore_entity_from_info()` never wrote
+  it, so a name survived only until the next snapshot — which is any undo, any
+  redo, an autosave, a level reload, or a Ctrl+D. After that the entity answered
+  to nothing and the outputs aimed at it fired into the air.
+  - Every one of those paths runs through the same pair of functions, so both ends
+    of the info dictionary carry the name now. Brush entities have carried theirs
+    since #149; point entities were left out of that pass.
+  - A prefab placed twice now gives both copies the same authored name, the same
+    way two placements of a named brush entity already do. The I/O remap works off
+    node names, which stay unique.
+  - **Coverage** (`tests/test_entity_props.gd`): capture and restore, duplication,
+    an unnamed entity gaining no metadata, and a real `LevelRoot` taken through a
+    state snapshot and asked to find the entity by name afterwards. Three of the
+    four fail against the old code.
 - **The entity wiring overlay stayed behind when the level left the tree.**
   `HFIOVisualizer` hangs a `MeshInstance3D` and its pulse overlays off the
   `LevelRoot`, and `cleanup()` was written to take them down, but

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -400,7 +400,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,141 tests across 162 test scripts (3,134 passing plus seven intentional no-assert safety tests; 16,333 assertions; verified in CI on September 9, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,145 tests across 162 test scripts (3,138 passing plus seven intentional no-assert safety tests; 16,341 assertions; verified in CI on September 9, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -540,6 +540,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 9, 2026): **3,141 tests** across **162 scripts** (**3,134 passing** plus seven intentional no-assert safety tests; **16,333 assertions**).
+Full suite (verified in CI on September 9, 2026): **3,145 tests** across **162 scripts** (**3,138 passing** plus seven intentional no-assert safety tests; **16,341 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3134%20passing-brightgreen" alt="3134 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3138%20passing-brightgreen" alt="3138 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,141 tests across 162 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,145 tests across 162 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/systems/hf_entity_system.gd
+++ b/addons/hammerforge/systems/hf_entity_system.gd
@@ -143,6 +143,13 @@ func capture_entity_info(entity: DraftEntity) -> Dictionary:
 	var group_id := str(entity.get_meta("group_id", ""))
 	if group_id != "":
 		info["group_id"] = group_id
+	# The authored name, which is not the node name. It is what an I/O output
+	# targets and what `find_entities_by_name()` looks up, so an entity that comes
+	# back without it is wired to nothing. Brush entities have carried it through
+	# their own infos since #149; point entities were left out.
+	var authored := str(entity.get_meta("entity_name", ""))
+	if authored != "":
+		info["entity_name"] = authored
 	return info
 
 
@@ -170,6 +177,9 @@ func restore_entity_from_info(info: Dictionary) -> DraftEntity:
 	var group_id := str(info.get("group_id", ""))
 	if group_id != "":
 		entity.set_meta("group_id", group_id)
+	var authored := str(info.get("entity_name", ""))
+	if authored != "":
+		entity.set_meta("entity_name", authored)
 	entity.set_meta("is_entity", true)
 	root.entities_node.add_child(entity)
 	root._assign_owner(entity)

--- a/docs/HammerForge_Data_Portability.md
+++ b/docs/HammerForge_Data_Portability.md
@@ -83,6 +83,7 @@ After import, run **Check Only** (Test tab) to detect any remaining non-planar f
 - Transforms are stored relative to the group centroid, so prefabs can be placed at any world position.
 - Brush IDs and group IDs are stripped on capture; new ones are assigned on instantiation.
 - Entity I/O connections are captured and remapped to new entity names when instantiated.
+- The authored entity name travels verbatim, so placing a prefab twice gives both copies the same name. The I/O remap works off node names, which are made unique on placement; rename the copies yourself if two of them are meant to be told apart by an output.
 - Data encoding uses the same `HFLevelIO.encode_variant()` / `decode_variant()` pipeline as `.hflevel` (handles Vector3, Transform3D, Basis, etc.).
 - Prefab files are saved to `res://prefabs/` by default. The directory is created automatically on first save.
 - Prefabs are portable between projects — just copy `.hfprefab` files to another project's `res://prefabs/` folder.

--- a/docs/features.md
+++ b/docs/features.md
@@ -373,7 +373,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 9, 2026 contains **3,141 tests across 162 scripts**: **3,134 passing tests**, seven intentional no-assert safety tests, and **16,333 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 9, 2026 contains **3,145 tests across 162 scripts**: **3,138 passing tests**, seven intentional no-assert safety tests, and **16,341 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_entity_props.gd
+++ b/tests/test_entity_props.gd
@@ -296,3 +296,61 @@ func test_create_entity_from_map_keeps_world_origin_when_root_is_offset():
 		Vector3(0.001, 0.001, 0.001),
 		"Map origins are world coordinates, not offsets from the level root"
 	)
+
+
+# ===========================================================================
+# The authored entity name survives capture and restore (#251)
+# ===========================================================================
+
+
+func test_roundtrip_preserves_the_authored_entity_name():
+	# The authored name is not the node name. It is what an I/O output targets and
+	# what find_entities_by_name() looks up, so an entity that comes back without
+	# it is wired to nothing.
+	var e = _make_draft_entity("info_target")
+	e.set_meta("entity_name", "key_door_target")
+
+	var info = sys.capture_entity_info(e)
+	assert_eq(str(info.get("entity_name", "")), "key_door_target", "the name is captured")
+
+	var restored = sys.restore_entity_from_info(info)
+	assert_not_null(restored)
+	assert_eq(str(restored.get_meta("entity_name", "")), "key_door_target")
+
+
+func test_duplicate_info_keeps_the_authored_entity_name():
+	var e = _make_draft_entity("info_target")
+	e.set_meta("entity_name", "key_door_target")
+
+	var dup = sys.restore_entity_from_info(sys.build_duplicate_info(e, Vector3(64, 0, 0)))
+
+	assert_not_null(dup)
+	assert_eq(str(dup.get_meta("entity_name", "")), "key_door_target")
+
+
+func test_roundtrip_without_a_name_sets_no_meta():
+	var e = _make_draft_entity("light_point")
+	var info = sys.capture_entity_info(e)
+	assert_false(info.has("entity_name"))
+	var restored = sys.restore_entity_from_info(info)
+	assert_false(restored.has_meta("entity_name"), "Unnamed entities stay free of the meta")
+
+
+func test_a_point_entity_name_survives_a_state_restore():
+	# The reported symptom: an undo, a redo, an autosave or a reload all run the
+	# level through a snapshot, and the name was dropped every time.
+	var level := LevelRoot.new()
+	level.auto_spawn_player = false
+	level.commit_freeze = false
+	level.hflevel_autosave_enabled = false
+	add_child_autoqfree(level)
+	var entity := DraftEntity.new()
+	entity.entity_type = "info_target"
+	entity.entity_class = "info_target"
+	level.entities_node.add_child(entity)
+	entity.set_meta("entity_name", "key_door_target")
+
+	level.restore_state(level.capture_state())
+
+	var found: Array = level.entity_system.find_entities_by_name("key_door_target")
+	assert_eq(found.size(), 1, "the restored entity still answers to the name it was given")


### PR DESCRIPTION
Fixes #251

The authored name is not the node name. It is what an I/O output targets and what `find_entities_by_name()` looks up. `capture_entity_info()` never read the `entity_name` meta and `restore_entity_from_info()` never wrote it, so the name survived only until the next snapshot — any undo, any redo, an autosave, a level reload, or a Ctrl+D. After that the entity answered to nothing and the outputs aimed at it fired into the air.

- Every one of those paths runs through the same pair of functions, so both ends of the info dictionary carry the name now. Brush entities have carried theirs since #149; point entities were left out of that pass.
- A prefab placed twice now gives both copies the same authored name, the same way two placements of a named brush entity already do. The I/O remap works off node names, which stay unique. Noted in the prefab section of `docs/HammerForge_Data_Portability.md`.

Tests: capture and restore, duplication, an unnamed entity gaining no metadata, and a real `LevelRoot` taken through a state snapshot and asked to find the entity by name afterwards. Three of the four fail against the old code.

Docs: CHANGELOG, `docs/HammerForge_Data_Portability.md`.