### PR TITLE
Remap prefab I/O through the entities it just made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,22 @@ The format is based on Keep a Changelog, and this project follows semantic versi
     copy, undo, and what survives a state restore.
 
 ### Fixed
+- **A prefab could wire its copy's outputs to the entities it was built from.**
+  `HFPrefab.instantiate()` remapped I/O by turning each old node name into the new
+  one and then looking that name back up. The lookup resolves an authored
+  `entity_name` as well as a node name, so an entity of the same prefab whose
+  authored name matched a later one's generated node name was returned first: it
+  was remapped twice, and the entity it stood in for was never remapped at all and
+  kept its outputs aimed outside the instance. The prefab looked right in the scene
+  tree and its wiring was wrong.
+  - It already had direct references to every entity it had just created. The
+    remap walks those instead, so each is remapped exactly once and no name lookup
+    is involved.
+  - **Coverage** (`tests/test_prefab.gd`): a two-entity prefab whose first entity
+    is renamed on the way in and carries an authored name matching the second one's
+    node name, asserting the second one's output lands inside the new instance; and
+    the ordinary case with no alias in the way. The first fails against the old
+    code, keeping the output aimed at the entity the prefab was built from.
 - **Deleting a named entity left the connections that used its authored name.**
   An entity has two addresses — its node name and its authored `entity_name` — and
   an output can be aimed at either. Deletion only ever cleaned up the node name, so

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -400,7 +400,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,160 tests across 162 test scripts (3,153 passing plus seven intentional no-assert safety tests; 16,385 assertions; verified in CI on September 9, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,162 tests across 162 test scripts (3,155 passing plus seven intentional no-assert safety tests; 16,391 assertions; verified in CI on September 9, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -540,6 +540,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 9, 2026): **3,160 tests** across **162 scripts** (**3,153 passing** plus seven intentional no-assert safety tests; **16,385 assertions**).
+Full suite (verified in CI on September 9, 2026): **3,162 tests** across **162 scripts** (**3,155 passing** plus seven intentional no-assert safety tests; **16,391 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3153%20passing-brightgreen" alt="3153 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3155%20passing-brightgreen" alt="3155 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,160 tests across 162 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,162 tests across 162 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/hf_prefab.gd
+++ b/addons/hammerforge/hf_prefab.gd
@@ -171,15 +171,17 @@ func instantiate(
 			if old_name != "":
 				name_map[old_name] = entity.name
 
-	# Remap I/O connections
+	# Remap I/O connections, through the nodes that were just created rather than by
+	# looking their new names back up.
+	#
+	# The lookup resolves an authored `entity_name` as well as a node name, so an
+	# entity of this same prefab whose authored name happens to match a later one's
+	# generated node name is returned first: remapped twice, while the entity it
+	# stood in for is never remapped at all and keeps its outputs aimed outside the
+	# instance. Every restored node is here already, exactly once.
 	if not name_map.is_empty() and entity_system.has_method("remap_io_connections"):
-		for entity_info in e_infos:
-			var ent_name: String = name_map.get(str(entity_info.get("name", "")), "")
-			if ent_name == "":
-				continue
-			var entities = entity_system.find_entities_by_name(ent_name)
-			if not entities.is_empty():
-				entity_system.remap_io_connections(entities[0], name_map)
+		for entity in new_entity_nodes:
+			entity_system.remap_io_connections(entity, name_map)
 
 	if root.has_method("end_signal_batch"):
 		root.end_signal_batch()

--- a/docs/HammerForge_Data_Portability.md
+++ b/docs/HammerForge_Data_Portability.md
@@ -82,7 +82,7 @@ After import, run **Check Only** (Test tab) to detect any remaining non-planar f
 - `.hfprefab` files store reusable brush + entity groups as JSON.
 - Transforms are stored relative to the group centroid, so prefabs can be placed at any world position.
 - Brush IDs and group IDs are stripped on capture; new ones are assigned on instantiation.
-- Entity I/O connections are captured and remapped to new entity names when instantiated.
+- Entity I/O connections are captured and remapped to new entity names when instantiated. The remap runs over the entities the placement just created, not over a name lookup, so an authored name that collides with another copy's node name cannot send it to the wrong one.
 - The authored entity name travels verbatim, so placing a prefab twice gives both copies the same name. The I/O remap works off node names, which are made unique on placement; rename the copies yourself if two of them are meant to be told apart by an output.
 - Data encoding uses the same `HFLevelIO.encode_variant()` / `decode_variant()` pipeline as `.hflevel` (handles Vector3, Transform3D, Basis, etc.).
 - Prefab files are saved to `res://prefabs/` by default. The directory is created automatically on first save.

--- a/docs/features.md
+++ b/docs/features.md
@@ -373,7 +373,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 9, 2026 contains **3,160 tests across 162 scripts**: **3,153 passing tests**, seven intentional no-assert safety tests, and **16,385 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 9, 2026 contains **3,162 tests across 162 scripts**: **3,155 passing tests**, seven intentional no-assert safety tests, and **16,391 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_prefab.gd
+++ b/tests/test_prefab.gd
@@ -3,6 +3,7 @@ extends GutTest
 const HFPrefabType = preload("res://addons/hammerforge/hf_prefab.gd")
 const HFLog = preload("res://addons/hammerforge/hf_log.gd")
 const HFLevelIO = preload("res://addons/hammerforge/hflevel_io.gd")
+const DraftEntity = preload("res://addons/hammerforge/draft_entity.gd")
 
 
 func before_each():
@@ -181,3 +182,87 @@ func test_centroid_uses_combined_aabb_center_not_origin_mean():
 	assert_almost_eq(centroid.x, 6.0, 0.05, "Centroid should be combined AABB center")
 	assert_almost_eq(centroid.y, 0.0, 0.05)
 	assert_almost_eq(centroid.z, 0.0, 0.05)
+
+
+# ===========================================================================
+# Prefab I/O is remapped through the entities it just made (#257)
+# ===========================================================================
+
+
+func _a_level() -> LevelRoot:
+	var level := LevelRoot.new()
+	level.auto_spawn_player = false
+	level.commit_freeze = false
+	level.hflevel_autosave_enabled = false
+	add_child_autoqfree(level)
+	return level
+
+
+func _an_entity_in(level: LevelRoot, node_name: String) -> DraftEntity:
+	var entity := DraftEntity.new()
+	entity.name = node_name
+	entity.entity_type = "light"
+	entity.entity_class = "light"
+	entity.set_meta("is_entity", true)
+	level.entities_node.add_child(entity)
+	return entity
+
+
+func test_prefab_io_is_remapped_through_the_entities_it_just_made():
+	# The alias-aware name lookup is not unique. Here the first prefab entity is
+	# renamed on the way in and carries an authored name matching the second one's
+	# node name, so looking the second one up by name returns the first: it gets
+	# remapped twice, and the entity it stood in for is never remapped at all.
+	var level := _a_level()
+	# Occupy the first name only, so the first entity is renamed and the second is not.
+	_an_entity_in(level, "Source")
+
+	var source_info := _make_entity_info(Vector3.ZERO, "Source")
+	source_info["entity_name"] = "Target"
+	var target_info := _make_entity_info(Vector3.ZERO, "Target")
+	target_info["io_outputs"] = [
+		{"output_name": "OnTrigger", "target_name": "Source", "input_name": "Open"}
+	]
+	var prefab = HFPrefabType.new()
+	prefab.entity_infos = [source_info, target_info]
+
+	var result: Dictionary = prefab.instantiate(
+		level.brush_system, level.entity_system, level, Vector3.ZERO
+	)
+
+	var made: Array = result.get("entity_nodes", [])
+	assert_eq(made.size(), 2, "both prefab entities were placed")
+	assert_ne(str(made[0].name), "Source", "the first was renamed, so the remap has work to do")
+	var outputs: Array = made[1].get_meta("entity_io_outputs", [])
+	assert_eq(outputs.size(), 1, "the output travelled with the prefab")
+	assert_eq(
+		str(outputs[0].get("target_name", "")),
+		str(made[0].name),
+		"the output points inside the new instance, not at the entity it was built from"
+	)
+
+
+func test_prefab_io_remap_still_works_without_an_alias_in_the_way():
+	var level := _a_level()
+	_an_entity_in(level, "Button")
+
+	var source_info := _make_entity_info(Vector3.ZERO, "Button")
+	var target_info := _make_entity_info(Vector3.ZERO, "Door")
+	target_info["io_outputs"] = [
+		{"output_name": "OnTrigger", "target_name": "Button", "input_name": "Open"}
+	]
+	var prefab = HFPrefabType.new()
+	prefab.entity_infos = [source_info, target_info]
+
+	var result: Dictionary = prefab.instantiate(
+		level.brush_system, level.entity_system, level, Vector3.ZERO
+	)
+
+	var made: Array = result.get("entity_nodes", [])
+	assert_eq(made.size(), 2)
+	var outputs: Array = made[1].get_meta("entity_io_outputs", [])
+	assert_eq(
+		str(outputs[0].get("target_name", "")),
+		str(made[0].name),
+		"the ordinary case still lands on the copy it was made with"
+	)


### PR DESCRIPTION
Fixes #257

`HFPrefab.instantiate()` remapped I/O by turning each old node name into the new one and then looking that name back up. The lookup resolves an authored `entity_name` as well as a node name, so an entity of the same prefab whose authored name matched a later one's generated node name was returned first: it got remapped twice, and the entity it stood in for was never remapped at all and kept its outputs aimed outside the instance. The prefab looked right in the scene tree and its wiring was wrong.

It already had direct references to every entity it had just created, in `new_entity_nodes`. The remap walks those now, so each entity is remapped exactly once and no name lookup is involved.

Tests: a two-entity prefab whose first entity is renamed on the way in and carries an authored name matching the second one's node name, asserting the second one's output lands inside the new instance; plus the ordinary case with no alias in the way. The first fails against the old code with the output still aimed at the entity the prefab was built from. The tests read the generated names off the result rather than predicting them, because Godot's collision renaming is not the `Name2` form headlessly.

Docs: CHANGELOG, and the prefab bullet in `docs/HammerForge_Data_Portability.md`.