### PR TITLE
Key the validation grid on cell indices instead of formatted strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,29 @@ The format is based on Keep a Changelog, and this project follows semantic versi
     presses without reselecting, undo, and what survives a state restore.
 
 ### Changed
+- **Check Issues spends its time on the level, not on building strings.** The
+  micro-gap and non-manifold scans key their spatial grid on the position of
+  every vertex and every edge. Those keys were formatted strings, and
+  `_cell_keys()` built **twenty-seven of them per vertex** so a pair straddling a
+  cell boundary would still be found. At 76 microseconds a call, once per vertex,
+  that was very nearly the whole pass.
+  - **The keys are grid indices now.** A cell is a `Vector3i`, its neighbours are
+    plus or minus one, and an edge is the pair of cells its ends fall in with the
+    smaller end first. Nothing is allocated to look a point up.
+  - **The buckets are the same buckets.** The index is the snapped position
+    divided by the step, with `snapped()` still in the middle, so the grid has not
+    moved and the same levels report the same issues.
+  - Measured over 1,000 brushes: a full `check_bake_issues()` went from 1,835.8 ms
+    to 460.4 ms. Per 20,000 calls, `_cell_keys()` went from 1,520.8 ms to 157.8 ms,
+    `_snap_key()` from 57.8 ms to 11.1 ms, and `_edge_key()` from 74.4 ms to
+    23.2 ms.
+  - **Coverage** (`tests/test_validation_cell_keys.gd`): 12 tests over the
+    tolerance, negative coordinates, the index matching the snapped position it
+    replaced, the twenty-seven distinct neighbours, a point finding its own cell,
+    a neighbour across a boundary, edge symmetry, fixed edge precision against a
+    raised weld tolerance, and both key kinds actually colliding as dictionary
+    keys rather than merely comparing equal.
+
 - **Floor paint stops running an inference stage that does nothing.** Every level
   handed its paint tool an `HFInferenceEngine`, and every ordinary stroke ended by
   classifying its intent and walking its dirty chunks calling a cleanup that was

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -400,7 +400,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,251 tests across 168 test scripts (3,244 passing plus seven intentional no-assert safety tests; 16,535 assertions; verified in CI on September 9, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,263 tests across 169 test scripts (3,256 passing plus seven intentional no-assert safety tests; 16,554 assertions; verified in CI on September 9, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -540,6 +540,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 9, 2026): **3,251 tests** across **168 scripts** (**3,244 passing** plus seven intentional no-assert safety tests; **16,535 assertions**).
+Full suite (verified in CI on September 9, 2026): **3,263 tests** across **169 scripts** (**3,256 passing** plus seven intentional no-assert safety tests; **16,554 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3244%20passing-brightgreen" alt="3244 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3256%20passing-brightgreen" alt="3256 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,251 tests across 168 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,263 tests across 169 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/systems/hf_validation_system.gd
+++ b/addons/hammerforge/systems/hf_validation_system.gd
@@ -391,11 +391,11 @@ func _check_non_manifold(brush: DraftBrush, issues: Array) -> void:
 		for i in range(verts.size()):
 			var a: Vector3 = verts[i]
 			var b: Vector3 = verts[(i + 1) % verts.size()]
-			var key: String = _edge_key(a, b)
+			var key: Array = _edge_key(a, b)
 			edge_counts[key] = edge_counts.get(key, 0) + 1
 	var open_count := 0
 	var non_manifold_count := 0
-	for key: String in edge_counts:
+	for key: Array in edge_counts:
 		var count: int = edge_counts[key]
 		if count == 1:
 			open_count += 1
@@ -432,17 +432,22 @@ func _check_non_manifold(brush: DraftBrush, issues: Array) -> void:
 ## Create a canonical edge key from two vertices (order-independent, rounded to 0.001).
 ## This tolerance is intentionally fixed — it must NOT vary with weld_tolerance,
 ## because non-manifold/open-edge detection depends on stable topology hashing.
-func _edge_key(a: Vector3, b: Vector3) -> String:
-	var ax := snapped(a.x, 0.001)
-	var ay := snapped(a.y, 0.001)
-	var az := snapped(a.z, 0.001)
-	var bx := snapped(b.x, 0.001)
-	var by := snapped(b.y, 0.001)
-	var bz := snapped(b.z, 0.001)
-	# Sort so edge (A,B) == edge (B,A)
-	if ax < bx or (ax == bx and ay < by) or (ax == bx and ay == by and az < bz):
-		return "%s,%s,%s-%s,%s,%s" % [ax, ay, az, bx, by, bz]
-	return "%s,%s,%s-%s,%s,%s" % [bx, by, bz, ax, ay, az]
+## An edge as the pair of grid cells its ends fall in, smaller end first so
+## (A,B) and (B,A) are one edge.
+##
+## Deliberately a pair of Vector3i rather than a formatted string. This runs for
+## every edge of every face of every brush, and building the string cost more
+## than everything it was a key for.
+func _edge_key(a: Vector3, b: Vector3) -> Array:
+	var ai := _quantise(a, 0.001)
+	var bi := _quantise(b, 0.001)
+	if (
+		ai.x < bi.x
+		or (ai.x == bi.x and ai.y < bi.y)
+		or (ai.x == bi.x and ai.y == bi.y and ai.z < bi.z)
+	):
+		return [ai, bi]
+	return [bi, ai]
 
 
 # ---------------------------------------------------------------------------
@@ -512,7 +517,7 @@ func _check_micro_gaps(all_brushes: Array, issues: Array) -> void:
 				var world_v: Vector3 = brush.global_transform * face.local_verts[vi]
 				var idx: int = entries.size()
 				entries.append({"brush": brush, "pos": world_v})
-				var key: String = _snap_key(world_v, tol)
+				var key: Vector3i = _snap_key(world_v, tol)
 				if not cells.has(key):
 					cells[key] = []
 				(cells[key] as Array).append(idx)
@@ -520,7 +525,7 @@ func _check_micro_gaps(all_brushes: Array, issues: Array) -> void:
 	var flagged_pairs: Dictionary = {}  # avoid duplicate warnings
 	for i in range(entries.size()):
 		var pos_i: Vector3 = entries[i]["pos"]
-		for cell_key: String in _cell_keys(pos_i, tol):
+		for cell_key: Vector3i in _cell_keys(pos_i, tol):
 			for j: int in cells.get(cell_key, []):
 				if j <= i:
 					continue  # ordered pair dedup
@@ -576,7 +581,7 @@ func weld_brush_vertices(brush: DraftBrush) -> int:
 			var idx: int = entries.size()
 			var pos: Vector3 = face.local_verts[vi]
 			entries.append({"fi": fi, "vi": vi, "pos": pos})
-			var key: String = _snap_key(pos, tol)
+			var key: Vector3i = _snap_key(pos, tol)
 			if not cells.has(key):
 				cells[key] = []
 			(cells[key] as Array).append(idx)
@@ -595,7 +600,7 @@ func weld_brush_vertices(brush: DraftBrush) -> int:
 		while not queue.is_empty():
 			var cur: int = queue.pop_front()
 			var cur_pos: Vector3 = entries[cur]["pos"]
-			for cell_key: String in _cell_keys(cur_pos, tol):
+			for cell_key: Vector3i in _cell_keys(cur_pos, tol):
 				for neighbor_idx: int in cells.get(cell_key, []):
 					if group_of[neighbor_idx] >= 0:
 						continue
@@ -661,21 +666,38 @@ func fix_non_planar_faces(brush: DraftBrush) -> int:
 	return fixed
 
 
-func _snap_key(v: Vector3, tol: float) -> String:
-	return "%s,%s,%s" % [snapped(v.x, tol), snapped(v.y, tol), snapped(v.z, tol)]
+## The grid cell a point falls in, at `tol` spacing.
+##
+## The index rather than the formatted position: same buckets, no allocation.
+## `snapped()` is kept in the middle so the bucket boundaries are exactly the
+## ones this used to produce.
+func _quantise(v: Vector3, tol: float) -> Vector3i:
+	return Vector3i(
+		roundi(snapped(v.x, tol) / tol),
+		roundi(snapped(v.y, tol) / tol),
+		roundi(snapped(v.z, tol) / tol)
+	)
+
+
+func _snap_key(v: Vector3, tol: float) -> Vector3i:
+	return _quantise(v, tol)
 
 
 ## Return all 27 cell keys (self + 26 neighbors) for a spatial hash lookup.
 ## Guarantees that any point within `cell_size` distance shares at least one cell.
+## This cell and its 26 neighbours, so a pair straddling a boundary is still
+## found.
+##
+## In index space the neighbours are just +/-1, which is why this is the change
+## that mattered: the old version formatted 27 strings for every vertex of every
+## brush, and that was almost the whole cost of a Check Issues pass.
 func _cell_keys(v: Vector3, cell_size: float) -> Array:
-	var cx: float = snapped(v.x, cell_size)
-	var cy: float = snapped(v.y, cell_size)
-	var cz: float = snapped(v.z, cell_size)
+	var c := _quantise(v, cell_size)
 	var keys: Array = []
-	for dx in [-cell_size, 0.0, cell_size]:
-		for dy in [-cell_size, 0.0, cell_size]:
-			for dz in [-cell_size, 0.0, cell_size]:
-				keys.append("%s,%s,%s" % [cx + dx, cy + dy, cz + dz])
+	for dx in [-1, 0, 1]:
+		for dy in [-1, 0, 1]:
+			for dz in [-1, 0, 1]:
+				keys.append(Vector3i(c.x + dx, c.y + dy, c.z + dz))
 	return keys
 
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -380,7 +380,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 9, 2026 contains **3,251 tests across 168 scripts**: **3,244 passing tests**, seven intentional no-assert safety tests, and **16,535 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 9, 2026 contains **3,263 tests across 169 scripts**: **3,256 passing tests**, seven intentional no-assert safety tests, and **16,554 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_validation_cell_keys.gd
+++ b/tests/test_validation_cell_keys.gd
@@ -1,0 +1,174 @@
+extends GutTest
+
+## The micro-gap and non-manifold scans bucket points into a grid. Those keys
+## used to be formatted strings and are now grid indices, which is a large speed
+## difference and must be no behaviour difference at all. These pin the bucketing
+## itself rather than only the issues it leads to.
+
+const HFValidationSystem = preload("res://addons/hammerforge/systems/hf_validation_system.gd")
+const DraftBrush = preload("res://addons/hammerforge/brush_instance.gd")
+
+var root: Node3D
+var val_sys: HFValidationSystem
+
+
+func before_each():
+	root = Node3D.new()
+	root.set_script(_root_shim_script())
+	add_child_autoqfree(root)
+	var draft = Node3D.new()
+	draft.name = "DraftBrushes"
+	root.add_child(draft)
+	root.draft_brushes_node = draft
+	var committed = Node3D.new()
+	committed.name = "Committed"
+	root.add_child(committed)
+	root.committed_node = committed
+	val_sys = HFValidationSystem.new(root)
+
+
+func after_each():
+	root = null
+	val_sys = null
+
+
+func _root_shim_script() -> GDScript:
+	var s = GDScript.new()
+	s.source_code = """
+extends Node3D
+
+var draft_brushes_node: Node3D
+var committed_node: Node3D
+
+func is_entity_node(node: Node) -> bool:
+	return node.has_meta("entity_type")
+"""
+	s.reload()
+	return s
+
+
+# ===========================================================================
+# Bucketing
+# ===========================================================================
+
+
+func test_points_inside_the_tolerance_share_a_cell():
+	var a := val_sys._snap_key(Vector3(1.0, 2.0, 3.0), 0.01)
+	var b := val_sys._snap_key(Vector3(1.002, 2.001, 2.998), 0.01)
+	assert_eq(a, b, "A nudge well under the tolerance is the same cell")
+
+
+func test_points_beyond_the_tolerance_do_not_share_a_cell():
+	var a := val_sys._snap_key(Vector3(1.0, 2.0, 3.0), 0.001)
+	var b := val_sys._snap_key(Vector3(1.05, 2.0, 3.0), 0.001)
+	assert_ne(a, b, "Fifty tolerances apart is a different cell")
+
+
+func test_negative_coordinates_bucket_the_same_way():
+	# Rounding across zero is where an index scheme most easily disagrees with
+	# the snapped positions it replaced.
+	var a := val_sys._snap_key(Vector3(-1.0, -2.0, -3.0), 0.01)
+	var b := val_sys._snap_key(Vector3(-1.002, -2.001, -2.998), 0.01)
+	assert_eq(a, b, "Negative coordinates cell together the same as positive")
+	assert_ne(
+		val_sys._snap_key(Vector3(-1.0, 0.0, 0.0), 0.01),
+		val_sys._snap_key(Vector3(1.0, 0.0, 0.0), 0.01),
+		"and either side of zero is not the same cell"
+	)
+
+
+func test_the_cell_matches_the_snapped_position_it_replaced():
+	# The index has to be the snapped position divided by the step, or the grid
+	# has silently moved.
+	var tol := 0.01
+	for v in [Vector3(1.234, -5.678, 9.0), Vector3.ZERO, Vector3(-0.004, 0.006, -0.5)]:
+		var key: Vector3i = val_sys._snap_key(v, tol)
+		var expected := Vector3i(
+			roundi(snapped(v.x, tol) / tol),
+			roundi(snapped(v.y, tol) / tol),
+			roundi(snapped(v.z, tol) / tol)
+		)
+		assert_eq(key, expected, "Cell for %s" % v)
+
+
+# ===========================================================================
+# The neighbourhood
+# ===========================================================================
+
+
+func test_the_neighbourhood_is_twenty_seven_distinct_cells():
+	var keys: Array = val_sys._cell_keys(Vector3(1.0, 2.0, 3.0), 0.01)
+	assert_eq(keys.size(), 27, "Own cell plus twenty-six neighbours")
+	var seen := {}
+	for k in keys:
+		seen[k] = true
+	assert_eq(seen.size(), 27, "and none of them repeat")
+
+
+func test_the_neighbourhood_contains_the_point_own_cell():
+	var v := Vector3(1.0, 2.0, 3.0)
+	assert_true(
+		val_sys._snap_key(v, 0.01) in val_sys._cell_keys(v, 0.01),
+		"A point must be found in its own cell"
+	)
+
+
+func test_a_neighbour_across_a_boundary_is_reachable():
+	# The reason the neighbourhood exists: two points a hair apart can still
+	# land in adjacent cells, and the scan has to look next door.
+	var tol := 0.01
+	var a := Vector3(1.0049, 0.0, 0.0)
+	var b := Vector3(1.0051, 0.0, 0.0)
+	assert_ne(val_sys._snap_key(a, tol), val_sys._snap_key(b, tol), "They straddle a boundary")
+	assert_true(
+		val_sys._snap_key(b, tol) in val_sys._cell_keys(a, tol),
+		"so each must appear in the other's neighbourhood"
+	)
+
+
+# ===========================================================================
+# Edges
+# ===========================================================================
+
+
+func test_an_edge_reads_the_same_both_ways_round():
+	var a := Vector3(1.0, 2.0, 3.0)
+	var b := Vector3(4.0, 5.0, 6.0)
+	assert_eq(val_sys._edge_key(a, b), val_sys._edge_key(b, a), "(A,B) and (B,A) are one edge")
+
+
+func test_edges_apart_by_more_than_the_precision_differ():
+	assert_ne(
+		val_sys._edge_key(Vector3(1.0, 2.0, 3.0), Vector3(4.0, 5.0, 6.0)),
+		val_sys._edge_key(Vector3(1.05, 2.0, 3.0), Vector3(4.0, 5.0, 6.0))
+	)
+
+
+func test_edge_precision_is_fixed_and_ignores_weld_tolerance():
+	# Raising the weld tolerance must not collapse distinct edges, or a real
+	# non-manifold brush stops being reported.
+	val_sys.weld_tolerance = 0.5
+	assert_ne(
+		val_sys._edge_key(Vector3(1.0, 2.0, 3.0), Vector3(4.0, 5.0, 6.0)),
+		val_sys._edge_key(Vector3(1.05, 2.0, 3.0), Vector3(4.0, 5.0, 6.0)),
+		"Edge keys use their own fixed precision"
+	)
+
+
+func test_an_edge_key_works_as_a_dictionary_key():
+	# The scans count edges in a Dictionary, so equal keys must collide there
+	# and not merely compare equal.
+	var counts := {}
+	counts[val_sys._edge_key(Vector3(1, 2, 3), Vector3(4, 5, 6))] = 1
+	var same: Array = val_sys._edge_key(Vector3(4, 5, 6), Vector3(1, 2, 3))
+	assert_true(counts.has(same), "The same edge from either end is one entry")
+	counts[same] = int(counts[same]) + 1
+	assert_eq(counts.size(), 1, "so the dictionary holds one edge")
+	assert_eq(counts[same], 2, "counted twice, which is what manifold means")
+
+
+func test_a_cell_key_works_as_a_dictionary_key():
+	var cells := {}
+	cells[val_sys._snap_key(Vector3(1.0, 2.0, 3.0), 0.01)] = "first"
+	var same: Vector3i = val_sys._snap_key(Vector3(1.001, 2.0, 3.0), 0.01)
+	assert_true(cells.has(same), "Points in one cell collide in the dictionary")

--- a/tests/test_validation_cell_keys.gd.uid
+++ b/tests/test_validation_cell_keys.gd.uid
@@ -1,0 +1,1 @@
+uid://bofkr8qtg2l3s


### PR DESCRIPTION
Landing #263 left the subtraction checks at about 11 ms of a pass that still took roughly 1.9 seconds on a thousand brushes. I said at the time the rest was elsewhere. It was: string keys.

`_check_micro_gaps()` and `_check_non_manifold()` bucket every vertex and every edge into a spatial grid. Those keys were formatted strings, and `_cell_keys()` built **twenty-seven of them per vertex** so a pair straddling a cell boundary would still be found. Measured at 76 microseconds a call, once per vertex — very nearly the whole pass.

What changed:

- A cell is a `Vector3i`. Its twenty-six neighbours are plus or minus one in index space, so the neighbourhood costs no allocation at all.
- An edge is the pair of cells its ends fall in, smaller end first, so (A,B) and (B,A) remain one edge.
- **The buckets are the same buckets.** The index is the snapped position divided by the step, with `snapped()` still in the middle, so the grid has not moved and the same levels report the same issues.

Measured over 1,000 brushes:

| | before | after |
| --- | --- | --- |
| whole `check_bake_issues()` | 1,835.8 ms | **460.4 ms** |
| `_cell_keys()` x20,000 | 1,520.8 ms | 157.8 ms |
| `_snap_key()` x20,000 | 57.8 ms | 11.1 ms |
| `_edge_key()` x20,000 | 74.4 ms | 23.2 ms |

`tests/test_validation_cell_keys.gd` pins the bucketing rather than only the issues it leads to: the tolerance, negative coordinates, the index matching the snapped position it replaced, twenty-seven distinct neighbours, a point finding its own cell, a neighbour across a boundary, edge symmetry, fixed edge precision against a raised weld tolerance, and both key kinds actually colliding as dictionary keys rather than merely comparing equal.

Two mutations fail it: dropping the `+1` side of the neighbourhood, and replacing `roundi(snapped(v.x, tol) / tol)` with `int(v.x / tol)` — which truncates toward zero and would have quietly broken negative coordinates.

Full suite: 3,263 tests, 3,256 passing, no failures.