### PR TITLE
Redraw the wiring overlay only when the wiring changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,36 @@ The format is based on Keep a Changelog, and this project follows semantic versi
     presses without reselecting, undo, and what survives a state restore.
 
 ### Changed
+- **The entity wiring overlay only redraws when the wiring changes.** It rebuilt
+  every ten editor frames whether or not anything had moved: the connection list
+  was recollected, every target was resolved by scanning the whole level, the
+  curve mesh was thrown away and rebuilt, and Highlight Connected freed and
+  remade its pulse spheres. On a level with 200 entities and 400 outputs that is
+  about 80,000 name comparisons per rebuild, six times a second, to draw the
+  picture that was already on screen.
+  - **Targets resolve through one index instead of one scan each.**
+    `HFEntitySystem.build_name_index()` maps every address in the level to the
+    nodes that answer to it in a single pass, and the drawing loop reads it. The
+    addresses and their order match `find_entities_by_name()` exactly, and they
+    are built next to it so the two cannot drift apart.
+  - **The redraw is guarded by a change check rather than by a signal.** A rename
+    in the Scene dock, an undo, and an entity dragged in the viewport all change
+    the picture without going through HammerForge, so a signal would have had to
+    be emitted from each of them and the ones nobody remembered would be
+    stale-overlay bugs. The check reads each node once; the rebuild it guards
+    reads every connection against every entity.
+  - **Pulse spheres are moved rather than freed and remade**, and the pulse now
+    advances on the real frame time instead of an assumed 60 frames per second.
+  - **A graph where every connection dangles no longer opens an empty mesh
+    surface.** Renaming the last live target left the overlay closing a surface
+    with no vertices in it, which Godot reports as an error. Nothing resolves, so
+    now nothing is drawn.
+  - **Coverage** (`tests/test_io_visualizer_dirty.gd`): 28 tests over idle frames,
+    an output added, removed and re-delayed, a native rename, an alias edit, a
+    moved entity, a moved brush entity, an entity added and removed, selection,
+    a forced rebuild, a lost mesh node, sphere reuse and release, the real delta,
+    the dangling-only graph and its recovery, and the index against the lookup it
+    replaces.
 - **The array edit warning counts more than movement.** It counted a copy that had
   been dragged and said nothing about one that had been resized, reshaped,
   retextured, or had a paint layer added — though the same press rebuilds over

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -400,7 +400,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,162 tests across 162 test scripts (3,155 passing plus seven intentional no-assert safety tests; 16,391 assertions; verified in CI on September 9, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,190 tests across 163 test scripts (3,183 passing plus seven intentional no-assert safety tests; 16,430 assertions; verified in CI on September 9, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -540,6 +540,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 9, 2026): **3,162 tests** across **162 scripts** (**3,155 passing** plus seven intentional no-assert safety tests; **16,391 assertions**).
+Full suite (verified in CI on September 9, 2026): **3,190 tests** across **163 scripts** (**3,183 passing** plus seven intentional no-assert safety tests; **16,430 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3155%20passing-brightgreen" alt="3155 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3183%20passing-brightgreen" alt="3183 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,162 tests across 162 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,190 tests across 163 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -627,7 +627,7 @@ func _process(_delta: float) -> void:
 		return
 	_process_hflevel_saves()
 	if io_visualizer:
-		io_visualizer.process()
+		io_visualizer.process(_delta)
 	if subtract_preview and subtract_preview.is_enabled():
 		subtract_preview.process(_delta)
 

--- a/addons/hammerforge/systems/hf_entity_system.gd
+++ b/addons/hammerforge/systems/hf_entity_system.gd
@@ -485,6 +485,41 @@ func find_entities_by_name(entity_name: String) -> Array:
 	return result
 
 
+## Every address in the level mapped to the nodes that answer to it.
+##
+## One pass over the entities and brush entities, so a caller resolving many
+## connections at once does not rescan the level per connection. The addresses
+## and the order within an address match `find_entities_by_name()` exactly, and
+## they are built here rather than at the call site so the two cannot drift.
+##
+## A snapshot. Anything that adds, removes, renames or re-aliases a node makes it
+## wrong, so build it inside the pass that reads it.
+func build_name_index() -> Dictionary:
+	var index: Dictionary = {}
+	if root.entities_node:
+		for child in root.entities_node.get_children():
+			_index_address(index, str(child.name), child)
+			_index_address(index, str(child.get_meta("entity_name", "")), child)
+	if root.draft_brushes_node:
+		for child in root.draft_brushes_node.get_children():
+			if is_brush_io_target(child):
+				_index_address(index, str(child.name), child)
+	return index
+
+
+## A node answering to both its node name and the same authored name is still one
+## target, the way `find_entities_by_name()` appends it once.
+static func _index_address(index: Dictionary, address: String, node: Node) -> void:
+	if address == "":
+		return
+	if not index.has(address):
+		index[address] = [node]
+		return
+	var nodes: Array = index[address]
+	if not nodes.has(node):
+		nodes.append(node)
+
+
 static func is_brush_io_target(node: Node) -> bool:
 	return (
 		node != null

--- a/addons/hammerforge/systems/hf_io_visualizer.gd
+++ b/addons/hammerforge/systems/hf_io_visualizer.gd
@@ -16,7 +16,12 @@ var _frame_counter: int = 0
 var _pulse_phase: float = 0.0
 var _highlight_overlays: Array = []  # MeshInstance3D nodes for pulse effect
 var _selected_entity_refs: Array[WeakRef] = []
-const REFRESH_INTERVAL := 10  # Update every N frames
+var _dirty: bool = true
+var _last_fingerprint: int = 0
+## Diagnostic: how many times the geometry has actually been rebuilt. Read by
+## the tests and useful when profiling a wired level.
+var refresh_count: int = 0
+const REFRESH_INTERVAL := 10  # Frames between staleness checks
 const CURVE_SEGMENTS := 12  # Segments per Bézier curve
 const ARROW_SIZE := 0.18
 const PULSE_SPEED := 4.0
@@ -82,23 +87,71 @@ func set_selected_entities(nodes: Array) -> void:
 		refresh()
 
 
-func process() -> void:
+## Force a rebuild on the next staleness check. For callers that know they
+## changed the graph and would rather not wait to be found out.
+func mark_dirty() -> void:
+	_dirty = true
+
+
+func process(delta: float) -> void:
 	if not enabled:
 		return
 	_frame_counter += 1
-	_pulse_phase += 0.016 * PULSE_SPEED  # ~60fps assumed
+	_pulse_phase += delta * PULSE_SPEED
 	if _pulse_phase > TAU:
 		_pulse_phase -= TAU
 	if _frame_counter >= REFRESH_INTERVAL:
 		_frame_counter = 0
-		refresh()
+		if _is_stale():
+			refresh()
 	if highlight_connected and not _highlight_overlays.is_empty():
 		_update_pulse()
+
+
+## Is anything the drawing depends on different from what was drawn?
+##
+## The overlay is driven off a change check rather than off a signal because a
+## rename done in the Scene dock, an undo, and a transform dragged in the viewport
+## all change the picture without going through HammerForge. A signal would have
+## to be emitted from every one of those, and the ones nobody remembers to emit
+## are exactly the stale-overlay bugs.
+##
+## The check reads each node once. The rebuild it guards resolves every
+## connection against every entity, so this is the cheap half by a wide margin.
+func _is_stale() -> bool:
+	if _dirty:
+		return true
+	if not _mesh_instance or not is_instance_valid(_mesh_instance):
+		return true
+	return _fingerprint() != _last_fingerprint
+
+
+func _fingerprint() -> int:
+	var parts: Array = []
+	for node in _io_nodes():
+		parts.append(node.name)
+		parts.append(node.get_meta("entity_name", ""))
+		parts.append(node.get_meta("entity_io_outputs", []))
+		if node is Node3D:
+			parts.append(node.global_position)
+	return hash(parts)
+
+
+func _io_nodes() -> Array:
+	var nodes: Array = []
+	if root and root.entities_node:
+		nodes.append_array(root.entities_node.get_children())
+	if root and root.get("draft_brushes_node") and root.draft_brushes_node:
+		nodes.append_array(root.draft_brushes_node.get_children())
+	return nodes
 
 
 func refresh() -> void:
 	if not root or not enabled:
 		return
+	refresh_count += 1
+	_dirty = false
+	_last_fingerprint = _fingerprint()
 	_ensure_mesh_instance()
 	if not _immediate_mesh:
 		return
@@ -109,6 +162,9 @@ func refresh() -> void:
 	if not root.entity_system:
 		return
 	var connections = root.entity_system.get_all_connections()
+	# One index for the whole pass. Resolving each connection against the level
+	# separately made this loop cost connections times entities.
+	var name_index: Dictionary = root.entity_system.build_name_index()
 	if connections.is_empty():
 		_mesh_instance.visible = false
 		_clear_highlight_overlays()
@@ -130,7 +186,9 @@ func refresh() -> void:
 	# Track connected entities for highlight mode
 	var connected_names: Dictionary = {}
 
-	_immediate_mesh.surface_begin(Mesh.PRIMITIVE_LINES)
+	# Resolve first, draw second. A level whose connections all dangle has nothing
+	# to put in the surface, and closing an empty one is an engine error.
+	var routes: Array = []
 	for conn in connections:
 		if not (conn is Dictionary):
 			continue
@@ -140,7 +198,7 @@ func refresh() -> void:
 		var target_name = str(conn.get("target_name", ""))
 		if target_name == "":
 			continue
-		var targets = root.entity_system.find_entities_by_name(target_name)
+		var targets: Array = name_index.get(target_name, [])
 		if targets.is_empty():
 			continue
 		var fire_once = bool(conn.get("fire_once", false))
@@ -166,9 +224,29 @@ func refresh() -> void:
 			if is_selected and highlight_connected:
 				_add_node_names(connected_names, source)
 				_add_node_names(connected_names, target)
-			var start_pos = source.global_position + Vector3(0, 0.3, 0)
-			var end_pos = target.global_position + Vector3(0, 0.3, 0)
-			_draw_curved_connection(start_pos, end_pos, color, route_idx, total_routes)
+			(
+				routes
+				. append(
+					{
+						"start": source.global_position + Vector3(0, 0.3, 0),
+						"end": target.global_position + Vector3(0, 0.3, 0),
+						"color": color,
+						"route_idx": route_idx,
+						"total_routes": total_routes,
+					}
+				)
+			)
+
+	if routes.is_empty():
+		_mesh_instance.visible = false
+		_clear_highlight_overlays()
+		return
+
+	_immediate_mesh.surface_begin(Mesh.PRIMITIVE_LINES)
+	for route in routes:
+		_draw_curved_connection(
+			route["start"], route["end"], route["color"], route["route_idx"], route["total_routes"]
+		)
 	_immediate_mesh.surface_end()
 
 	# Update highlight overlays
@@ -278,21 +356,32 @@ func _draw_arrowhead(pos: Vector3, dir: Vector3, color: Color) -> void:
 
 
 func _update_highlight_overlays(connected_names: Dictionary, _selected_names: Dictionary) -> void:
-	_clear_highlight_overlays()
 	# Gather candidate nodes from both entities and brush entities
-	var candidates: Array = []
-	if root.entities_node:
-		candidates.append_array(root.entities_node.get_children())
-	if root.get("draft_brushes_node") and root.draft_brushes_node:
-		candidates.append_array(root.draft_brushes_node.get_children())
-	for child in candidates:
+	var highlighted: Array = []
+	for child in _io_nodes():
 		if not is_instance_valid(child) or not (child is Node3D):
 			continue
 		# Highlight connected entities but NOT the selected one itself
 		if _node_has_any_name(child, connected_names) and not _is_selected_entity(child):
-			var overlay = _create_pulse_overlay(child)
-			if overlay:
-				_highlight_overlays.append(overlay)
+			highlighted.append(child)
+	# Move the spheres already in the scene rather than freeing and remaking them.
+	# A refresh usually highlights the same entities it highlighted last time.
+	var kept: Array = []
+	for entity in highlighted:
+		var overlay: MeshInstance3D = null
+		while not _highlight_overlays.is_empty():
+			var candidate = _highlight_overlays.pop_back()
+			if is_instance_valid(candidate):
+				overlay = candidate
+				break
+		if overlay:
+			overlay.global_position = entity.global_position + Vector3(0, 0.3, 0)
+		else:
+			overlay = _create_pulse_overlay(entity)
+		if overlay:
+			kept.append(overlay)
+	_clear_highlight_overlays()
+	_highlight_overlays = kept
 
 
 func _find_io_entity_owner(candidate: Node) -> Node3D:

--- a/docs/features.md
+++ b/docs/features.md
@@ -373,7 +373,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 9, 2026 contains **3,162 tests across 162 scripts**: **3,155 passing tests**, seven intentional no-assert safety tests, and **16,391 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 9, 2026 contains **3,190 tests across 163 scripts**: **3,183 passing tests**, seven intentional no-assert safety tests, and **16,430 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_io_visualizer_dirty.gd
+++ b/tests/test_io_visualizer_dirty.gd
@@ -1,0 +1,371 @@
+extends GutTest
+
+## The wiring overlay used to rebuild every ten editor frames whether or not the
+## graph had moved. These tests hold it still over idle frames and then make each
+## kind of edit that has to bring it back.
+
+const HFEntitySystem = preload("res://addons/hammerforge/systems/hf_entity_system.gd")
+const HFIOVisualizer = preload("res://addons/hammerforge/systems/hf_io_visualizer.gd")
+
+const FRAME := 1.0 / 60.0
+
+var root: Node3D
+var sys: HFEntitySystem
+var viz: HFIOVisualizer
+
+
+func before_each():
+	root = Node3D.new()
+	root.set_script(_root_shim_script())
+	add_child_autoqfree(root)
+	var entities = Node3D.new()
+	entities.name = "Entities"
+	root.add_child(entities)
+	root.entities_node = entities
+	var draft = Node3D.new()
+	draft.name = "DraftBrushes"
+	root.add_child(draft)
+	root.draft_brushes_node = draft
+	root.entity_definitions = {}
+	root.entity_definitions_path = ""
+	sys = HFEntitySystem.new(root)
+	root.entity_system = sys
+	viz = HFIOVisualizer.new(root)
+
+
+func after_each():
+	viz.cleanup()
+	root = null
+	sys = null
+	viz = null
+
+
+func _root_shim_script() -> GDScript:
+	var s = GDScript.new()
+	s.source_code = """
+extends Node3D
+
+var entities_node: Node3D
+var draft_brushes_node: Node3D
+var entity_definitions: Dictionary = {}
+var entity_definitions_path: String = ""
+var entity_system = null
+
+func _assign_owner(node: Node) -> void:
+	pass
+"""
+	s.reload()
+	return s
+
+
+func _make_entity(entity_name: String, pos: Vector3 = Vector3.ZERO) -> Node3D:
+	var e = Node3D.new()
+	e.name = entity_name
+	e.set_meta("is_entity", true)
+	root.entities_node.add_child(e)
+	e.global_position = pos
+	return e
+
+
+func _make_brush_entity(brush_name: String) -> Node3D:
+	var b = Node3D.new()
+	b.name = brush_name
+	b.set_meta("brush_entity_class", "func_door")
+	root.draft_brushes_node.add_child(b)
+	return b
+
+
+## A wired pair, drawn once, with the counter zeroed so a test measures only the
+## rebuilds its own edit caused.
+func _wired_pair() -> Array:
+	var a = _make_entity("button_a", Vector3.ZERO)
+	var b = _make_entity("door_b", Vector3(4, 0, 0))
+	sys.add_entity_output(a, "OnUse", "door_b", "Open")
+	viz.set_enabled(true)
+	viz.refresh_count = 0
+	return [a, b]
+
+
+func _idle(frames: int) -> void:
+	for i in range(frames):
+		viz.process(FRAME)
+
+
+# ===========================================================================
+# Idle frames
+# ===========================================================================
+
+
+func test_idle_frames_do_not_rebuild_geometry():
+	_wired_pair()
+	_idle(60)
+	assert_eq(viz.refresh_count, 0, "Idle frames should not rebuild the connection mesh")
+
+
+func test_disabled_visualizer_does_no_work():
+	_wired_pair()
+	viz.set_enabled(false)
+	viz.refresh_count = 0
+	_idle(60)
+	assert_eq(viz.refresh_count, 0, "A disabled overlay should not rebuild at all")
+
+
+func test_enabling_draws_once():
+	var a = _make_entity("button_a", Vector3.ZERO)
+	_make_entity("door_b", Vector3(4, 0, 0))
+	sys.add_entity_output(a, "OnUse", "door_b", "Open")
+	viz.refresh_count = 0
+	viz.set_enabled(true)
+	assert_eq(viz.refresh_count, 1, "Enabling should draw exactly once")
+
+
+# ===========================================================================
+# Every edit that has to bring the overlay back
+# ===========================================================================
+
+
+func test_output_edit_rebuilds():
+	var pair = _wired_pair()
+	sys.add_entity_output(pair[0], "OnUse", "door_b", "Close")
+	_idle(15)
+	assert_eq(viz.refresh_count, 1, "A new output should rebuild the overlay")
+
+
+func test_output_removal_rebuilds():
+	var pair = _wired_pair()
+	sys.remove_entity_output(pair[0], 0)
+	_idle(15)
+	assert_eq(viz.refresh_count, 1, "Removing an output should rebuild the overlay")
+
+
+func test_delay_change_rebuilds():
+	var pair = _wired_pair()
+	var outputs: Array = pair[0].get_meta("entity_io_outputs", [])
+	outputs[0]["delay"] = 2.5
+	pair[0].set_meta("entity_io_outputs", outputs)
+	_idle(15)
+	assert_eq(viz.refresh_count, 1, "Delay drives the line colour, so it must rebuild")
+
+
+func test_native_rename_rebuilds():
+	var pair = _wired_pair()
+	pair[1].name = "door_renamed"
+	_idle(15)
+	assert_eq(viz.refresh_count, 1, "A rename in the Scene dock should rebuild the overlay")
+
+
+func test_alias_edit_rebuilds():
+	var pair = _wired_pair()
+	pair[1].set_meta("entity_name", "door_alias")
+	_idle(15)
+	assert_eq(viz.refresh_count, 1, "An authored-name edit should rebuild the overlay")
+
+
+func test_transform_rebuilds():
+	var pair = _wired_pair()
+	pair[1].global_position = Vector3(9, 2, 0)
+	_idle(15)
+	assert_eq(viz.refresh_count, 1, "A moved entity should redraw its lines")
+
+
+func test_entity_added_rebuilds():
+	_wired_pair()
+	_make_entity("lamp_c", Vector3(0, 3, 0))
+	_idle(15)
+	assert_eq(viz.refresh_count, 1, "A new entity should rebuild the overlay")
+
+
+func test_entity_removed_rebuilds():
+	var pair = _wired_pair()
+	root.entities_node.remove_child(pair[1])
+	pair[1].free()
+	_idle(15)
+	assert_eq(viz.refresh_count, 1, "A removed entity should rebuild the overlay")
+
+
+func test_brush_entity_move_rebuilds():
+	var a = _make_entity("button_a", Vector3.ZERO)
+	var brush = _make_brush_entity("door_brush")
+	sys.add_entity_output(a, "OnUse", "door_brush", "Open")
+	viz.set_enabled(true)
+	viz.refresh_count = 0
+	brush.global_position = Vector3(0, 6, 0)
+	_idle(15)
+	assert_eq(viz.refresh_count, 1, "Brush entities are drawn too, so they count as state")
+
+
+func test_selection_change_rebuilds():
+	var pair = _wired_pair()
+	viz.set_selected_entities([pair[0]])
+	assert_eq(viz.refresh_count, 1, "Selection recolours the lines, so it redraws")
+
+
+func test_mark_dirty_forces_one_rebuild():
+	_wired_pair()
+	viz.mark_dirty()
+	_idle(15)
+	assert_eq(viz.refresh_count, 1, "mark_dirty should be honoured")
+	_idle(30)
+	assert_eq(viz.refresh_count, 1, "and it should not stick on")
+
+
+func test_freed_mesh_instance_rebuilds():
+	_wired_pair()
+	var mesh_instance: MeshInstance3D = viz._mesh_instance
+	root.remove_child(mesh_instance)
+	mesh_instance.free()
+	_idle(15)
+	assert_eq(viz.refresh_count, 1, "A lost mesh node should be rebuilt")
+
+
+# ===========================================================================
+# Highlight overlays
+# ===========================================================================
+
+
+func test_highlight_overlays_are_reused_across_rebuilds():
+	var pair = _wired_pair()
+	viz.set_highlight_connected(true)
+	viz.set_selected_entities([pair[0]])
+	assert_eq(viz._highlight_overlays.size(), 1, "The connected door should be highlighted")
+	var first_id = viz._highlight_overlays[0].get_instance_id()
+	pair[1].global_position = Vector3(7, 0, 0)
+	_idle(15)
+	assert_eq(viz._highlight_overlays.size(), 1, "Still one highlighted entity")
+	assert_eq(
+		viz._highlight_overlays[0].get_instance_id(),
+		first_id,
+		"The pulse sphere should be moved, not thrown away and remade"
+	)
+
+
+func test_highlight_overlays_follow_the_entity():
+	var pair = _wired_pair()
+	viz.set_highlight_connected(true)
+	viz.set_selected_entities([pair[0]])
+	pair[1].global_position = Vector3(7, 0, 0)
+	_idle(15)
+	assert_almost_eq(
+		viz._highlight_overlays[0].global_position,
+		Vector3(7, 0.3, 0),
+		Vector3.ONE * 0.001,
+		"A reused sphere has to be moved onto its entity"
+	)
+
+
+func test_highlight_overlays_shrink_when_connections_go():
+	var pair = _wired_pair()
+	var c = _make_entity("door_c", Vector3(0, 0, 4))
+	sys.add_entity_output(pair[0], "OnUse", "door_c", "Open")
+	viz.set_highlight_connected(true)
+	viz.set_selected_entities([pair[0]])
+	assert_eq(viz._highlight_overlays.size(), 2, "Both doors are connected")
+	root.entities_node.remove_child(c)
+	c.free()
+	_idle(15)
+	assert_eq(viz._highlight_overlays.size(), 1, "The spare sphere should be released")
+
+
+func test_idle_frames_do_not_churn_overlay_nodes():
+	var pair = _wired_pair()
+	viz.set_highlight_connected(true)
+	viz.set_selected_entities([pair[0]])
+	var first_id = viz._highlight_overlays[0].get_instance_id()
+	var child_count = root.get_child_count()
+	_idle(60)
+	assert_eq(root.get_child_count(), child_count, "Idle frames should not add scene nodes")
+	assert_eq(
+		viz._highlight_overlays[0].get_instance_id(), first_id, "Nor replace the pulse spheres"
+	)
+
+
+func test_pulse_uses_the_real_delta():
+	var pair = _wired_pair()
+	viz.set_highlight_connected(true)
+	viz.set_selected_entities([pair[0]])
+	viz._pulse_phase = 0.0
+	viz.process(0.5)
+	assert_almost_eq(
+		viz._pulse_phase,
+		0.5 * HFIOVisualizer.PULSE_SPEED,
+		0.0001,
+		"The pulse should advance by the frame time it was given"
+	)
+
+
+# ===========================================================================
+# Name index
+# ===========================================================================
+
+
+func test_name_index_matches_lookup_for_node_names():
+	var e = _make_entity("button_a")
+	var index = sys.build_name_index()
+	assert_eq(index.get("button_a", []), [e], "Node name should resolve to the node")
+	assert_eq(index.get("button_a", []), sys.find_entities_by_name("button_a"))
+
+
+func test_name_index_matches_lookup_for_aliases():
+	var e = _make_entity("Node3D42")
+	e.set_meta("entity_name", "big_red_button")
+	var index = sys.build_name_index()
+	assert_eq(index.get("big_red_button", []), [e], "The authored name is an address too")
+	assert_eq(index.get("big_red_button", []), sys.find_entities_by_name("big_red_button"))
+
+
+func test_name_index_lists_an_entity_once_when_both_names_agree():
+	var e = _make_entity("button_a")
+	e.set_meta("entity_name", "button_a")
+	var index = sys.build_name_index()
+	assert_eq(index.get("button_a", []).size(), 1, "One node, one entry")
+	assert_eq(index.get("button_a", []), sys.find_entities_by_name("button_a"))
+
+
+func test_name_index_holds_both_entities_sharing_a_name():
+	var first = _make_entity("Node3D1")
+	first.set_meta("entity_name", "shared")
+	var second = _make_entity("Node3D2")
+	second.set_meta("entity_name", "shared")
+	var index = sys.build_name_index()
+	assert_eq(index.get("shared", []), [first, second], "Duplicated names both resolve")
+	assert_eq(index.get("shared", []), sys.find_entities_by_name("shared"))
+
+
+func test_name_index_covers_brush_entities_by_node_name_only():
+	var brush = _make_brush_entity("door_brush")
+	brush.set_meta("entity_name", "brush_alias")
+	var index = sys.build_name_index()
+	assert_eq(index.get("door_brush", []), [brush], "Brush entities answer to their node name")
+	assert_false(
+		index.has("brush_alias"), "and not to an alias, the way find_entities_by_name has it"
+	)
+	assert_eq(sys.find_entities_by_name("brush_alias"), [], "Lookup agrees")
+
+
+func test_name_index_skips_plain_brushes():
+	var plain = Node3D.new()
+	plain.name = "brush_1"
+	root.draft_brushes_node.add_child(plain)
+	var index = sys.build_name_index()
+	assert_false(index.has("brush_1"), "A brush with no entity class is not an I/O target")
+
+
+# ===========================================================================
+# Nothing left to draw
+# ===========================================================================
+
+
+func test_dangling_only_graph_hides_the_mesh():
+	var pair = _wired_pair()
+	pair[1].name = "door_renamed"
+	_idle(15)
+	assert_false(viz._mesh_instance.visible, "Nothing resolves, so nothing should be drawn")
+
+
+func test_graph_comes_back_when_the_target_returns():
+	var pair = _wired_pair()
+	pair[1].name = "door_renamed"
+	_idle(15)
+	pair[1].name = "door_b"
+	_idle(15)
+	assert_true(viz._mesh_instance.visible, "Renaming back should redraw the line")

--- a/tests/test_io_visualizer_dirty.gd.uid
+++ b/tests/test_io_visualizer_dirty.gd.uid
@@ -1,0 +1,1 @@
+uid://mc5j8lqx1rrr


### PR DESCRIPTION
Fixes #259

The I/O connection overlay rebuilt every ten editor frames while it was enabled, whether or not anything had moved. Each rebuild recollected the connection list, resolved every target by scanning the whole level, threw the curve mesh away and rebuilt it, and freed and remade the Highlight Connected pulse spheres. At 200 entities and 400 outputs that is about 80,000 name comparisons per rebuild, six times a second, to draw the picture that was already on screen.

What changed:

- `HFEntitySystem.build_name_index()` maps every address in the level to the nodes that answer to it in one pass. The drawing loop reads that instead of calling `find_entities_by_name()` per connection. Addresses and their order match the lookup exactly, and they are built beside it so the two cannot drift.
- `HFIOVisualizer.process()` now checks whether anything the drawing depends on has changed before rebuilding. A rename in the Scene dock, an undo and a viewport drag all change the picture without going through HammerForge, so a signal would have needed emitting from each of them. The check reads each node once; the rebuild it guards reads every connection against every entity.
- Pulse spheres are moved rather than freed and remade, and the pulse advances on the real frame time instead of an assumed 60 fps.
- A graph where every connection dangles no longer opens a mesh surface with nothing in it, which Godot reports as an error. Found by the new tests.

`tests/test_io_visualizer_dirty.gd` covers idle frames, an output added, removed and re-delayed, a native rename, an alias edit, a moved entity, a moved brush entity, an entity added and removed, selection, a forced rebuild, a lost mesh node, sphere reuse and release, the real delta, the dangling-only graph and its recovery, and the index against the lookup it replaces.

Full suite: 3,190 tests, 3,183 passing, no failures.