### PR TITLE
Make Create Starter callable without the dock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Added
+- **Create Starter is callable without the dock** (#278). The starter level was
+  a dock button handler and nothing else, so tests, tool scripts and editor
+  bridges had no way to build one. `HFLevelFactory.create_starter(parent)` now
+  adds a `LevelRoot` and fills it with the floor, sun and player spawn;
+  `HFLevelFactory.create_level_root(parent)` stops at the empty root. Both take
+  an optional scene owner and an optional property dictionary, applied before
+  the node enters the tree because `LevelRoot` reads its exports in `_ready`.
+  The editor plugin gained `create_starter_level()` for the same result in the
+  open scene as one undo entry, and the console's Create Starter action falls
+  back to it when no dock is present. The dock buttons are unchanged.
+  - `LevelRoot._get_editor_owner()` no longer assumes there is a `SceneTree` to
+    ask, so a root built in code and not yet parented falls back to its owner
+    instead of erroring.
+  - **Coverage** (`tests/test_level_factory.gd`): parenting, owner resolution
+    through an explicit owner and an inherited one, properties applied before
+    `_ready`, a rejected null and detached parent, the reported property typo,
+    the floor/sun/spawn set, child ownership so the scene saves, and a second
+    call not duplicating the fixtures.
 - **`tools/wait_for_ci.py` waits on the commit, not the branch.** Waiting on a
   pull request's checks by branch is the obvious thing and it is wrong: the
   newest run on a branch is often the previous one, so a merge can go ahead on a

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -400,7 +400,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,286 tests across 170 test scripts (3,279 passing plus seven intentional no-assert safety tests; 16,695 assertions; verified in CI on September 10, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,299 tests across 171 test scripts (3,292 passing plus seven intentional no-assert safety tests; 16,724 assertions; verified in CI on September 10, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 10, 2026): **3,286 tests** across **170 scripts** (**3,279 passing** plus seven intentional no-assert safety tests; **16,695 assertions**).
+Full suite (verified in CI on September 10, 2026): **3,299 tests** across **171 scripts** (**3,292 passing** plus seven intentional no-assert safety tests; **16,724 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -388,9 +388,14 @@ Godot editor input and UI
      -> level_root.gd           (public level facade and cross-system coordination)
         -> runtime core         (brush, entity, bake, paint, file)
         -> editor-only graph    (drag, grid, snap, state, validation, previews, authoring tools)
+
+HFLevelFactory                  (makes a LevelRoot from code; no dock, no EditorPlugin)
+  -> level_root.gd
 ```
 
 `LevelRoot` preserves the public level API used by `plugin.gd` and `dock.gd` (`root.bake()`, `root.begin_drag()`, and similar operations). It delegates cohesive behavior to subsystems while retaining container ownership, exported settings, signals, runtime lifecycle, and cross-system coordination; its methods are therefore not uniformly one-line delegates.
+
+`HFLevelFactory` makes the root itself, which is the one step that sits in front of that API. `create_level_root(parent)` adds an empty `LevelRoot`, and `create_starter(parent)` adds one and fills it with the floor, sun and player spawn that Create Starter builds. Both take an optional owner and an optional property dictionary applied before `_ready`, since `LevelRoot` reads its exports there and outside the editor a fresh root would otherwise start a playtest. `plugin.gd` exposes `create_starter_level()` for the same result in the scene the editor has open, as one undo entry.
 
 `plugin.gd`'s `_forward_3d_gui_input()` is a two-line boundary that delegates viewport arbitration to `HFPluginViewportInput.handle()`. That module coordinates the focused paint, keyboard, RMB, selection, extrude, draw, motion, vertex, and external-tool paths. Numeric dimension parsing, live preview, and draw/extrude commit live in `HFPluginNumericInput`. Other `plugin_*.gd` modules similarly own selection state, commands, HUD state, overlays, edit actions, and viewport drops.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3279%20passing-brightgreen" alt="3279 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3292%20passing-brightgreen" alt="3292 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,286 tests across 170 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,299 tests across 171 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/dock.gd
+++ b/addons/hammerforge/dock.gd
@@ -3160,6 +3160,8 @@ func _on_create_level_root(create_starter: bool) -> void:
 	if not root:
 		show_toast("Open or create a 3D scene first", 2)
 		return
+	# The history browser reads its versions through this node, so adopt it
+	# before the starter fill is committed against it.
 	level_root = root
 	if create_starter:
 		_on_new_level()

--- a/addons/hammerforge/hf_level_factory.gd
+++ b/addons/hammerforge/hf_level_factory.gd
@@ -1,0 +1,79 @@
+@tool
+class_name HFLevelFactory
+extends RefCounted
+
+## Builds HammerForge level roots from code.
+##
+## The dock's empty-state banner is one caller of this, not the definition of
+## it. Tests, headless tools and editor bridges get the same starter level
+## without constructing a dock or an EditorPlugin. `LevelRoot` already exposes
+## the level's own behaviour (`create_new_level`, the `bake` family); this is
+## the missing step in front of that, which is making the node itself.
+
+
+## A detached `LevelRoot`, named but not parented.
+##
+## For callers that add the node themselves, which is what the editor plugin
+## does so the add is one undo entry, and what anyone who needs to set exported
+## properties before `_ready` runs does.
+static func make_level_root() -> LevelRoot:
+	var root := LevelRoot.new()
+	root.name = "LevelRoot"
+	return root
+
+
+## Add an empty `LevelRoot` under `parent` and return it.
+##
+## `scene_owner` decides whether the node survives a scene save. It defaults to
+## whatever owns `parent`, falling back to `parent` itself, which is the right
+## answer when `parent` is the scene root.
+##
+## `properties` is applied before the node enters the tree, because `LevelRoot`
+## reads its exports in `_ready` and there is no later chance. Outside the
+## editor that is the only way to stop a fresh root starting a playtest:
+## `{"auto_spawn_player": false}`. Inside the editor the defaults are correct
+## and this can be left empty.
+##
+## `parent` must already be inside a `SceneTree`, because the root builds its
+## subsystems in `_ready`. Returns null if it is not.
+static func create_level_root(
+	parent: Node, scene_owner: Node = null, properties: Dictionary = {}
+) -> LevelRoot:
+	if parent == null:
+		push_error("HFLevelFactory: parent is null")
+		return null
+	if not parent.is_inside_tree():
+		push_error("HFLevelFactory: parent must be inside the scene tree")
+		return null
+	var root := make_level_root()
+	for key in properties:
+		if not key in root:
+			push_error("HFLevelFactory: LevelRoot has no property '%s'" % key)
+			continue
+		root.set(key, properties[key])
+	parent.add_child(root)
+	root.owner = _resolve_owner(parent, scene_owner)
+	return root
+
+
+## Add a `LevelRoot` under `parent` and fill it with the starter level: a floor,
+## an angled sun light and a player spawn.
+##
+## Same result as Create Starter in the dock's empty-state banner. Returns null
+## if the root could not be made.
+static func create_starter(
+	parent: Node, scene_owner: Node = null, properties: Dictionary = {}
+) -> LevelRoot:
+	var root := create_level_root(parent, scene_owner, properties)
+	if root == null:
+		return null
+	root.create_new_level()
+	return root
+
+
+static func _resolve_owner(parent: Node, scene_owner: Node) -> Node:
+	if scene_owner != null:
+		return scene_owner
+	if parent.owner != null:
+		return parent.owner
+	return parent

--- a/addons/hammerforge/hf_level_factory.gd.uid
+++ b/addons/hammerforge/hf_level_factory.gd.uid
@@ -1,0 +1,1 @@
+uid://4ly8n47ced0u

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -2968,7 +2968,9 @@ func create_new_level() -> void:
 
 
 func _get_editor_owner() -> Node:
-	var scene = get_tree().edited_scene_root
+	# A root built in code and not yet parented has no tree to ask.
+	var tree := get_tree()
+	var scene = tree.edited_scene_root if tree else null
 	if scene:
 		return scene
 	return get_owner()

--- a/addons/hammerforge/plugin.gd
+++ b/addons/hammerforge/plugin.gd
@@ -1643,12 +1643,24 @@ func ensure_level_root() -> Node:
 	return _create_level_root()
 
 
+## Create a starter level in the edited scene and return its LevelRoot: a
+## floor, an angled sun light and a player spawn. One undo entry.
+##
+## This is Create Starter without the dock. For a scene that is not the one open
+## in the editor, use `HFLevelFactory.create_starter()` instead.
+func create_starter_level() -> Node:
+	var root = ensure_level_root()
+	if not root:
+		return null
+	HFUndoHelper.commit(undo_redo_manager, root, "New HammerForge Level", "create_new_level")
+	return root
+
+
 func _create_level_root() -> Node:
 	var scene = get_editor_interface().get_edited_scene_root()
 	if not scene:
 		return null
-	var root = LevelRootType.new()
-	root.name = "LevelRoot"
+	var root = HFLevelFactory.make_level_root()
 	if undo_redo_manager:
 		undo_redo_manager.create_action("Create HammerForge Level")
 		undo_redo_manager.add_do_method(scene, "add_child", root)

--- a/addons/hammerforge/plugin_console.gd
+++ b/addons/hammerforge/plugin_console.gd
@@ -191,9 +191,14 @@ static func handle_action(plugin: Object, action_id: String) -> void:
 		"focus_dock":
 			focus_dock(plugin)
 		"create_starter":
+			# Prefer the dock so its banner and hints refresh with the scene.
+			# Without one, the plugin still knows how to build a starter level.
 			if dock and dock.has_method("_on_create_level_root"):
 				dock._on_create_level_root(true)
 				_note(panel, "Created a starter level.")
+			elif plugin.has_method("create_starter_level"):
+				if plugin.call("create_starter_level") != null:
+					_note(panel, "Created a starter level.")
 		"bake":
 			if dock and dock.has_method("_on_bake"):
 				dock._on_bake()

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 10, 2026 contains **3,286 tests across 170 scripts**: **3,279 passing tests**, seven intentional no-assert safety tests, and **16,695 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 10, 2026 contains **3,299 tests across 171 scripts**: **3,292 passing tests**, seven intentional no-assert safety tests, and **16,724 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_level_factory.gd
+++ b/tests/test_level_factory.gd
@@ -1,0 +1,136 @@
+extends GutTest
+## Tests for HFLevelFactory, the dockless entry point for making a LevelRoot
+## and for building the starter level the dock's empty-state banner builds.
+
+# A fresh root outside the editor would otherwise bake and spawn a player the
+# moment it enters the tree.
+const HEADLESS := {"auto_spawn_player": false, "hflevel_autosave_enabled": false}
+
+var parent: Node3D
+
+
+func before_each():
+	parent = Node3D.new()
+	parent.name = "SceneRoot"
+	add_child_autoqfree(parent)
+
+
+func after_each():
+	parent = null
+
+
+# ===========================================================================
+# make_level_root
+# ===========================================================================
+
+
+func test_make_level_root_returns_named_detached_node():
+	var root: LevelRoot = HFLevelFactory.make_level_root()
+	assert_not_null(root, "make_level_root should return a node")
+	assert_eq(root.name, StringName("LevelRoot"), "Node should be named LevelRoot")
+	assert_false(root.is_inside_tree(), "Node should not be parented yet")
+	root.free()
+
+
+# ===========================================================================
+# create_level_root
+# ===========================================================================
+
+
+func test_create_level_root_parents_under_the_given_node():
+	var root: LevelRoot = HFLevelFactory.create_level_root(parent, null, HEADLESS)
+	assert_not_null(root, "Factory should return a root")
+	assert_eq(root.get_parent(), parent, "Root should be a child of parent")
+	assert_eq(root.name, StringName("LevelRoot"), "Root should be named LevelRoot")
+
+
+func test_create_level_root_owns_to_parent_when_parent_has_no_owner():
+	var root: LevelRoot = HFLevelFactory.create_level_root(parent, null, HEADLESS)
+	assert_eq(root.owner, parent, "Owner should fall back to parent")
+
+
+func test_create_level_root_inherits_the_parents_owner():
+	var middle := Node3D.new()
+	parent.add_child(middle)
+	middle.owner = parent
+	var root: LevelRoot = HFLevelFactory.create_level_root(middle, null, HEADLESS)
+	assert_eq(root.owner, parent, "Owner should be the parent's own owner")
+
+
+func test_create_level_root_honours_an_explicit_owner():
+	var middle := Node3D.new()
+	parent.add_child(middle)
+	middle.owner = parent
+	var root: LevelRoot = HFLevelFactory.create_level_root(middle, middle, HEADLESS)
+	assert_eq(root.owner, middle, "Explicit scene_owner should win")
+
+
+func test_create_level_root_applies_properties():
+	var root: LevelRoot = HFLevelFactory.create_level_root(parent, null, HEADLESS)
+	assert_false(root.auto_spawn_player, "Property should be set on the node")
+	assert_false(root.hflevel_autosave_enabled, "Property should be set on the node")
+
+
+func test_create_level_root_ignores_an_unknown_property():
+	var props := HEADLESS.duplicate()
+	props["no_such_property"] = 1
+	var root: LevelRoot = HFLevelFactory.create_level_root(parent, null, props)
+	assert_not_null(root, "An unknown property should not stop creation")
+	assert_false(root.auto_spawn_player, "Known properties should still be applied")
+	assert_push_error("no_such_property", "The typo should be reported, not swallowed")
+
+
+func test_create_level_root_rejects_a_null_parent():
+	assert_null(HFLevelFactory.create_level_root(null), "Null parent should return null")
+	assert_push_error("parent is null")
+
+
+func test_create_level_root_rejects_a_parent_outside_the_tree():
+	var detached := Node3D.new()
+	assert_null(
+		HFLevelFactory.create_level_root(detached, null, HEADLESS),
+		"A parent outside the tree should return null"
+	)
+	assert_push_error("inside the scene tree")
+	detached.free()
+
+
+# ===========================================================================
+# create_starter
+# ===========================================================================
+
+
+func test_create_starter_builds_floor_sun_and_spawn():
+	var root: LevelRoot = HFLevelFactory.create_starter(parent, null, HEADLESS)
+	assert_not_null(root, "Factory should return a root")
+
+	var floor_node := root.get_node_or_null("TempFloor")
+	assert_not_null(floor_node, "Starter level should have a floor")
+	assert_true(floor_node is CSGBox3D, "Floor should be a CSGBox3D")
+
+	var sun := root.get_node_or_null("DefaultSun")
+	assert_not_null(sun, "Starter level should have a sun light")
+	assert_true(sun is DirectionalLight3D, "Sun should be a DirectionalLight3D")
+
+	if root.spawn_system:
+		assert_not_null(root.spawn_system.get_active_spawn(), "Starter level should have a spawn")
+
+
+func test_create_starter_owns_its_children_so_the_scene_can_be_saved():
+	var root: LevelRoot = HFLevelFactory.create_starter(parent, null, HEADLESS)
+	var floor_node := root.get_node_or_null("TempFloor")
+	var sun := root.get_node_or_null("DefaultSun")
+	assert_eq(floor_node.owner, parent, "Floor should be owned by the scene root")
+	assert_eq(sun.owner, parent, "Sun should be owned by the scene root")
+
+
+func test_create_starter_is_repeatable_on_the_same_root():
+	var root: LevelRoot = HFLevelFactory.create_starter(parent, null, HEADLESS)
+	var before := root.get_child_count()
+	root.create_new_level()
+	assert_eq(root.get_child_count(), before, "A second call should not duplicate the fixtures")
+
+
+func test_create_starter_rejects_a_null_parent():
+	assert_null(HFLevelFactory.create_starter(null), "Null parent should return null")
+	assert_push_error("parent is null")

--- a/tests/test_level_factory.gd.uid
+++ b/tests/test_level_factory.gd.uid
@@ -1,0 +1,1 @@
+uid://b4c4yf75iwb4g


### PR DESCRIPTION
## Summary

`Create Starter` only existed as a dock button handler, so nothing outside the dock could build a starter level. This adds `HFLevelFactory`, which makes a `LevelRoot` and fills it, and a `create_starter_level()` on the editor plugin for the scene the editor has open.

The dock buttons are unchanged. I tried routing them through the plugin and backed it out: the dock's history browser resolves undo versions through `dock.level_root`, and the plugin's commit fires `record_history` before the dock has adopted the node.

## Before / After Behavior

- Before: a starter level could only be made by pressing a dock button. Headless scripts, tests and editor bridges had no entry point. The console's `create_starter` action did nothing without a dock.
- After: `HFLevelFactory.create_starter(parent)` builds one anywhere, `HFLevelFactory.create_level_root(parent)` stops at the empty root, and `plugin.create_starter_level()` does it in the open scene as one undo entry. The console action falls back to the plugin when there is no dock. Dock behaviour is identical.

`LevelRoot._get_editor_owner()` no longer assumes there is a `SceneTree` to ask, so a root built in code and not yet parented falls back to its owner instead of erroring.

## Related Issue

Fixes #278

## Checks

- [x] `gdformat --check addons/hammerforge/ tests/` passes
- [x] `gdlint addons/hammerforge/` passes
- [x] `godot --headless -s res://addons/gut/gut_cmdln.gd --path .` passes (3292 passing, 7 known no-assert, 0 failing)
- [x] Docs updated together where behavior changed (spec data flow and API note, `[Unreleased]` in CHANGELOG)
- [x] `git diff --check` is clean and relative Markdown links resolve
- [x] No MCP tokens, `user://` settings, verification logs, editor screenshots, or local client overrides committed
- [x] `addons/godot_mcp` left untouched