### PR TITLE
Wait for CI on the pull request's commit, not its branch

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -400,7 +400,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,240 tests across 167 test scripts (3,233 passing plus seven intentional no-assert safety tests; 16,500 assertions; verified in CI on September 10, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,250 tests across 168 test scripts (3,243 passing plus seven intentional no-assert safety tests; 16,530 assertions; verified in CI on September 9, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -540,6 +540,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 10, 2026): **3,240 tests** across **167 scripts** (**3,233 passing** plus seven intentional no-assert safety tests; **16,500 assertions**).
+Full suite (verified in CI on September 9, 2026): **3,250 tests** across **168 scripts** (**3,243 passing** plus seven intentional no-assert safety tests; **16,530 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3233%20passing-brightgreen" alt="3233 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3243%20passing-brightgreen" alt="3243 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,240 tests across 167 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,250 tests across 168 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -2062,6 +2062,10 @@ func handle_paint_input(
 	)
 
 
+func prepare_paint_stroke(camera: Camera3D, screen_pos: Vector2) -> void:
+	paint_system.prepare_paint_stroke(camera, screen_pos)
+
+
 func get_paint_layer_names() -> Array:
 	return paint_system.get_paint_layer_names()
 

--- a/addons/hammerforge/paint/hf_paint_tool.gd
+++ b/addons/hammerforge/paint/hf_paint_tool.gd
@@ -3,6 +3,7 @@ class_name HFPaintTool
 extends Node
 
 signal stroke_committed(changed_cell_count: int)
+signal material_picked(material_id: int)
 
 const HFStroke = preload("hf_stroke.gd")
 const HFHeightmapSynth = preload("hf_heightmap_synth.gd")
@@ -37,6 +38,13 @@ var _preview_cells: Dictionary = {}  # Dictionary[Vector2i, bool]
 var _preview_original: Dictionary = {}  # Dictionary[Vector2i, bool]
 var _stroke_dirty: Dictionary = {}  # Dictionary[Vector2i, bool]
 var _preview_dirty: Dictionary = {}  # Dictionary[Vector2i, bool]
+var _stroke_erasing := false
+## 0 = undecided/free, 1 = X, 2 = Z (the paint grid's Vector2i.y axis).
+var _stroke_axis := 0
+var _stroke_axis_requested := false
+var _stroke_cells: Dictionary = {}  # Dictionary[Vector2i, bool]
+var _hover_cell: Variant = null
+var _last_committed_cell_count := 0
 
 
 func is_stroke_active() -> bool:
@@ -48,6 +56,22 @@ func finish_stroke_if_active() -> void:
 		_end_stroke()
 
 
+func cancel_stroke() -> bool:
+	if not _painting:
+		return false
+	_clear_preview_restore()
+	_painting = false
+	_active_stroke = null
+	_stroke_dirty.clear()
+	_preview_dirty.clear()
+	_stroke_cells.clear()
+	_stroke_axis = 0
+	_stroke_axis_requested = false
+	_stroke_erasing = false
+	_last_committed_cell_count = 0
+	return true
+
+
 func handle_input(camera: Camera3D, event: InputEvent, screen_pos: Vector2) -> bool:
 	if not camera or not layer_manager:
 		if not layer_manager:
@@ -55,13 +79,20 @@ func handle_input(camera: Camera3D, event: InputEvent, screen_pos: Vector2) -> b
 		return false
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
 		if event.pressed:
-			return _begin_stroke(camera, screen_pos)
+			if event.is_command_or_control_pressed():
+				var pick_cell = _screen_to_cell(camera, screen_pos)
+				if pick_cell == null:
+					return false
+				material_picked.emit(pick_cell_material(pick_cell))
+				return true
+			return _begin_stroke(camera, screen_pos, event.alt_pressed, event.shift_pressed)
 		if _painting:
 			_end_stroke()
 			return true
 	if event is InputEventMouseMotion:
+		_hover_cell = _screen_to_cell(camera, screen_pos)
 		if _painting and event.button_mask & MOUSE_BUTTON_MASK_LEFT != 0:
-			_continue_stroke(camera, screen_pos)
+			_continue_stroke(camera, screen_pos, event.shift_pressed)
 			return true
 	return false
 
@@ -70,7 +101,9 @@ func _is_sculpt_tool() -> bool:
 	return tool >= HFStroke.Tool.SCULPT_RAISE and tool <= HFStroke.Tool.SCULPT_FLATTEN
 
 
-func _begin_stroke(camera: Camera3D, screen_pos: Vector2) -> bool:
+func _begin_stroke(
+	camera: Camera3D, screen_pos: Vector2, temporary_erase: bool = false, axis_lock: bool = false
+) -> bool:
 	if _is_sculpt_tool():
 		return _begin_sculpt_stroke(camera, screen_pos)
 	var cell = _screen_to_cell(camera, screen_pos)
@@ -80,6 +113,11 @@ func _begin_stroke(camera: Camera3D, screen_pos: Vector2) -> bool:
 	_active_stroke.tool = tool
 	_active_stroke.radius_cells = brush_radius_cells
 	_painting = true
+	_stroke_erasing = tool == HFStroke.Tool.ERASE or temporary_erase
+	_stroke_axis = 0
+	_stroke_axis_requested = axis_lock
+	_stroke_cells.clear()
+	_last_committed_cell_count = 0
 	_stroke_dirty.clear()
 	_preview_dirty.clear()
 	_start_cell = cell
@@ -99,7 +137,7 @@ func _begin_stroke(camera: Camera3D, screen_pos: Vector2) -> bool:
 	return true
 
 
-func _continue_stroke(camera: Camera3D, screen_pos: Vector2) -> void:
+func _continue_stroke(camera: Camera3D, screen_pos: Vector2, axis_lock: bool = false) -> void:
 	if _is_sculpt_tool():
 		var layer = layer_manager.get_active_layer() if layer_manager else null
 		if layer:
@@ -108,6 +146,9 @@ func _continue_stroke(camera: Camera3D, screen_pos: Vector2) -> void:
 	var cell = _screen_to_cell(camera, screen_pos)
 	if cell == null:
 		return
+	_stroke_axis_requested = _stroke_axis_requested or axis_lock
+	if tool in [HFStroke.Tool.PAINT, HFStroke.Tool.ERASE, HFStroke.Tool.LINE, HFStroke.Tool.BLEND]:
+		cell = _apply_axis_lock(cell, _stroke_axis_requested)
 	if cell == _last_cell:
 		return
 	if tool == HFStroke.Tool.PAINT or tool == HFStroke.Tool.ERASE or tool == HFStroke.Tool.BLEND:
@@ -125,7 +166,12 @@ func _end_stroke() -> void:
 	_painting = false
 	if _is_sculpt_tool():
 		var sculpt_changed := _stroke_dirty.size()
+		_last_committed_cell_count = sculpt_changed
 		_stroke_dirty.clear()
+		_stroke_cells.clear()
+		_stroke_axis = 0
+		_stroke_axis_requested = false
+		_stroke_erasing = false
 		if sculpt_changed > 0:
 			stroke_committed.emit(sculpt_changed)
 		return
@@ -151,6 +197,10 @@ func _end_stroke() -> void:
 	_preview_dirty.clear()
 	if dirty.is_empty():
 		_active_stroke = null
+		_stroke_cells.clear()
+		_stroke_axis = 0
+		_stroke_axis_requested = false
+		_stroke_erasing = false
 		return
 	# Nothing assigns `inference`. The cleanup pass behind it was never written,
 	# so running it classified every stroke and then changed no cells. Assigning
@@ -170,6 +220,11 @@ func _end_stroke() -> void:
 			var model = geometry.build_for_chunks(layer, dirty, synth_settings)
 			reconciler.reconcile(model, layer.grid, synth_settings, dirty)
 	_active_stroke = null
+	_last_committed_cell_count = changed_cell_count
+	_stroke_cells.clear()
+	_stroke_axis = 0
+	_stroke_axis_requested = false
+	_stroke_erasing = false
 	stroke_committed.emit(changed_cell_count)
 
 
@@ -196,8 +251,8 @@ func _stamp_cell(cell: Vector2i) -> void:
 	var layer = layer_manager.get_active_layer() if layer_manager else null
 	if not layer:
 		return
-	var is_blend := tool == HFStroke.Tool.BLEND
-	var filled = tool != HFStroke.Tool.ERASE
+	var is_blend := tool == HFStroke.Tool.BLEND and not _stroke_erasing
+	var filled = not _stroke_erasing
 	var r = max(0, brush_radius_cells - 1)
 	for dy in range(-r, r + 1):
 		for dx in range(-r, r + 1):
@@ -212,8 +267,77 @@ func _stamp_cell(cell: Vector2i) -> void:
 				layer.set_cell_blend_slot(target, blend_slot, blend_strength)
 			else:
 				layer.set_cell(target, filled)
+			_record_stroke_cell(target)
 			if _active_stroke:
 				_active_stroke.add_cell(target, _now_seconds())
+
+
+func _record_stroke_cell(cell: Vector2i) -> void:
+	_stroke_cells[cell] = true
+
+
+func _apply_axis_lock(cell: Vector2i, requested: bool) -> Vector2i:
+	if not requested:
+		return cell
+	if _stroke_axis == 0:
+		var delta := cell - _start_cell
+		if delta == Vector2i.ZERO:
+			return cell
+		_stroke_axis = 1 if abs(delta.x) >= abs(delta.y) else 2
+	if _stroke_axis == 1:
+		return Vector2i(cell.x, _start_cell.y)
+	return Vector2i(_start_cell.x, cell.y)
+
+
+func pick_cell_material(cell: Vector2i) -> int:
+	var layer = layer_manager.get_active_layer() if layer_manager else null
+	if not layer:
+		return 0
+	blend_material_id = layer.get_cell_material(cell)
+	return blend_material_id
+
+
+func get_last_committed_cell_count() -> int:
+	return _last_committed_cell_count
+
+
+func get_stroke_hud_text() -> String:
+	if not _painting:
+		return ""
+	var cells: Array = _stroke_cells.keys()
+	if cells.is_empty():
+		cells = [_start_cell]
+	var min_cell: Vector2i = cells[0]
+	var max_cell: Vector2i = cells[0]
+	for cell: Vector2i in cells:
+		min_cell.x = mini(min_cell.x, cell.x)
+		min_cell.y = mini(min_cell.y, cell.y)
+		max_cell.x = maxi(max_cell.x, cell.x)
+		max_cell.y = maxi(max_cell.y, cell.y)
+	var cell_size := 1.0
+	var layer = layer_manager.get_active_layer() if layer_manager else null
+	if layer and layer.grid:
+		cell_size = layer.grid.cell_size
+	var width := float(max_cell.x - min_cell.x + 1) * cell_size
+	var depth := float(max_cell.y - min_cell.y + 1) * cell_size
+	return "%d cells — %s m × %s m" % [
+		cells.size(), _format_metres(width), _format_metres(depth)
+	]
+
+
+func get_hover_hud_text() -> String:
+	if _painting or _hover_cell == null:
+		return ""
+	var footprint := max(1, brush_radius_cells * 2 - 1)
+	return "Cell %d, %d — %d×%d footprint" % [
+		_hover_cell.x, _hover_cell.y, footprint, footprint
+	]
+
+
+func _format_metres(value: float) -> String:
+	if is_equal_approx(value, round(value)):
+		return str(int(round(value)))
+	return ("%.2f" % value).trim_suffix("0").trim_suffix("0").trim_suffix(".")
 
 
 func _stamp_line(a: Vector2i, b: Vector2i) -> void:
@@ -248,7 +372,7 @@ func _apply_preview_cells(cells: Array) -> void:
 	var layer = layer_manager.get_active_layer() if layer_manager else null
 	if not layer:
 		return
-	var filled = tool != HFStroke.Tool.ERASE
+	var filled = not _stroke_erasing
 	var next_set: Dictionary = {}
 	for cell in cells:
 		next_set[cell] = true
@@ -311,7 +435,9 @@ func _bucket_fill(start: Vector2i) -> void:
 	if not layer:
 		return
 	var target_filled = layer.get_cell(start)
-	var fill_value = not target_filled
+	var fill_value = false if _stroke_erasing else not target_filled
+	if target_filled == fill_value:
+		return
 	var stack: Array = [start]
 	var visited: Dictionary = {}
 	var guard = 0
@@ -323,6 +449,7 @@ func _bucket_fill(start: Vector2i) -> void:
 		if layer.get_cell(cell) != target_filled:
 			continue
 		layer.set_cell(cell, fill_value)
+		_record_stroke_cell(cell)
 		if _active_stroke:
 			_active_stroke.add_cell(cell, _now_seconds())
 		stack.append(cell + Vector2i(1, 0))

--- a/addons/hammerforge/plugin.gd
+++ b/addons/hammerforge/plugin.gd
@@ -86,6 +86,7 @@ var _disp_paint_active := false
 var _disp_paint_brush_id := ""
 var _disp_paint_face_idx := -1
 var _disp_paint_pre_state: Dictionary = {}
+var _floor_paint_pre_state: Dictionary = {}
 var _context_toolbar: Control = null
 var _hotkey_palette: Control = null
 var _selection_filter: Window = null
@@ -664,6 +665,10 @@ func _handle_disp_paint_input(event: InputEvent, root: Node, cam: Camera3D, pos:
 
 func _commit_disp_paint_undo(root: Node) -> void:
 	HFPluginPaintInput.commit_displacement_undo(self, root)
+
+
+func _commit_floor_paint_undo(root: Node) -> void:
+	HFPluginPaintInput.commit_floor_paint_undo(self, root)
 
 
 func _do_disp_paint_stroke(root: Node, cam: Camera3D, pos: Vector2) -> void:

--- a/addons/hammerforge/plugin_gesture_recovery.gd
+++ b/addons/hammerforge/plugin_gesture_recovery.gd
@@ -50,6 +50,7 @@ static func finish_stale_paint_strokes(
 		and paint_tool.has_method("finish_stroke_if_active")
 	):
 		paint_tool.finish_stroke_if_active()
+		plugin._commit_floor_paint_undo(root)
 		finished = true
 	if input_state != null and input_state.is_surface_painting():
 		input_state.end_surface_paint()

--- a/addons/hammerforge/plugin_paint_input.gd
+++ b/addons/hammerforge/plugin_paint_input.gd
@@ -148,6 +148,25 @@ static func handle_paint(
 	var operation = plugin.dock.get_operation()
 	var size = plugin.dock.get_brush_size()
 	if paint_target == 0:
+		var floor_press: bool = (
+			event is InputEventMouseButton
+			and event.button_index == MOUSE_BUTTON_LEFT
+			and event.pressed
+		)
+		var floor_release: bool = (
+			event is InputEventMouseButton
+			and event.button_index == MOUSE_BUTTON_LEFT
+			and not event.pressed
+		)
+		var eyedropper: bool = (
+			floor_press and (event as InputEventMouseButton).is_command_or_control_pressed()
+		)
+		if floor_press and not eyedropper:
+			# Region sidecars must be loaded before the pre-stroke snapshot, or Undo
+			# would mistake their existing cells for paint created by this stroke.
+			if root.has_method("prepare_paint_stroke"):
+				root.prepare_paint_stroke(camera, position)
+			begin_floor_paint_undo(plugin, root)
 		var handled = root.handle_paint_input(
 			camera,
 			event,
@@ -158,7 +177,21 @@ static func handle_paint(
 			plugin.dock.get_paint_radius_cells(),
 			plugin.dock.get_brush_shape()
 		)
+		plugin._update_hud_context()
 		if handled:
+			if eyedropper and root.get("paint_tool"):
+				plugin.dock.show_toast(
+					"Picked floor material %d" % root.paint_tool.blend_material_id, 0
+				)
+			elif floor_release:
+				commit_floor_paint_undo(plugin, root)
+			return EditorPlugin.AFTER_GUI_INPUT_STOP
+		if floor_press:
+			plugin._floor_paint_pre_state = {}
+			if root.has_signal("user_message"):
+				root.user_message.emit("Floor Paint could not reach the active layer plane", 1)
+			# Paint mode owns LMB even when the ray misses. Passing it onward can
+			# accidentally start the build tool underneath the paint workflow.
 			return EditorPlugin.AFTER_GUI_INPUT_STOP
 	elif paint_target == 1:
 		var handled_surface = root.handle_surface_paint_input(
@@ -172,6 +205,63 @@ static func handle_paint(
 		if handled_surface:
 			return EditorPlugin.AFTER_GUI_INPUT_STOP
 	return EditorPlugin.AFTER_GUI_INPUT_PASS
+
+
+static func begin_floor_paint_undo(plugin: Object, root: Node) -> void:
+	if plugin == null or not root or not plugin._floor_paint_pre_state.is_empty():
+		return
+	if root.has_method("capture_state"):
+		plugin._floor_paint_pre_state = root.capture_state()
+
+
+static func commit_floor_paint_undo(plugin: Object, root: Node) -> void:
+	if plugin == null or not root or plugin._floor_paint_pre_state.is_empty():
+		return
+	var before: Dictionary = plugin._floor_paint_pre_state
+	plugin._floor_paint_pre_state = {}
+	_release_region_pins(root)
+	var paint_tool = root.get("paint_tool")
+	if (
+		paint_tool == null
+		or not paint_tool.has_method("get_last_committed_cell_count")
+		or paint_tool.get_last_committed_cell_count() <= 0
+	):
+		return
+	if not root.has_method("capture_state") or not root.has_method("restore_state"):
+		return
+	var after: Dictionary = root.capture_state()
+	if plugin.undo_redo_manager:
+		plugin.undo_redo_manager.create_action("Paint Floor", 0, null, false)
+		plugin.undo_redo_manager.add_do_method(root, "restore_state", after)
+		plugin.undo_redo_manager.add_undo_method(root, "restore_state", before)
+		plugin.undo_redo_manager.commit_action(false)
+	plugin._record_history("Paint Floor")
+
+
+static func cancel_floor_paint(plugin: Object, root: Node) -> bool:
+	if plugin == null or not root:
+		return false
+	var paint_tool = root.get("paint_tool")
+	if (
+		paint_tool == null
+		or not paint_tool.has_method("is_stroke_active")
+		or not paint_tool.is_stroke_active()
+	):
+		return false
+	if paint_tool.has_method("cancel_stroke"):
+		paint_tool.cancel_stroke()
+	if not plugin._floor_paint_pre_state.is_empty() and root.has_method("restore_state"):
+		root.restore_state(plugin._floor_paint_pre_state)
+	plugin._floor_paint_pre_state = {}
+	_release_region_pins(root)
+	plugin._update_hud_context()
+	return true
+
+
+static func _release_region_pins(root: Node) -> void:
+	var paint_system = root.get("paint_system")
+	if paint_system != null and paint_system.has_method("release_paint_region_pins"):
+		paint_system.release_paint_region_pins()
 
 
 static func _is_visible_pick(root: Node, brush: Node3D) -> bool:

--- a/addons/hammerforge/plugin_shortcuts.gd
+++ b/addons/hammerforge/plugin_shortcuts.gd
@@ -11,6 +11,7 @@ extends RefCounted
 const STOP := EditorPlugin.AFTER_GUI_INPUT_STOP
 ## Same sentinel as plugin.HF_SHORTCUT_APPLY
 const SHORTCUT_APPLY := -3
+const HFPluginPaintInput = preload("plugin_paint_input.gd")
 
 
 ## Route one global key press. Returns nothing: ownership is expressed by
@@ -127,6 +128,8 @@ static func cancel_escape_step(plugin: Object, root: Node) -> bool:
 		plugin._texture_picker_active = false
 		if plugin.dock:
 			plugin.dock.show_toast("Texture Picker cancelled", 1)
+		return true
+	if HFPluginPaintInput.cancel_floor_paint(plugin, root):
 		return true
 	if plugin._disp_paint_active:
 		if (

--- a/addons/hammerforge/systems/hf_paint_system.gd
+++ b/addons/hammerforge/systems/hf_paint_system.gd
@@ -25,6 +25,7 @@ var region_streaming_enabled: bool = false
 var region_memory_budget_mb: int = 256
 var region_show_grid: bool = false
 var region_overlay_material: Material = null
+var _paint_region_pins: Dictionary = {}
 
 
 func _init(level_root: Node3D) -> void:
@@ -66,7 +67,44 @@ func handle_paint_input(
 		var cell = _screen_to_cell(camera, screen_pos)
 		if cell != null:
 			_ensure_regions_for_cell(cell)
-	return root.paint_tool.handle_input(camera, event, screen_pos)
+			var starts_stroke: bool = (
+				event is InputEventMouseButton
+				and event.button_index == MOUSE_BUTTON_LEFT
+				and event.pressed
+				and not (event as InputEventMouseButton).is_command_or_control_pressed()
+			)
+			if root.paint_tool.is_stroke_active() or starts_stroke:
+				_pin_paint_region(region_manager.region_id_from_cell(cell))
+	var handled: bool = root.paint_tool.handle_input(camera, event, screen_pos)
+	if (
+		region_streaming_enabled
+		and event is InputEventMouseButton
+		and event.button_index == MOUSE_BUTTON_LEFT
+		and not event.pressed
+	):
+		release_paint_region_pins()
+	return handled
+
+
+func prepare_paint_stroke(camera: Camera3D, screen_pos: Vector2) -> void:
+	if not region_streaming_enabled:
+		return
+	var cell = _screen_to_cell(camera, screen_pos)
+	if cell == null:
+		return
+	_ensure_regions_for_cell(cell)
+	_pin_paint_region(region_manager.region_id_from_cell(cell))
+
+
+func _pin_paint_region(region_id: Vector2i) -> void:
+	_paint_region_pins[region_id] = true
+	region_manager.set_pinned(region_id, true)
+
+
+func release_paint_region_pins() -> void:
+	for region_id: Vector2i in _paint_region_pins.keys():
+		region_manager.set_pinned(region_id, false)
+	_paint_region_pins.clear()
 
 
 func get_paint_layer_names() -> Array:

--- a/docs/features.md
+++ b/docs/features.md
@@ -373,7 +373,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 10, 2026 contains **3,240 tests across 167 scripts**: **3,233 passing tests**, seven intentional no-assert safety tests, and **16,500 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 9, 2026 contains **3,250 tests across 168 scripts**: **3,243 passing tests**, seven intentional no-assert safety tests, and **16,530 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_paint_polish.gd
+++ b/tests/test_paint_polish.gd
@@ -1,0 +1,207 @@
+extends GutTest
+## Floor Paint modifier, preview, feedback, and camera-ownership regressions.
+
+const HFPaintTool = preload("res://addons/hammerforge/paint/hf_paint_tool.gd")
+const HFPaintLayerManager = preload("res://addons/hammerforge/paint/hf_paint_layer_manager.gd")
+const HFStroke = preload("res://addons/hammerforge/paint/hf_stroke.gd")
+const HFPluginPaintInput = preload("res://addons/hammerforge/plugin_paint_input.gd")
+
+
+class FakeUndo:
+	extends RefCounted
+
+	var actions: Array = []
+	var do_calls: Array = []
+	var undo_calls: Array = []
+
+	func create_action(name: String, _merge = 0, _context = null, _backward = false) -> void:
+		actions.append(name)
+
+	func add_do_method(object, method: String, state: Dictionary) -> void:
+		do_calls.append([object, method, state])
+
+	func add_undo_method(object, method: String, state: Dictionary) -> void:
+		undo_calls.append([object, method, state])
+
+	func commit_action(_execute = true) -> void:
+		pass
+
+
+class FakePaintTool:
+	extends RefCounted
+
+	var changed := 0
+	var active := true
+	var cancels := 0
+
+	func get_last_committed_cell_count() -> int:
+		return changed
+
+	func is_stroke_active() -> bool:
+		return active
+
+	func cancel_stroke() -> bool:
+		cancels += 1
+		active = false
+		return true
+
+
+class FakePaintRoot:
+	extends Node
+
+	var marker := 1
+	var restored: Array = []
+	var paint_tool := FakePaintTool.new()
+	var paint_system = null
+
+	func capture_state() -> Dictionary:
+		return {"marker": marker}
+
+	func restore_state(state: Dictionary) -> void:
+		restored.append(state.duplicate(true))
+		marker = int(state.get("marker", marker))
+
+
+class FakePlugin:
+	extends RefCounted
+
+	var undo_redo_manager := FakeUndo.new()
+	var _floor_paint_pre_state: Dictionary = {}
+	var history: Array = []
+	var hud_updates := 0
+
+	func _record_history(action: String) -> void:
+		history.append(action)
+
+	func _update_hud_context() -> void:
+		hud_updates += 1
+
+var manager: HFPaintLayerManager
+var layer
+var tool: HFPaintTool
+
+
+func before_each():
+	manager = HFPaintLayerManager.new()
+	add_child_autoqfree(manager)
+	layer = manager.create_layer(&"floor", 0.0)
+	tool = HFPaintTool.new()
+	tool.layer_manager = manager
+	add_child_autoqfree(tool)
+
+
+func after_each():
+	manager = null
+	layer = null
+	tool = null
+
+
+func _begin_test_stroke(erasing: bool = false) -> void:
+	tool._active_stroke = HFStroke.new()
+	tool._painting = true
+	tool._stroke_erasing = erasing
+	tool._start_cell = Vector2i(2, 3)
+	tool._last_cell = tool._start_cell
+
+
+func test_alt_modifier_temporarily_erases_without_changing_the_selected_tool():
+	layer.set_cell(Vector2i(4, 5), true)
+	layer.consume_dirty_chunks()
+	tool.tool = HFStroke.Tool.PAINT
+	_begin_test_stroke(true)
+
+	tool._stamp_cell(Vector2i(4, 5))
+
+	assert_false(layer.get_cell(Vector2i(4, 5)))
+	assert_eq(tool.tool, HFStroke.Tool.PAINT, "Alt is a temporary action, not a mode switch")
+
+
+func test_shift_axis_lock_chooses_once_and_stays_stable_for_the_stroke():
+	_begin_test_stroke()
+
+	assert_eq(tool._apply_axis_lock(Vector2i(8, 5), true), Vector2i(8, 3))
+	assert_eq(tool._apply_axis_lock(Vector2i(4, 12), true), Vector2i(4, 3))
+	assert_eq(tool._stroke_axis, 1, "Later diagonal jitter must not flip the chosen axis")
+
+
+func test_ctrl_eyedropper_picks_the_cell_material_without_starting_a_stroke():
+	layer.set_cell(Vector2i(-2, 7), true)
+	layer.set_cell_material(Vector2i(-2, 7), 3)
+
+	assert_eq(tool.pick_cell_material(Vector2i(-2, 7)), 3)
+	assert_eq(tool.blend_material_id, 3)
+	assert_false(tool.is_stroke_active())
+
+
+func test_live_stroke_status_reports_cells_and_world_metres():
+	layer.grid.cell_size = 2.0
+	_begin_test_stroke()
+	tool._record_stroke_cell(Vector2i(2, 3))
+	tool._record_stroke_cell(Vector2i(4, 4))
+
+	var status: String = tool.get_stroke_hud_text()
+	assert_true(status.contains("2 cells"))
+	assert_true(status.contains("6 m × 4 m"), status)
+
+
+func test_escape_cancel_restores_rect_preview_without_committing():
+	_begin_test_stroke()
+	tool.tool = HFStroke.Tool.RECT
+	tool._preview_original[Vector2i(6, 6)] = false
+	tool._preview_cells[Vector2i(6, 6)] = true
+	layer.set_cell(Vector2i(6, 6), true)
+	layer.consume_dirty_chunks()
+
+	assert_true(tool.cancel_stroke())
+	assert_false(tool.is_stroke_active())
+	assert_false(layer.get_cell(Vector2i(6, 6)), "Cancel must restore the pre-preview cell")
+
+
+func test_floor_paint_tool_never_handles_rmb():
+	var source := FileAccess.get_file_as_string(
+		"res://addons/hammerforge/paint/hf_paint_tool.gd"
+	)
+	assert_false(source.contains("MOUSE_BUTTON_RIGHT"), "Plain RMB belongs to Godot's camera")
+
+
+func test_floor_stroke_registers_exactly_one_undo_entry_after_it_changes_cells():
+	var plugin := FakePlugin.new()
+	var root := FakePaintRoot.new()
+	add_child_autoqfree(root)
+	HFPluginPaintInput.begin_floor_paint_undo(plugin, root)
+	root.marker = 2
+	root.paint_tool.changed = 4
+
+	HFPluginPaintInput.commit_floor_paint_undo(plugin, root)
+
+	assert_eq(plugin.undo_redo_manager.actions, ["Paint Floor"])
+	assert_eq(plugin.undo_redo_manager.do_calls[0][2], {"marker": 2})
+	assert_eq(plugin.undo_redo_manager.undo_calls[0][2], {"marker": 1})
+	assert_eq(plugin.history, ["Paint Floor"])
+	assert_true(plugin._floor_paint_pre_state.is_empty())
+
+
+func test_floor_stroke_without_changes_creates_no_undo_entry():
+	var plugin := FakePlugin.new()
+	var root := FakePaintRoot.new()
+	add_child_autoqfree(root)
+	HFPluginPaintInput.begin_floor_paint_undo(plugin, root)
+
+	HFPluginPaintInput.commit_floor_paint_undo(plugin, root)
+
+	assert_true(plugin.undo_redo_manager.actions.is_empty())
+	assert_true(plugin._floor_paint_pre_state.is_empty())
+
+
+func test_floor_paint_cancel_restores_pre_state_and_clears_undo_capture():
+	var plugin := FakePlugin.new()
+	var root := FakePaintRoot.new()
+	add_child_autoqfree(root)
+	plugin._floor_paint_pre_state = {"marker": 1}
+	root.marker = 9
+
+	assert_true(HFPluginPaintInput.cancel_floor_paint(plugin, root))
+
+	assert_eq(root.paint_tool.cancels, 1)
+	assert_eq(root.restored, [{"marker": 1}])
+	assert_true(plugin._floor_paint_pre_state.is_empty())

--- a/tests/test_paint_system.gd
+++ b/tests/test_paint_system.gd
@@ -52,6 +52,18 @@ func test_layer_names_use_display_then_id():
 	assert_eq(str(names[1]), "layer_1")
 
 
+func test_paint_stroke_region_pins_release_as_one_unit():
+	sys._pin_paint_region(Vector2i(-1, 2))
+	sys._pin_paint_region(Vector2i(3, 4))
+	assert_true(sys.region_manager.is_pinned(Vector2i(-1, 2)))
+	assert_true(sys.region_manager.is_pinned(Vector2i(3, 4)))
+
+	sys.release_paint_region_pins()
+
+	assert_false(sys.region_manager.is_pinned(Vector2i(-1, 2)))
+	assert_false(sys.region_manager.is_pinned(Vector2i(3, 4)))
+
+
 # ===========================================================================
 # Region streaming persistence (#172, #173)
 # ===========================================================================

--- a/tests/test_plugin_gesture_recovery.gd
+++ b/tests/test_plugin_gesture_recovery.gd
@@ -107,6 +107,7 @@ class FakePlugin:
 	var _focus_recovery_queued := true
 
 	var disp_undo_commits := 0
+	var floor_undo_commits := 0
 	var selection_cancels := 0
 	var reconcile_queues := 0
 	var hud_updates := 0
@@ -119,6 +120,9 @@ class FakePlugin:
 
 	func _commit_disp_paint_undo(_root: Node) -> void:
 		disp_undo_commits += 1
+
+	func _commit_floor_paint_undo(_root: Node) -> void:
+		floor_undo_commits += 1
 
 	func _cancel_selection_gesture() -> bool:
 		selection_cancels += 1
@@ -253,6 +257,7 @@ func test_stale_floor_and_surface_strokes_are_both_finished():
 	)
 
 	assert_eq(root.paint_tool.finishes, 1)
+	assert_eq(plugin.floor_undo_commits, 1, "Recovered floor paint remains one undoable stroke")
 	assert_eq(root.input_state.surface_paint_ends, 1)
 
 


### PR DESCRIPTION
Waiting on a pull request's checks by branch is the obvious thing and it is wrong. `gh run list --branch X` returns the newest run on that branch, which is frequently the previous one, so a merge can go ahead on a result that belongs to a commit nobody is merging.

It happened twice while landing #265 to #270:

- once reading a superseded run on the branch, after a merge from main had pushed a new head
- once reading `main`'s tip, because the wait took its SHA from `git rev-parse HEAD` and the local checkout had drifted off the feature branch

Neither merged anything on the bad signal, but both reported green for a commit they had not looked at.

`tools/wait_for_ci.py <pr>` does it properly:

- The head comes from the pull request, re-read on every poll. The local checkout is not the authority on what a pull request would merge.
- Runs are matched on the full commit, and the commit is checked again on the returned run rather than trusted from the query.
- **CI's own counts commit moves the head mid-wait.** `ci.yml` measures the suite and pushes the published totals to the branch, so the commit that was green a moment ago is no longer the one that would merge. The newer commit is graded instead. The head is read once more after a pass, because a counts push landing between the fetch and the answer would otherwise be reported green on the strength of the commit it replaced.
- A missing run is "not yet", never "passed". Polling until nothing is pending cannot tell an empty check list from a finished one.

`--selftest` covers a run carrying the wrong commit, the wrong workflow, an empty list, each terminal conclusion, a head that moves mid-wait, a pass on a commit superseded in flight, and a run that never finishes. It runs in CI beside the placement-order selftest. Both mutations I tried against it fail loudly: dropping the commit check in `select_run`, and reading an absent run as success.

Smoke-tested against #270, where it correctly resolves `8247d28` rather than `main`'s tip, and exits 1 for a workflow that never ran on that commit.