### PR TITLE
Measure the level only while the Performance section is on screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,27 @@ The format is based on Keep a Changelog, and this project follows semantic versi
     presses without reselecting, undo, and what survives a state restore.
 
 ### Changed
+- **The Performance section stops measuring the level when nobody is looking at
+  it.** It refreshed every thirty editor frames whether it was open or shut, and
+  it is created shut. Those readouts are not label assignments: the vertex
+  estimate walks every brush and every face, the paint figure walks every layer,
+  and with chunking on the chunk count recollects the whole bake candidate set,
+  builds the chunk dictionary and sorts it while the recommendation measures the
+  level bounds all over again. The levels that make that expensive are the ones
+  that make the panel worth opening, so an idle editor on a big chunked scene was
+  paying the most for numbers on screen nowhere.
+  - **Collapsed, on another tab, or in a hidden dock all count as not looking.**
+    Leaving the section open on the Manage tab and working on the Build tab is
+    the common case, and it used to cost the same as watching it.
+  - **Opening the section fills it in at once** rather than showing whatever the
+    last look left behind until the next tick.
+  - The **Live Brushes** count in the footer is on screen at all times and still
+    refreshes on the same tick. It reads a cached count, so it was never part of
+    the cost.
+  - **Coverage** (`tests/test_perf_panel_visibility.gd`): 8 tests over the section
+    starting shut, a shut section left alone across ninety frames, the footer
+    still counting, opening, an open section refreshing, closing again, an open
+    section on a tab nobody is on, and coming back to that tab.
 - **The array edit warning counts more than movement.** It counted a copy that had
   been dragged and said nothing about one that had been resized, reshaped,
   retextured, or had a paint layer added — though the same press rebuilds over

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -400,7 +400,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,162 tests across 162 test scripts (3,155 passing plus seven intentional no-assert safety tests; 16,391 assertions; verified in CI on September 9, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,170 tests across 163 test scripts (3,163 passing plus seven intentional no-assert safety tests; 16,406 assertions; verified in CI on September 9, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -540,6 +540,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 9, 2026): **3,162 tests** across **162 scripts** (**3,155 passing** plus seven intentional no-assert safety tests; **16,391 assertions**).
+Full suite (verified in CI on September 9, 2026): **3,170 tests** across **163 scripts** (**3,163 passing** plus seven intentional no-assert safety tests; **16,406 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3155%20passing-brightgreen" alt="3155 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3163%20passing-brightgreen" alt="3163 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,162 tests across 162 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,170 tests across 163 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/dock.gd
+++ b/addons/hammerforge/dock.gd
@@ -1073,6 +1073,27 @@ func _on_section_toggled(expanded: bool, section_name: String) -> void:
 		_user_prefs.save()
 	if section_name == "Structure":
 		HFDockBrushHandler.refresh_structure_preview(self)
+	if section_name == "Performance" and expanded:
+		# Opened, so the numbers in it are however old the last look left them.
+		_update_perf_panel()
+
+
+## Is anybody actually looking at the Performance section?
+##
+## Its readouts are not label assignments. The vertex estimate walks every brush
+## and every face, the paint figure walks every layer, and with chunking on the
+## chunk count recollects the whole bake candidate set and the recommendation
+## measures the level bounds again. The levels that make that expensive are the
+## same ones that make the panel worth opening, so it used to cost the most on
+## exactly the scenes that could least afford it, collapsed or not.
+##
+## Collapsed counts as not looking, and so does sitting on another tab or in a
+## hidden dock.
+func _is_perf_panel_visible() -> bool:
+	var section = _all_sections.get("Performance")
+	if not section or not is_instance_valid(section):
+		return false
+	return section.is_expanded() and section.is_visible_in_tree()
 
 
 func set_keymap(km: HFKeymap) -> void:
@@ -2101,8 +2122,9 @@ func _process(_delta):
 	_perf_frame_counter += 1
 	if _perf_frame_counter >= 30:
 		_perf_frame_counter = 0
-		_update_perf_panel()
 		_update_perf_label()
+		if _is_perf_panel_visible():
+			_update_perf_panel()
 
 
 func _sync_paint_layers_from_root() -> void:

--- a/docs/features.md
+++ b/docs/features.md
@@ -373,7 +373,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 9, 2026 contains **3,162 tests across 162 scripts**: **3,155 passing tests**, seven intentional no-assert safety tests, and **16,391 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 9, 2026 contains **3,170 tests across 163 scripts**: **3,163 passing tests**, seven intentional no-assert safety tests, and **16,406 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_hollow_edit_warning.gd.uid
+++ b/tests/test_hollow_edit_warning.gd.uid
@@ -1,1 +1,0 @@
-uid://bkhptjpnc0sqq

--- a/tests/test_perf_panel_visibility.gd
+++ b/tests/test_perf_panel_visibility.gd
@@ -1,0 +1,137 @@
+extends GutTest
+
+## The Performance section used to recompute its readouts every thirty editor
+## frames whether or not anybody could see them, and it is created collapsed. The
+## work behind those readouts walks every brush, every face and every paint layer,
+## so these tests hold the section shut and check that nothing is written.
+
+const DockScene = preload("res://addons/hammerforge/dock.tscn")
+
+const SENTINEL := "untouched"
+
+var dock: HammerForgeDock
+
+
+func before_each() -> void:
+	dock = DockScene.instantiate()
+	add_child_autoqfree(dock)
+	dock.level_root = null
+
+
+func after_each() -> void:
+	dock = null
+
+
+func _perf_section():
+	return dock._all_sections.get("Performance")
+
+
+## Mark every readout so a refresh is visible as the mark being overwritten.
+func _mark_readouts() -> void:
+	dock.perf_vertex_value.text = SENTINEL
+	dock.perf_brushes_value.text = SENTINEL
+	dock.perf_paint_mem_value.text = SENTINEL
+	dock.perf_bake_chunks_value.text = SENTINEL
+	dock.perf_chunk_rec_value.text = SENTINEL
+
+
+func _idle(frames: int) -> void:
+	for i in range(frames):
+		dock._process(1.0 / 60.0)
+
+
+func _show_manage_tab() -> void:
+	for index in dock.main_tabs.get_tab_count():
+		if dock.main_tabs.get_tab_control(index) == dock.manage_tab:
+			dock.main_tabs.current_tab = index
+			return
+	fail_test("The Manage tab should be one of the main tabs")
+
+
+# ===========================================================================
+# The section starts shut
+# ===========================================================================
+
+
+func test_performance_section_is_registered_and_starts_collapsed() -> void:
+	var section = _perf_section()
+	assert_not_null(section, "The dock should keep a reference to the Performance section")
+	assert_false(section.is_expanded(), "It is created collapsed")
+
+
+func test_collapsed_section_is_not_refreshed_on_the_frame_path() -> void:
+	_mark_readouts()
+	_idle(90)
+	assert_eq(dock.perf_vertex_value.text, SENTINEL, "A collapsed panel should not be recomputed")
+	assert_eq(dock.perf_brushes_value.text, SENTINEL)
+	assert_eq(dock.perf_paint_mem_value.text, SENTINEL)
+	assert_eq(dock.perf_bake_chunks_value.text, SENTINEL)
+	assert_eq(dock.perf_chunk_rec_value.text, SENTINEL)
+
+
+func test_footer_brush_count_keeps_updating_while_the_section_is_shut() -> void:
+	dock.perf_label.text = SENTINEL
+	_idle(31)
+	assert_eq(
+		dock.perf_label.text,
+		"Live Brushes: 0",
+		"The footer label is always on screen, so it still refreshes"
+	)
+
+
+# ===========================================================================
+# Opening it
+# ===========================================================================
+
+
+func test_expanding_the_section_refreshes_it_at_once() -> void:
+	_show_manage_tab()
+	_mark_readouts()
+	_perf_section().set_expanded(true)
+	assert_eq(dock.perf_vertex_value.text, "0", "Opening the panel should fill it in")
+
+
+func test_open_section_refreshes_on_the_frame_path() -> void:
+	_show_manage_tab()
+	_perf_section().set_expanded(true)
+	_mark_readouts()
+	_idle(31)
+	assert_eq(dock.perf_vertex_value.text, "0", "An open panel still refreshes")
+
+
+func test_closing_the_section_stops_the_refresh_again() -> void:
+	_show_manage_tab()
+	_perf_section().set_expanded(true)
+	_perf_section().set_expanded(false)
+	_mark_readouts()
+	_idle(90)
+	assert_eq(dock.perf_vertex_value.text, SENTINEL, "Shut again means quiet again")
+
+
+# ===========================================================================
+# Visible means visible
+# ===========================================================================
+
+
+func test_expanded_section_on_another_tab_does_not_count_as_visible() -> void:
+	_show_manage_tab()
+	_perf_section().set_expanded(true)
+	dock.main_tabs.current_tab = 0
+	assert_false(
+		dock._is_perf_panel_visible(),
+		"An open section on a tab nobody is on is still not on screen"
+	)
+	_mark_readouts()
+	_idle(90)
+	assert_eq(dock.perf_vertex_value.text, SENTINEL, "So it should not be recomputed")
+
+
+func test_returning_to_the_tab_makes_it_visible_again() -> void:
+	_show_manage_tab()
+	_perf_section().set_expanded(true)
+	dock.main_tabs.current_tab = 0
+	_show_manage_tab()
+	assert_true(dock._is_perf_panel_visible(), "Back on the tab, with the section open")
+	_mark_readouts()
+	_idle(31)
+	assert_eq(dock.perf_vertex_value.text, "0", "And the numbers come back")

--- a/tests/test_perf_panel_visibility.gd.uid
+++ b/tests/test_perf_panel_visibility.gd.uid
@@ -1,0 +1,1 @@
+uid://1b30ebrmfhn1


### PR DESCRIPTION
Fixes #261

`HFDock._process()` refreshed the Performance section every thirty editor frames whether it was open or shut, and `manage_tab_builder.gd` creates it shut. The readouts behind it are not label assignments: `get_total_vertex_estimate()` walks every brush and every face, `get_paint_memory_bytes()` walks every paint layer, and with chunking on `get_bake_chunk_count()` recollects the whole bake candidate set, builds the chunk dictionary, computes bounds and sorts them while `get_recommended_chunk_size()` measures the level bounds all over again. An idle editor on a big chunked level paid for all of that six times a second to fill in numbers nobody could see.

What changed:

- The dock reads the Performance section out of `_all_sections` and only refreshes it when it is expanded and visible in the tree. Collapsed, sitting on another tab, and a hidden dock all count as nobody looking. Leaving the section open on the Manage tab and then working on the Build tab is the common case and it used to cost the same as watching it.
- Opening the section refreshes it straight away rather than showing whatever the last look left behind until the next tick.
- The Live Brushes count in the footer is on screen at all times, so it still refreshes on the same tick. It reads a cached count and was never part of the cost.

`tests/test_perf_panel_visibility.gd` covers the section starting shut, a shut section left alone across ninety frames, the footer still counting, opening, an open section refreshing, closing again, an open section on a tab nobody is on, and coming back to that tab.

Full suite: 3,170 tests, 3,163 passing, no failures.