### PR TITLE
Fail CI on a project.godot that enables local tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,16 @@ jobs:
       - name: Check placement order
         run: python3 tools/check_placement_order.py
 
+      # project.godot is tracked, and the editor rewrites it the moment anyone
+      # enables a plugin. addons/godot_mcp and its autoload rode in that way and
+      # shipped enabled for months. The template asks a human to check; this is
+      # the part that cannot forget.
+      - name: Check the project-settings guard still detects
+        run: python3 tools/check_project_settings.py --selftest
+
+      - name: Check project settings
+        run: python3 tools/check_project_settings.py
+
       # wait_for_ci.py decides whether a branch is safe to merge. Its whole job
       # is refusing a green run that belongs to some other commit, so the
       # fixtures for that case run here rather than being taken on trust.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Added
+- **CI refuses a `project.godot` that enables local tooling.** The file is
+  tracked and the editor rewrites it the moment anyone enables a plugin, so a
+  locally installed bridge rides into the next `git add -A`. That is how
+  `addons/godot_mcp` and its `MCPRuntimeProbe` autoload got in and stayed
+  enabled for months. `tools/check_project_settings.py` asserts the enabled list
+  is HammerForge and nothing else, and that no autoload is registered.
+  - **`override.cfg` is not a way out of this and the tool says so.** On 4.7 an
+    `editor_plugins/enabled` written there does not enable the plugin in the
+    editor, while the same value in `project.godot` does. Checked against
+    4.7.stable with a control, since the documentation is quiet on the point.
+  - **`--selftest` covers nine cases**, including the exact shape this
+    repository shipped before #277, a plugin name that merely contains the
+    allowed one, an enabled list the guard cannot parse, and a missing
+    `[editor_plugins]` section. It runs in CI ahead of the check itself.
+  - DEVELOPMENT.md now carries the `git update-index --skip-worktree` recipe for
+    keeping a local enable out of `git status`, along with the pull it breaks
+    and how to get out of that.
 - **Create Starter is callable without the dock** (#278). The starter level was
   a dock button handler and nothing else, so tests, tool scripts and editor
   bridges had no way to build one. `HFLevelFactory.create_starter(parent)` now

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ the change.
 - **Test Level variants** (internally Quick Play): `_on_quick_play_from_camera()` and `_on_quick_play_selected_area()` must follow the same severity ≥ 2 blocking, auto-create, and fix-dialog patterns as `_on_quick_play()`. Both must restore temporary state (spawn position/angle, cordon) on both success and error paths. Use `_restore_spawn()` helper and explicit type annotations (e.g. `var old_pos: Vector3 =`) to avoid GDScript `:=` inference failures with untyped spawn references.
 - **Camera yaw propagation**: write yaw to `entity_data["angle"]` (not `set_meta`). The playtest runtime reads `deg_to_rad(entity_data.get("angle", 0.0))` at `level_root.gd` line ~1979.
 - Avoid adding new dependencies unless necessary.
-- No editor bridge is vendored here. Install the one you use into your own `addons/` folder; `.gitignore` allowlists `addons/`, so it stays untracked. Enabling it rewrites the tracked `project.godot`, so check that file before you push.
+- No editor bridge is vendored here. Install the one you use into your own `addons/` folder; `.gitignore` allowlists `addons/`, so it stays untracked. Enabling it rewrites the tracked `project.godot`; `tools/check_project_settings.py` fails CI if that reaches a branch, and [DEVELOPMENT.md](DEVELOPMENT.md#keeping-a-local-enable-out-of-git-status) has the way to keep it out of `git status`.
 - Never commit bridge tokens, `user://` settings, generated verification logs, editor screenshots, or local client overrides. A token belongs in an environment variable, not in a committed file.
 
 ## Running Checks Locally

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -104,7 +104,35 @@ old.
 
 This repository vendors none. It used to carry a copy of Godot MCP Native in `addons/godot_mcp`, enabled in `project.godot` for everyone. That was one contributor's tooling and it had nothing to do with the plugin, so it is gone. Install whichever bridge you use into your own `addons/` folder.
 
-Two things have to stay out of the repository. The addon folder itself, which `.gitignore` now handles by allowlisting `addons/`. And the `enabled=PackedStringArray(...)` line in `project.godot`, which changes the moment you enable a plugin and is tracked, so it is on you to keep it out of a commit.
+Two things have to stay out of the repository. The addon folder itself, which `.gitignore` now handles by allowlisting `addons/`. And the `enabled=PackedStringArray(...)` line in `project.godot`, which the editor rewrites the moment you enable a plugin. That file is tracked, so `.gitignore` cannot cover it.
+
+CI refuses a `project.godot` that enables anything but HammerForge, or that registers an autoload:
+
+```bash
+python tools/check_project_settings.py
+```
+
+### Keeping a local enable out of `git status`
+
+`override.cfg` looks like the answer and is not. On 4.7 an `editor_plugins/enabled` written there does not enable the plugin in the editor at all, while the same value in `project.godot` does.
+
+What works is telling git to stop watching the file:
+
+```bash
+git update-index --skip-worktree project.godot
+```
+
+`git status` goes quiet, and `git commit -a` cannot pick the file up. The cost is that a pull which changes `project.godot` aborts with *Please commit your changes or stash them before you merge*. When that happens:
+
+```bash
+git update-index --no-skip-worktree project.godot
+git checkout -- project.godot
+git pull
+# re-enable your plugin in the editor, then:
+git update-index --skip-worktree project.godot
+```
+
+The flag is per-clone and cannot be committed, so this is a thing you do once on each machine and again after every upstream change to the file.
 
 Tokens, client configuration, and anything Godot writes under `user://` are machine-local. Bind a local server to loopback and leave authentication on.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -112,6 +112,10 @@ CI refuses a `project.godot` that enables anything but HammerForge, or that regi
 python tools/check_project_settings.py
 ```
 
+Tokens, client configuration, and anything Godot writes under `user://` are machine-local. Bind a local server to loopback and leave authentication on.
+
+If you are an agent reading this: nothing here publishes a session, and an addon named "Godot MCP Native" is not Didi's `godot-mcp-native`. They are different products by different authors.
+
 ### Keeping a local enable out of `git status`
 
 `override.cfg` looks like the answer and is not. On 4.7 an `editor_plugins/enabled` written there does not enable the plugin in the editor at all, while the same value in `project.godot` does.
@@ -133,10 +137,6 @@ git update-index --skip-worktree project.godot
 ```
 
 The flag is per-clone and cannot be committed, so this is a thing you do once on each machine and again after every upstream change to the file.
-
-Tokens, client configuration, and anything Godot writes under `user://` are machine-local. Bind a local server to loopback and leave authentication on.
-
-If you are an agent reading this: nothing here publishes a session, and an addon named "Godot MCP Native" is not Didi's `godot-mcp-native`. They are different products by different authors.
 
 ## Codebase Structure
 

--- a/tools/check_project_settings.py
+++ b/tools/check_project_settings.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Refuse a project.godot that enables anything but HammerForge.
+
+`project.godot` is tracked, and the Godot editor rewrites it the moment you
+enable a plugin. So a contributor who installs an MCP bridge, a profiler or any
+other editor addon has a dirty tracked file from then on, and the enable rides
+into the next commit that runs `git add -A`.
+
+That is not hypothetical. `addons/godot_mcp` and its `MCPRuntimeProbe` autoload
+sat enabled in this file for months and shipped to everyone, which is what
+issue #277 was about. The pull request template asks a human to confirm the file
+is clean. A checkbox is not a guard.
+
+There is no engine-side way out. `override.cfg` looks like the answer and is
+not: on Godot 4.7 an `editor_plugins/enabled` written there does not enable the
+plugin in the editor, while the same value in `project.godot` does. Verified
+against 4.7.stable rather than taken from the documentation, which is quiet on
+the point.
+
+    python tools/check_project_settings.py
+
+Exits 1 and names what it found. `--selftest` checks the detector still catches
+each way this goes wrong, because a guard that cannot fail is not a guard.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+# The only editor plugin this repository ships enabled. `addons/gut` runs from
+# the command line and is never enabled; `addons/hf_docshot` is switched on for
+# the length of a capture by tools/capture_ui.py and switched back off. Adding a
+# name here is a deliberate act, which is the point.
+ALLOWED_PLUGINS = ["res://addons/hammerforge/plugin.cfg"]
+
+# HammerForge ships no autoload. One appearing here means an addon put it there.
+ALLOWED_AUTOLOADS: list[str] = []
+
+SECTION_RE = re.compile(r"^\[([^\]]+)\]\s*$")
+KEY_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_/.]*)\s*=")
+PACKED_RE = re.compile(r"^enabled\s*=\s*PackedStringArray\((.*)\)\s*$")
+QUOTED_RE = re.compile(r'"([^"]*)"')
+
+
+class ParseError(Exception):
+    """The file did not look the way this guard knows how to read."""
+
+
+def parse(text: str) -> tuple[list[str], list[str]]:
+    """Return the enabled editor plugins and the autoload names.
+
+    Raises ParseError rather than guessing. A guard that cannot read the file
+    must not report it clean.
+    """
+    section = ""
+    plugins: list[str] | None = None
+    autoloads: list[str] = []
+
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith(";"):
+            continue
+
+        matched = SECTION_RE.match(line)
+        if matched:
+            section = matched.group(1)
+            continue
+
+        if section == "editor_plugins" and line.startswith("enabled"):
+            packed = PACKED_RE.match(line)
+            if not packed:
+                raise ParseError(f"cannot read the enabled plugin list: {line}")
+            plugins = QUOTED_RE.findall(packed.group(1))
+            continue
+
+        if section == "autoload":
+            key = KEY_RE.match(line)
+            if not key:
+                raise ParseError(f"cannot read the autoload entry: {line}")
+            autoloads.append(key.group(1))
+
+    if plugins is None:
+        raise ParseError("no [editor_plugins] enabled list found")
+    return plugins, autoloads
+
+
+def check(text: str) -> list[str]:
+    """Return one line per problem. Empty means the file is clean."""
+    try:
+        plugins, autoloads = parse(text)
+    except ParseError as exc:
+        return [str(exc)]
+
+    problems = []
+    for plugin in plugins:
+        if plugin not in ALLOWED_PLUGINS:
+            problems.append(
+                f"{plugin} is enabled; it is local tooling, not part of this repo"
+            )
+    for allowed in ALLOWED_PLUGINS:
+        if allowed not in plugins:
+            problems.append(
+                f"{allowed} is not enabled; the plugin has to load for anyone cloning"
+            )
+    for name in autoloads:
+        if name not in ALLOWED_AUTOLOADS:
+            problems.append(f"autoload {name} is registered; HammerForge ships none")
+    return problems
+
+
+# ---------------------------------------------------------------------------
+# Selftest
+# ---------------------------------------------------------------------------
+
+CLEAN = """config_version=5
+
+[application]
+
+config/name="HammerForge"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/hammerforge/plugin.cfg")
+
+[physics]
+
+3d/default_gravity=9.8
+"""
+
+# The exact shape this repository shipped before issue #277.
+LEAKED_BRIDGE = """config_version=5
+
+[autoload]
+
+MCPRuntimeProbe="*uid://bsg12huaf1u5i"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/hammerforge/plugin.cfg", "res://addons/godot_mcp/plugin.cfg")
+"""
+
+CASES: list[tuple[str, str, bool]] = [
+    ("clean", CLEAN, True),
+    ("the shape #277 was about", LEAKED_BRIDGE, False),
+    (
+        "a local bridge enabled",
+        CLEAN.replace(
+            'PackedStringArray("res://addons/hammerforge/plugin.cfg")',
+            'PackedStringArray("res://addons/hammerforge/plugin.cfg", "res://addons/didi/plugin.cfg")',
+        ),
+        False,
+    ),
+    (
+        "hammerforge switched off",
+        CLEAN.replace('"res://addons/hammerforge/plugin.cfg"', ""),
+        False,
+    ),
+    (
+        "an autoload with nothing else wrong",
+        CLEAN + '\n[autoload]\n\nSomeProbe="*res://addons/thing/probe.gd"\n',
+        False,
+    ),
+    (
+        "an empty autoload section",
+        CLEAN + "\n[autoload]\n",
+        True,
+    ),
+    (
+        "an enabled list this guard cannot read",
+        CLEAN.replace(
+            'enabled=PackedStringArray("res://addons/hammerforge/plugin.cfg")',
+            "enabled=[something new]",
+        ),
+        False,
+    ),
+    ("no editor_plugins section at all", "config_version=5\n", False),
+    (
+        "a plugin name that merely contains the allowed one",
+        CLEAN.replace(
+            '"res://addons/hammerforge/plugin.cfg"',
+            '"res://addons/hammerforge_extras/plugin.cfg"',
+        ),
+        False,
+    ),
+]
+
+
+def selftest() -> int:
+    failures = 0
+    for name, text, should_pass in CASES:
+        problems = check(text)
+        passed = not problems
+        if passed != should_pass:
+            want = "clean" if should_pass else "rejected"
+            print(
+                f"selftest: {name} should have been {want}, got {problems or 'clean'}"
+            )
+            failures += 1
+    if failures:
+        print(f"selftest: {failures} of {len(CASES)} cases wrong")
+        return 1
+    print(f"selftest: {len(CASES)} cases correct")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project", nargs="?", default="project.godot")
+    parser.add_argument(
+        "--selftest",
+        action="store_true",
+        help="check the detector still catches each way this goes wrong",
+    )
+    args = parser.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    try:
+        with open(args.project, encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError as exc:
+        print(f"{args.project}: {exc}")
+        return 1
+
+    problems = check(text)
+    if not problems:
+        return 0
+    for problem in problems:
+        print(f"{args.project}: {problem}")
+    print("Keep a local enable out of the commit. See DEVELOPMENT.md.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`project.godot` is tracked and the Godot editor rewrites it the moment anyone enables a plugin. So a locally installed editor bridge leaves a dirty tracked file, and the enable rides into the next `git add -A`. That is exactly how `addons/godot_mcp` and its `MCPRuntimeProbe` autoload got in and stayed enabled for months, which was #277.

`tools/check_project_settings.py` asserts the enabled plugin list is HammerForge and nothing else, and that no autoload is registered. It runs in CI beside the other guards, selftest first.

`override.cfg` was the obvious engine-side fix and it does not work. On 4.7 an `editor_plugins/enabled` written there does not enable the plugin in the editor, while the same value in `project.godot` does. I checked that against 4.7.stable with a control rather than trusting the documentation, which does not cover it.

## Before / After Behavior

- Before: the pull request template asked a human to confirm `project.godot` carried no locally enabled plugin. Nothing checked it. The file also stays dirty for anyone running a local bridge, with no documented way to quiet it.
- After: CI fails the branch and names the offending entry. DEVELOPMENT.md carries the `git update-index --skip-worktree` recipe, the pull it breaks, and how to get out of that.

## Verification

- `--selftest` covers nine cases: the current clean file, the exact shape shipped before #277, a local bridge enabled, HammerForge switched off, a stray autoload, an empty `[autoload]` section, an enabled list the guard cannot parse, a missing `[editor_plugins]` section, and a plugin path that merely contains the allowed one.
- Pointed the guard at the real `project.godot` mutated back to this morning's state and it exited 1 naming `res://addons/didi/plugin.cfg`; restored, it exits 0.
- override.cfg: scratch 4.7 project with a probe `EditorPlugin` that prints on `_enter_tree`. Enabled via `override.cfg`, the marker never appears and `project.godot` is not rewritten. The same entry moved into `project.godot` prints it.
- skip-worktree: synthetic origin plus two clones. `git status` stays clean over a local edit and `git commit -a` reports nothing to commit; a pull carrying an upstream change to the same file aborts; the documented unset, checkout, pull, re-enable, re-set sequence recovers and leaves the tree clean.
- `ruff check`, `ruff format --check`, `actionlint`, `gdformat --check`, `gdlint` all clean. No GDScript or test file is touched.

## Related Issue

None. Follows on from #277.

## Checks

- [x] `gdformat --check addons/hammerforge/ tests/` passes
- [x] `gdlint addons/hammerforge/` passes
- [ ] `godot --headless -s res://addons/gut/gut_cmdln.gd --path .` passes (not run locally; no `.gd` or `tests/` file is touched, CI runs it)
- [x] Docs updated together where behavior changed (DEVELOPMENT, CONTRIBUTING, `[Unreleased]` in CHANGELOG)
- [x] `git diff --check` is clean and relative Markdown links resolve
- [x] No bridge tokens, `user://` settings, verification logs, editor screenshots, or local client overrides committed
- [x] No local editor bridge addon committed, and `project.godot` carries no locally enabled plugin