### PR TITLE
Remap face material indices on palette removal and stop the prototype set doubling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -606,6 +606,26 @@ The format is based on Keep a Changelog, and this project follows semantic versi
     a capture, a selection edit after a restore, an untyped palette replacing a
     live one, an empty payload clearing it, a junk slot kept in place, and a
     terrain slot path round trip. All six fail on the previous code.
+- **Removing a palette material no longer repaints the brushes above it**
+  (#285). `FaceData.material_idx` is a plain index into
+  `MaterialManager.materials`, and removal compacted that array without touching
+  the faces pointing into it, so deleting the first material repainted every
+  brush that used a later one and any face on the last slot pointed past the
+  end. `remove_material_from_palette()` now shifts every index above the removed
+  slot down and sets faces that used the removed slot to unset, walking the same
+  managed-brush traversal that identity work uses so committed cutters are
+  covered too. An out-of-range index is a no-op rather than a signal.
+- **Refresh Prototypes is a refresh again** (#298). The button appended all 150
+  prototype materials every time it was pressed, so a second click gave a
+  300-entry palette with every name twice, and the palette is saved with the
+  level. `HFPrototypeTextures.load_all_into()` skips a pattern/colour already in
+  the palette, keyed on `resource_path`, and returns the number actually added,
+  so a second call returns 0. `LevelRoot.add_prototype_materials()` calls it
+  rather than keeping a second copy of the same loop.
+  - **Coverage** (`tests/test_material_palette_integrity.gd`): a face following
+    its material down a slot, a face whose material was removed, a face below the
+    removal, an out-of-range index, a second prototype load adding nothing,
+    unique names after two loads, and a hand-made material keeping slot 0.
 - **A prefab could wire its copy's outputs to the entities it was built from.**
   `HFPrefab.instantiate()` remapped I/O by turning each old node name into the new
   one and then looking that name back up. The lookup resolves an authored

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,350 tests across 172 test scripts (3,343 passing plus seven intentional no-assert safety tests; 16,956 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,357 tests across 173 test scripts (3,350 passing plus seven intentional no-assert safety tests; 17,133 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,350 tests** across **172 scripts** (**3,343 passing** plus seven intentional no-assert safety tests; **16,956 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,357 tests** across **173 scripts** (**3,350 passing** plus seven intentional no-assert safety tests; **17,133 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3343%20passing-brightgreen" alt="3343 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3350%20passing-brightgreen" alt="3350 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,350 tests across 172 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,357 tests across 173 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/hf_prototype_textures.gd
+++ b/addons/hammerforge/hf_prototype_textures.gd
@@ -85,13 +85,25 @@ static func create_material(pattern: String, color: String) -> StandardMaterial3
 
 ## Batch-loads every prototype texture as a material into [param manager].
 ## Returns the number of materials added.
+## A pattern/colour pair already in the palette is skipped, so calling this
+## twice leaves the palette at 150 and returns 0 the second time. The materials
+## come from ResourceLoader, so their resource_path is a stable key.
 static func load_all_into(manager: MaterialManager) -> int:
+	if manager == null:
+		return 0
+	var existing: Dictionary = {}
+	for held in manager.materials:
+		if held != null and held.resource_path != "":
+			existing[held.resource_path] = true
 	var count := 0
 	for pattern in PATTERNS:
 		for color in COLORS:
+			if existing.has(get_material_path(pattern, color)):
+				continue
 			var mat := create_material(pattern, color)
 			if mat:
 				manager.add_material(mat)
+				existing[mat.resource_path] = true
 				count += 1
 	return count
 

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -2509,27 +2509,52 @@ func add_material_to_palette(material: Material) -> int:
 	return idx
 
 
+## Removes a palette slot and repoints every face that referenced a later one.
+##
+## FaceData.material_idx is a plain index into MaterialManager.materials, so
+## compacting the array without a remap repaints every brush that used a slot
+## above the removed one. Faces that used the removed slot fall back to unset.
 func remove_material_from_palette(index: int) -> void:
 	if not material_manager:
 		return
+	if index < 0 or index >= material_manager.materials.size():
+		return
 	material_manager.remove_material(index)
+	_remap_face_material_indices(index)
 	_refresh_brush_previews()
 	material_list_changed.emit()
 
 
+## Shifts face material indices down over a removed palette slot. Faces that
+## pointed at the removed slot become -1, which is the unset value.
+func _remap_face_material_indices(removed_index: int) -> void:
+	for node in _iter_managed_brush_nodes():
+		var brush := node as DraftBrush
+		if not brush or not is_instance_valid(brush):
+			continue
+		var changed := false
+		for face in brush.faces:
+			if face == null:
+				continue
+			if face.material_idx == removed_index:
+				face.material_idx = -1
+				changed = true
+			elif face.material_idx > removed_index:
+				face.material_idx -= 1
+				changed = true
+		if changed:
+			tag_brush_dirty(brush.brush_id)
+
+
 ## Batch-loads all built-in prototype textures into the material palette.
 ## Uses signal batching and a single preview refresh for performance.
+## Returns the number actually added, so a second call returns 0 rather than
+## putting a second copy of all 150 into the palette.
 func add_prototype_materials() -> int:
 	if not material_manager:
 		_setup_material_manager()
 	begin_signal_batch()
-	var count := 0
-	for pattern in HFPrototypeTextures.PATTERNS:
-		for color in HFPrototypeTextures.COLORS:
-			var mat = HFPrototypeTextures.create_material(pattern, color)
-			if mat:
-				material_manager.add_material(mat)
-				count += 1
+	var count := HFPrototypeTextures.load_all_into(material_manager)
 	_refresh_brush_previews()
 	end_signal_batch()
 	material_list_changed.emit()

--- a/docs/HammerForge_Texture_Materials.md
+++ b/docs/HammerForge_Texture_Materials.md
@@ -160,6 +160,10 @@ When a brush is carved (boolean subtracted), the resulting slice pieces inherit 
 
 ## Suggested Testing
 - Click Refresh Prototypes and confirm 150 materials appear in the browser grid with thumbnails.
+- Click it a second time and confirm the palette stays at 150. A pattern/colour already in the
+  palette is skipped, so the button is a refresh rather than a second helping.
+- Remove a material that is not the last one and confirm brushes using a later slot keep the
+  material they had. Faces that used the removed slot fall back to unset.
 - Use pattern filter, color swatches, and search bar to narrow the grid. Verify counts in the status label.
 - Switch between Prototypes / Palette / Favorites views.
 - Right-click a thumbnail → Toggle Favorite. Switch to Favorites view and confirm it appears.

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,350 tests across 172 scripts**: **3,343 passing tests**, seven intentional no-assert safety tests, and **16,956 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,357 tests across 173 scripts**: **3,350 passing tests**, seven intentional no-assert safety tests, and **17,133 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_material_palette_integrity.gd
+++ b/tests/test_material_palette_integrity.gd
@@ -1,0 +1,118 @@
+extends GutTest
+
+## FaceData.material_idx is a plain index into MaterialManager.materials, so
+## anything that changes the shape of that array has to answer for the faces
+## pointing into it. These tests cover removal and the prototype batch load.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+const HFPrototypeTexturesType = preload("res://addons/hammerforge/hf_prototype_textures.gd")
+
+var root: LevelRoot
+
+
+func before_each():
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	# The editor seeds a fresh root with the prototype set. Start from empty so
+	# each test names its own palette slots.
+	root.material_manager.clear()
+
+
+func _make_material(mat_name: String) -> StandardMaterial3D:
+	var mat := StandardMaterial3D.new()
+	mat.resource_name = mat_name
+	return mat
+
+
+func _make_brush(brush_id: String) -> DraftBrush:
+	return (
+		root.create_brush_from_info({"size": Vector3(8, 8, 8), "brush_id": brush_id}) as DraftBrush
+	)
+
+
+# -- Removal remaps the faces above the removed slot --------------------------
+
+
+func test_removing_a_slot_keeps_faces_on_the_material_they_had():
+	root.add_material_to_palette(_make_material("A"))
+	root.add_material_to_palette(_make_material("B"))
+	var brush := _make_brush("b1")
+	root.assign_material_to_whole_brushes(1, ["b1"])
+
+	root.remove_material_from_palette(0)
+
+	assert_eq(root.get_material_names(), ["B"], "B should be the only slot left")
+	for face in brush.faces:
+		assert_eq(face.material_idx, 0, "Faces on B should follow it down to slot 0")
+
+
+func test_removing_the_slot_a_face_uses_leaves_the_face_unset():
+	root.add_material_to_palette(_make_material("A"))
+	var brush := _make_brush("b1")
+	root.assign_material_to_whole_brushes(0, ["b1"])
+
+	root.remove_material_from_palette(0)
+
+	for face in brush.faces:
+		assert_eq(face.material_idx, -1, "A face whose material is gone should be unset")
+
+
+func test_removing_a_slot_leaves_faces_below_it_alone():
+	root.add_material_to_palette(_make_material("A"))
+	root.add_material_to_palette(_make_material("B"))
+	root.add_material_to_palette(_make_material("C"))
+	var brush := _make_brush("b1")
+	root.assign_material_to_whole_brushes(0, ["b1"])
+
+	root.remove_material_from_palette(2)
+
+	for face in brush.faces:
+		assert_eq(face.material_idx, 0, "A face below the removed slot should not move")
+
+
+func test_removing_an_out_of_range_index_changes_nothing():
+	root.add_material_to_palette(_make_material("A"))
+	var brush := _make_brush("b1")
+	root.assign_material_to_whole_brushes(0, ["b1"])
+
+	root.remove_material_from_palette(5)
+	root.remove_material_from_palette(-1)
+
+	assert_eq(root.get_materials().size(), 1, "The palette should be untouched")
+	assert_eq(brush.faces[0].material_idx, 0, "and so should the face index")
+
+
+# -- The prototype batch is not additive --------------------------------------
+
+
+func test_loading_the_prototypes_twice_does_not_double_the_palette():
+	var first := root.add_prototype_materials()
+	var after_first := root.get_materials().size()
+	assert_gt(first, 0, "The first load should add the prototype set")
+	assert_eq(after_first, first, "and nothing else should be in the palette")
+
+	var second := root.add_prototype_materials()
+
+	assert_eq(second, 0, "The second load should add nothing")
+	assert_eq(root.get_materials().size(), after_first, "and the palette should not grow")
+
+
+func test_prototype_names_are_unique_after_two_loads():
+	root.add_prototype_materials()
+	root.add_prototype_materials()
+
+	var names := root.get_material_names()
+	var seen: Dictionary = {}
+	for n in names:
+		assert_false(seen.has(n), "Duplicate palette name after a second load: %s" % n)
+		seen[n] = true
+
+
+func test_load_all_into_keeps_materials_that_were_already_there():
+	root.add_material_to_palette(_make_material("hand_made"))
+	var added := HFPrototypeTexturesType.load_all_into(root.material_manager)
+
+	assert_gt(added, 0, "The prototypes should still load alongside a hand made material")
+	assert_eq(root.get_material_names()[0], "hand_made", "and the existing slot 0 should not move")


### PR DESCRIPTION
Two bugs in the material palette.

Fixes #285
Fixes #298

- `remove_material_from_palette()` compacted `MaterialManager.materials` and left every `FaceData.material_idx` where it was, so deleting the first material repainted every brush that used a later one. It now shifts indices above the removed slot down and unsets faces that used the removed slot, over `_iter_managed_brush_nodes()` so committed cutters are covered. An out of range index is a no-op.
- `Refresh Prototypes` appended all 150 materials on every press, so a second click gave a 300-entry palette with every name twice, saved with the level. `HFPrototypeTextures.load_all_into()` skips a pattern/colour already in the palette and returns what it actually added. `LevelRoot.add_prototype_materials()` calls it instead of keeping a second copy of the loop.

New `tests/test_material_palette_integrity.gd`, 7 tests. Four fail on main; the other three are guards that the remap does not over-reach. Full suite 3299 passing, 0 failing.