### PR TITLE
Date the suite figures to the day they were verified

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development Guide
 
-Last updated: September 9, 2026
+Last updated: September 10, 2026
 
 This document covers local setup, codebase structure, and how to test features.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -400,7 +400,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,240 tests across 167 test scripts (3,233 passing plus seven intentional no-assert safety tests; 16,500 assertions; verified in CI on September 9, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,240 tests across 167 test scripts (3,233 passing plus seven intentional no-assert safety tests; 16,500 assertions; verified in CI on September 10, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -540,6 +540,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 9, 2026): **3,240 tests** across **167 scripts** (**3,233 passing** plus seven intentional no-assert safety tests; **16,500 assertions**).
+Full suite (verified in CI on September 10, 2026): **3,240 tests** across **167 scripts** (**3,233 passing** plus seven intentional no-assert safety tests; **16,500 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -1,6 +1,6 @@
 # HammerForge Spec
 
-Last updated: September 9, 2026
+Last updated: September 10, 2026
 
 This document describes HammerForge's architecture and data flow.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last updated: September 9, 2026
+Last updated: September 10, 2026
 
 This roadmap is a directional plan. Items may change based on user feedback.
 

--- a/docs/HammerForge_FloorPaint_Greyboxing.md
+++ b/docs/HammerForge_FloorPaint_Greyboxing.md
@@ -4,7 +4,7 @@ description: "Grid-based floor painting and greyboxing in HammerForge: heightmap
 
 # HammerForge Floor Paint Greyboxing
 
-Last updated: March 27, 2026
+Last updated: September 10, 2026
 
 This document describes the floor paint system: grid storage, tools, geometry synthesis, heightmap integration, reconciliation, and persistence. Surface paint (per-face splat layers) is documented separately and does not use the grid system.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -468,5 +468,5 @@ Run `godot --headless --import --path .` first, then re-run the test command.
 
 <p align="center">
   <strong>MIT License</strong><br>
-  <sub>Built for Godot 4.7+ | Last updated September 9, 2026</sub>
+  <sub>Built for Godot 4.7+ | Last updated September 10, 2026</sub>
 </p>

--- a/docs/features.md
+++ b/docs/features.md
@@ -373,7 +373,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 9, 2026 contains **3,240 tests across 167 scripts**: **3,233 passing tests**, seven intentional no-assert safety tests, and **16,500 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 10, 2026 contains **3,240 tests across 167 scripts**: **3,233 passing tests**, seven intentional no-assert safety tests, and **16,500 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_hollow_edit_warning.gd.uid
+++ b/tests/test_hollow_edit_warning.gd.uid
@@ -1,0 +1,1 @@
+uid://bkhptjpnc0sqq


### PR DESCRIPTION
Three bits of housekeeping.

- The suite figures in DEVELOPMENT.md, HammerForge_SPEC.md and docs/features.md were dated September 9. The counts they carry (3,240 tests, 3,233 passing, 167 scripts, 16,500 assertions) were verified against the merged tree on September 10, so the date now says so. The counts themselves are unchanged and correct.
- The `Last updated` stamps are bumped on the five docs that actually changed on September 10: DEVELOPMENT.md, ROADMAP.md, HammerForge_SPEC.md, docs/features.md and docs/HammerForge_FloorPaint_Greyboxing.md. The floor paint guide's stamp still read March 27 even though unwiring paint inference edited it. Docs that did not change today are left alone, since these stamps are per file.
- `tests/test_hollow_edit_warning.gd.uid` was the only test file in the tree without its uid committed, so every import left it as an untracked file in `git status`. Committed.