### PR TITLE
Copy state into undo snapshots and convert typed arrays on restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -579,6 +579,33 @@ The format is based on Keep a Changelog, and this project follows semantic versi
     copy, undo, and what survives a state restore.
 
 ### Fixed
+- **Undo snapshots no longer share mutable state with the live level** (#282).
+  `HFStateSystem` handed the live containers to the snapshot on one side of two
+  pairs: capture aliased `MaterialManager.materials`, and restore handed the
+  snapshot's own `face_selection` dictionary back as the live selection. Each
+  pair was already guarded on its other side, so the shape was easy to miss. A
+  palette edit after a capture wrote into the snapshot, and undo could not put
+  back the material it was taken to protect. Both sides now copy.
+- **Loading a `.hflevel` restores the material palette again** (#283).
+  `LevelRoot.set_materials()` assigned an untyped `Array` into the
+  `Array[Material]` the manager exports. Godot 4 rejects that, so the write was
+  skipped and nothing checked the result: the editor kept whatever palette it
+  already had while the saved one was dropped, and every face `material_idx`
+  from the file then indexed into the wrong palette. The array is converted
+  first. Slot positions are preserved and a slot that does not hold a Material
+  comes back as null with a warning naming the index, because compacting would
+  repoint every face above it.
+- **Terrain slot paths survive a load** (#284). The same untyped-into-typed
+  assignment in `HFPaintSystem.restore_paint_layers()` dropped
+  `terrain_slot_paths`, `terrain_slot_uv_scales` and `terrain_slot_tints` on
+  every `.hflevel` load. `_ensure_terrain_slots()` ran straight after and
+  refilled the four slots with defaults, so a loaded layer came back pointing at
+  no textures with nothing to say why. Checked against 4.7.stable: the engine
+  rejects the assignment for all three, not only the paths.
+  - **Coverage** (`tests/test_state_snapshot_isolation.gd`): a palette edit after
+    a capture, a selection edit after a restore, an untyped palette replacing a
+    live one, an empty payload clearing it, a junk slot kept in place, and a
+    terrain slot path round trip. All six fail on the previous code.
 - **A prefab could wire its copy's outputs to the entities it was built from.**
   `HFPrefab.instantiate()` remapped I/O by turning each old node name into the new
   one and then looking that name back up. The lookup resolves an authored

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,344 tests across 171 test scripts (3,337 passing plus seven intentional no-assert safety tests; 16,942 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,350 tests across 172 test scripts (3,343 passing plus seven intentional no-assert safety tests; 16,956 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,344 tests** across **171 scripts** (**3,337 passing** plus seven intentional no-assert safety tests; **16,942 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,350 tests** across **172 scripts** (**3,343 passing** plus seven intentional no-assert safety tests; **16,956 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3337%20passing-brightgreen" alt="3337 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3343%20passing-brightgreen" alt="3343 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,344 tests across 171 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,350 tests across 172 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -2470,10 +2470,33 @@ func get_materials() -> Array:
 	return material_manager.materials if material_manager else []
 
 
+## Replaces the palette. Accepts an untyped Array, which is what a decoded
+## .hflevel payload is, and converts it to the Array[Material] the manager
+## exports. Assigning an untyped array straight into that property is rejected
+## by the engine and the write is silently skipped, so the conversion is the
+## whole point of this function.
+##
+## Slot positions are preserved. A slot that does not hold a Material comes back
+## as null rather than being dropped, because face material_idx values are plain
+## indices into this array and compacting it would repoint every face above the
+## bad slot.
 func set_materials(materials: Array) -> void:
 	if not material_manager:
 		_setup_material_manager()
-	material_manager.materials = materials.duplicate()
+	var typed: Array[Material] = []
+	typed.resize(materials.size())
+	for i in materials.size():
+		var entry = materials[i]
+		if entry == null or entry is Material:
+			typed[i] = entry
+		else:
+			HFLog.warn(
+				(
+					"set_materials: palette slot %d is a %s, not a Material. Slot kept empty."
+					% [i, type_string(typeof(entry))]
+				)
+			)
+	material_manager.materials = typed
 	_refresh_brush_previews()
 
 

--- a/addons/hammerforge/systems/hf_paint_system.gd
+++ b/addons/hammerforge/systems/hf_paint_system.gd
@@ -465,15 +465,28 @@ func restore_paint_layers(data: Array, active_index: int) -> void:
 		var wall_heights = entry.get("wall_heights", [])
 		if wall_heights is Array:
 			layer.restore_wall_height_entries(wall_heights)
+		# These three properties are typed arrays. A decoded .hflevel payload is
+		# untyped, and the engine rejects an untyped array assigned into a typed
+		# property, so each one has to be converted first or the slot data is
+		# dropped and _ensure_terrain_slots() refills it with defaults.
 		var slot_paths = entry.get("terrain_slot_paths", [])
 		if slot_paths is Array:
-			layer.terrain_slot_paths = slot_paths.duplicate()
+			var typed_paths: Array[String] = []
+			for p in slot_paths:
+				typed_paths.append(str(p))
+			layer.terrain_slot_paths = typed_paths
 		var slot_scales = entry.get("terrain_slot_uv_scales", [])
 		if slot_scales is Array:
-			layer.terrain_slot_uv_scales = slot_scales.duplicate()
+			var typed_scales: Array[float] = []
+			for s in slot_scales:
+				typed_scales.append(float(s) if s is float or s is int else 1.0)
+			layer.terrain_slot_uv_scales = typed_scales
 		var slot_tints = entry.get("terrain_slot_tints", [])
 		if slot_tints is Array:
-			layer.terrain_slot_tints = slot_tints.duplicate()
+			var typed_tints: Array[Color] = []
+			for t in slot_tints:
+				typed_tints.append(t if t is Color else Color(0.5, 0.5, 0.5))
+			layer.terrain_slot_tints = typed_tints
 		layer._ensure_terrain_slots()
 		var hm_b64 = str(entry.get("heightmap_b64", ""))
 		if hm_b64 != "":

--- a/addons/hammerforge/systems/hf_state_system.gd
+++ b/addons/hammerforge/systems/hf_state_system.gd
@@ -93,7 +93,9 @@ func capture_state(include_transient: bool = true) -> Dictionary:
 	if include_transient:
 		state["face_selection"] = root.face_selection.duplicate(true)
 	if root.material_manager:
-		state["materials"] = root.material_manager.materials
+		# A copy, not the live array. Without this every later palette edit
+		# writes straight into the snapshot that was taken to protect it.
+		state["materials"] = root.material_manager.materials.duplicate()
 	for node in root._iter_pick_nodes():
 		var info = root.get_brush_info_from_node(node)
 		if info.is_empty():
@@ -161,7 +163,9 @@ func restore_state(state: Dictionary) -> void:
 	if state.has("materials"):
 		root.set_materials(state.get("materials", []))
 	if state.has("face_selection"):
-		root.face_selection = state.get("face_selection", {})
+		# Deep copy on the way out too, so later selection edits do not write
+		# back into the snapshot that restored them.
+		root.face_selection = state.get("face_selection", {}).duplicate(true)
 		root._apply_face_selection()
 	else:
 		root.face_selection.clear()

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,344 tests across 171 scripts**: **3,337 passing tests**, seven intentional no-assert safety tests, and **16,942 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,350 tests across 172 scripts**: **3,343 passing tests**, seven intentional no-assert safety tests, and **16,956 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_state_snapshot_isolation.gd
+++ b/tests/test_state_snapshot_isolation.gd
@@ -1,0 +1,96 @@
+extends GutTest
+
+## An undo snapshot is meant to be a frozen copy of the level. These tests
+## mutate the live level after a capture and after a restore and assert the
+## snapshot did not move with it, and that a decoded (untyped) payload still
+## lands in the typed properties it is meant to fill.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+
+var root: LevelRoot
+
+
+func before_each():
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func _make_material(mat_name: String) -> StandardMaterial3D:
+	var mat := StandardMaterial3D.new()
+	mat.resource_name = mat_name
+	return mat
+
+
+# -- Snapshot isolation ------------------------------------------------------
+
+
+func test_palette_edit_after_capture_does_not_reach_the_snapshot():
+	root.add_material_to_palette(_make_material("A"))
+	var snap = root.capture_state(true)
+
+	root.remove_material_from_palette(0)
+	assert_eq(root.get_materials().size(), 0, "Palette should be empty after the removal")
+
+	root.restore_state(snap)
+	assert_eq(root.get_materials().size(), 1, "Restore should bring the material back")
+	assert_eq(root.get_material_names()[0], "A", "and it should be the one that was captured")
+
+
+func test_selection_edit_after_restore_does_not_reach_the_snapshot():
+	root.face_selection = {"brush_a": [0, 1]}
+	var snap = root.capture_state(true)
+	root.restore_state(snap)
+
+	root.face_selection["brush_a"] = [3]
+
+	var snapped: Dictionary = snap["face_selection"]
+	assert_eq(snapped["brush_a"], [0, 1], "The snapshot should still hold the captured selection")
+
+
+# -- Typed property restores -------------------------------------------------
+
+
+func test_set_materials_accepts_an_untyped_array():
+	root.add_material_to_palette(_make_material("stale"))
+
+	# What a decoded .hflevel payload actually is: a plain untyped Array.
+	var loaded: Array = [_make_material("loaded_a"), _make_material("loaded_b")]
+	root.set_materials(loaded)
+
+	assert_eq(root.get_materials().size(), 2, "The loaded palette should replace the live one")
+	assert_eq(root.get_material_names(), ["loaded_a", "loaded_b"], "with the loaded names")
+
+
+func test_set_materials_clears_the_palette_for_an_empty_untyped_array():
+	root.add_material_to_palette(_make_material("stale"))
+	root.set_materials([])
+	assert_eq(root.get_materials().size(), 0, "An empty payload should clear the palette")
+
+
+func test_set_materials_keeps_a_bad_slot_as_null_rather_than_compacting():
+	root.set_materials([_make_material("a"), 7, _make_material("c")])
+
+	var palette := root.get_materials()
+	assert_eq(palette.size(), 3, "Slot positions must survive so face indices stay valid")
+	assert_null(palette[1], "The junk slot should come back empty")
+	assert_eq(palette[2].resource_name, "c", "and the slot above it should keep its index")
+
+
+func test_restore_paint_layers_keeps_terrain_slot_paths_from_an_untyped_payload():
+	assert_not_null(root.paint_system, "LevelRoot should have built its paint system")
+	var payload: Array = [
+		{
+			"id": "layer_0",
+			"terrain_slot_paths": ["res://grass.tres", "", "", ""],
+			"terrain_slot_uv_scales": [2.0, 1.0, 1.0, 1.0],
+			"terrain_slot_tints": [Color.RED, Color.WHITE, Color.WHITE, Color.WHITE],
+		}
+	]
+	root.paint_system.restore_paint_layers(payload, 0)
+
+	var layer = root.paint_layers.get_active_layer()
+	assert_eq(layer.terrain_slot_paths[0], "res://grass.tres", "Slot path should survive the load")
+	assert_eq(layer.terrain_slot_uv_scales[0], 2.0, "Slot uv scale should survive the load")
+	assert_eq(layer.terrain_slot_tints[0], Color.RED, "Slot tint should survive the load")


### PR DESCRIPTION
Three bugs in the same save, load and undo path.

Fixes #282
Fixes #283
Fixes #284

- `HFStateSystem` capture handed the live `MaterialManager.materials` array to the snapshot, and restore handed the snapshot's own `face_selection` dictionary back as the live selection. Each pair was guarded on exactly one side. Both sides copy now.
- `LevelRoot.set_materials()` assigned an untyped Array into the `Array[Material]` export. The engine rejects that and the write was skipped in silence, so loading a level never replaced the palette. It converts first, preserves slot positions, and warns on a slot that is not a Material rather than compacting the array under every face index.
- `HFPaintSystem.restore_paint_layers()` had the same assignment for `terrain_slot_paths`, `terrain_slot_uv_scales` and `terrain_slot_tints`. Checked on 4.7.stable: all three are rejected, not just the paths.

New `tests/test_state_snapshot_isolation.gd`, six tests, all six fail on main. Full suite 3298 passing, 0 failing.