### PR TITLE
Validate an array before tearing down the copies, and cap it on every path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -626,6 +626,31 @@ The format is based on Keep a Changelog, and this project follows semantic versi
     its material down a slot, a face whose material was removed, a face below the
     removal, an out-of-range index, a second prototype load adding nothing,
     unique names after two loads, and a hand-made material keeping slot 0.
+- **A bad array count no longer deletes the array** (#299). `regenerate()` called
+  `clear_instances()` before asking whether the new numbers produced anything, so
+  typing 0 into an array's count threw the copies away and then reported failure.
+  `update_duplicate_array()` read that failure as "the copies are gone, so the
+  record is dead" and erased the record, leaving the array unreachable: a good
+  count afterwards returned false, and so did detach. The check now runs before
+  the teardown, on both sides, so a count the layout cannot use is a no-op with
+  the copies still standing and the record still there to correct. The erase is
+  kept for the case it was written for, which is every source brush deleted.
+- **The 256-copy ceiling holds on every path** (#300). `can_generate()` was
+  called only from the dock's linear-create button, so `create_grid_array()` and
+  `update_duplicate_array()` walked straight past it: a 12-cubed grid built 1728
+  brushes and reported success, and an array created inside the cap could be
+  raised to any size afterwards. The check now sits in `generate()`,
+  `generate_radial()`, `generate_grid()` and `regenerate()`, and in the three
+  `create_*` methods on `HFBrushSystem` ahead of `_new_duplicator_for()` so a
+  refusal cannot take the array the user already had with it. The dock keeps its
+  early check for the message it shows before the user commits.
+  - `HFDuplicator.grid_copy_count()` and `requested_copy_count()` work out how
+    many copies a layout would make without building it, which is what lets the
+    refusal land first. Both agree with `placements_for()`, and a test pins that.
+  - **Coverage** (`tests/test_array_limits.gd`): a refused update leaving copies,
+    record, correction and detach intact, an update refused at the cap, a grid and
+    a radial array over the cap, a grid under it still building, a refused create
+    not disturbing the existing array, and the copy count matching the placements.
 - **A prefab could wire its copy's outputs to the entities it was built from.**
   `HFPrefab.instantiate()` remapped I/O by turning each old node name into the new
   one and then looking that name back up. The lookup resolves an authored

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,357 tests across 173 test scripts (3,350 passing plus seven intentional no-assert safety tests; 17,133 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,366 tests across 174 test scripts (3,359 passing plus seven intentional no-assert safety tests; 17,155 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,357 tests** across **173 scripts** (**3,350 passing** plus seven intentional no-assert safety tests; **17,133 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,366 tests** across **174 scripts** (**3,359 passing** plus seven intentional no-assert safety tests; **17,155 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3350%20passing-brightgreen" alt="3350 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3359%20passing-brightgreen" alt="3359 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,357 tests across 173 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,366 tests across 174 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/hf_duplicator.gd
+++ b/addons/hammerforge/hf_duplicator.gd
@@ -130,6 +130,22 @@ static func can_generate(copy_count: int, source_count: int) -> HFOpResult:
 	return HFOpResult.success("%d copies" % copy_count)
 
 
+## How many copies a grid of these counts makes. The counts include the source
+## cell on each axis, so the source itself is not a copy.
+static func grid_copy_count(p_counts: Vector3i) -> int:
+	var counts := Vector3i(maxi(1, p_counts.x), maxi(1, p_counts.y), maxi(1, p_counts.z))
+	return counts.x * counts.y * counts.z - 1
+
+
+## How many copies a rebuild with these parameters would make, worked out
+## without building anything. This is what lets a refusal land before the old
+## copies are torn down.
+func requested_copy_count(p_mode: int, params: Dictionary) -> int:
+	if p_mode == ArrayMode.GRID:
+		return grid_copy_count(params.get("counts", grid_counts))
+	return int(params.get("count", count))
+
+
 var duplicator_id := ""
 var source_brush_ids: PackedStringArray = PackedStringArray()
 var instance_groups: Array = []  # Array of PackedStringArray, one per copy
@@ -157,7 +173,7 @@ func _init() -> void:
 ## Create N copies of the source brushes with progressive offset.
 ## brush_system is untyped to avoid circular preload.
 func generate(brush_system, p_count: int, p_offset: Vector3) -> bool:
-	if source_brush_ids.is_empty() or p_count < 1:
+	if not can_generate(p_count, source_brush_ids.size()).ok:
 		return false
 	count = p_count
 	offset = p_offset
@@ -206,7 +222,7 @@ func generate_radial(
 	p_pivot: Vector3,
 	p_rise: float = 0.0
 ) -> bool:
-	if source_brush_ids.is_empty() or p_count < 1:
+	if not can_generate(p_count, source_brush_ids.size()).ok:
 		return false
 	mode = ArrayMode.RADIAL
 	count = p_count
@@ -237,11 +253,9 @@ func generate_radial(
 ## Create a lattice of copies. `p_counts` includes the source cell on each axis,
 ## so 2x1x2 produces three copies around one original.
 func generate_grid(brush_system, p_counts: Vector3i, p_spacing: Vector3) -> bool:
-	if source_brush_ids.is_empty():
+	if not can_generate(grid_copy_count(p_counts), source_brush_ids.size()).ok:
 		return false
 	var counts := Vector3i(maxi(1, p_counts.x), maxi(1, p_counts.y), maxi(1, p_counts.z))
-	if counts.x * counts.y * counts.z <= 1:
-		return false
 	mode = ArrayMode.GRID
 	grid_counts = counts
 	grid_spacing = p_spacing
@@ -321,6 +335,11 @@ func settings() -> Dictionary:
 ## stays an editor for it.
 func regenerate(brush_system, p_mode: int, params: Dictionary) -> bool:
 	if source_brush_ids.is_empty():
+		return false
+	# Asked before anything is torn down. A count the layout cannot use is a
+	# refusal with the existing copies still standing, not a demolition
+	# followed by the news that nothing could be built in their place.
+	if not can_generate(requested_copy_count(p_mode, params), source_brush_ids.size()).ok:
 		return false
 	clear_instances(brush_system)
 	if not _lay_out(brush_system, p_mode, params):

--- a/addons/hammerforge/systems/hf_brush_system.gd
+++ b/addons/hammerforge/systems/hf_brush_system.gd
@@ -2177,7 +2177,10 @@ var _duplicators: Dictionary = {}  # duplicator_id -> HFDuplicator
 func create_duplicate_array(
 	brush_ids: PackedStringArray, p_count: int, p_offset: Vector3
 ) -> Variant:
-	if brush_ids.is_empty() or p_count < 1:
+	# Asked before _new_duplicator_for, which retires whatever array already owns
+	# these sources and takes its copies with it. A refusal must not cost the user
+	# the array they already had.
+	if not HFDuplicator.can_generate(p_count, brush_ids.size()).ok:
 		return null
 	var dup := _new_duplicator_for(brush_ids)
 	if not dup.generate(self, p_count, p_offset):
@@ -2196,7 +2199,7 @@ func create_radial_array(
 	pivot: Vector3,
 	rise: float = 0.0
 ) -> Variant:
-	if brush_ids.is_empty() or p_count < 1:
+	if not HFDuplicator.can_generate(p_count, brush_ids.size()).ok:
 		return null
 	var dup := _new_duplicator_for(brush_ids)
 	if not dup.generate_radial(self, p_count, axis_index, step_degrees, pivot, rise):
@@ -2207,7 +2210,7 @@ func create_radial_array(
 
 ## Lattice of copies. `counts` includes the source cell on each axis.
 func create_grid_array(brush_ids: PackedStringArray, counts: Vector3i, spacing: Vector3) -> Variant:
-	if brush_ids.is_empty():
+	if not HFDuplicator.can_generate(HFDuplicator.grid_copy_count(counts), brush_ids.size()).ok:
 		return null
 	var dup := _new_duplicator_for(brush_ids)
 	if not dup.generate_grid(self, counts, spacing):
@@ -2248,9 +2251,19 @@ func update_duplicate_array(duplicator_id: String, mode: int, params: Dictionary
 	if not _duplicators.has(duplicator_id):
 		return false
 	var dup: HFDuplicator = _duplicators[duplicator_id]
+	# A layout that cannot be built is refused with the array untouched, so the
+	# user can correct the number they typed. Nothing is torn down and the record
+	# stays reachable.
+	if not (
+		HFDuplicator
+		. can_generate(dup.requested_copy_count(mode, params), dup.source_brush_ids.size())
+		. ok
+	):
+		return false
 	if not dup.regenerate(self, mode, params):
-		# A rebuild that produced nothing has already thrown the old copies away,
-		# so the record no longer describes anything that exists.
+		# Past that check, a rebuild that produced nothing means the sources
+		# themselves are gone, so the record no longer describes anything that
+		# could exist.
 		_duplicators.erase(duplicator_id)
 		return false
 	return true

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -544,7 +544,14 @@ brings it back.
 is a lattice of over thirty-two thousand brushes — not an edit but a hang. Ask
 for more than the ceiling and the ghost disappears and the line tells you the
 number you asked for, so you know which control to turn back. **Create Array**
-refuses the same arrays for the same reason.
+refuses the same arrays for the same reason, and so does **Update Array**: the
+ceiling is not a property of one button, so raising an existing array past it is
+refused too.
+
+**A refused array costs you nothing.** Whether you are creating or updating, the
+refusal lands before anything is built or taken away. Type a count the layout
+cannot use into an array you already have, press Update, and the copies stay
+where they are with the array still selected, ready for a number that works.
 
 **Ctrl+Z takes an array back out.** All three layouts are one undo step, so an
 array you did not want goes away in a single press rather than one copy at a

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,357 tests across 173 scripts**: **3,350 passing tests**, seven intentional no-assert safety tests, and **17,133 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,366 tests across 174 scripts**: **3,359 passing tests**, seven intentional no-assert safety tests, and **17,155 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_array_limits.gd
+++ b/tests/test_array_limits.gd
@@ -1,0 +1,132 @@
+extends GutTest
+
+## The 256 copy cap and the refusal path around it. Both are about the same
+## thing: an array that cannot be built has to be refused before anything is
+## torn down, and refused wherever it is asked for rather than only at the
+## button the dock happens to use.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+const HFDuplicatorType = preload("res://addons/hammerforge/hf_duplicator.gd")
+
+var root: LevelRoot
+
+
+func before_each():
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func _make_brush(brush_id: String) -> DraftBrush:
+	return (
+		root.create_brush_from_info({"size": Vector3(8, 8, 8), "brush_id": brush_id}) as DraftBrush
+	)
+
+
+func _ids(brush_id: String) -> PackedStringArray:
+	return PackedStringArray([brush_id])
+
+
+# -- A bad count is a no-op, not a demolition --------------------------------
+
+
+func test_updating_to_a_zero_count_leaves_the_copies_and_the_record_alone():
+	_make_brush("b1")
+	var dup = root.create_duplicate_array(_ids("b1"), 3, Vector3(64, 0, 0))
+	assert_not_null(dup, "The array should have been created")
+	var did: String = dup.duplicator_id
+	var live_before := root.get_live_brush_count()
+
+	var ok = root.update_duplicate_array(did, 0, {"count": 0, "offset": Vector3(64, 0, 0)})
+
+	assert_false(ok, "A zero count should be refused")
+	assert_eq(root.get_live_brush_count(), live_before, "The copies should still be there")
+	assert_not_null(root.duplicator_for_id(did), "and the record should still be reachable")
+
+
+func test_a_refused_update_can_be_corrected():
+	_make_brush("b1")
+	var did: String = root.create_duplicate_array(_ids("b1"), 3, Vector3(64, 0, 0)).duplicator_id
+
+	root.update_duplicate_array(did, 0, {"count": 0, "offset": Vector3(64, 0, 0)})
+	var ok = root.update_duplicate_array(did, 0, {"count": 5, "offset": Vector3(64, 0, 0)})
+
+	assert_true(ok, "A good count after a refused one should rebuild")
+	assert_eq(root.get_live_brush_count(), 6, "one source plus five copies")
+
+
+func test_a_refused_update_leaves_the_array_detachable():
+	_make_brush("b1")
+	var did: String = root.create_duplicate_array(_ids("b1"), 3, Vector3(64, 0, 0)).duplicator_id
+	root.update_duplicate_array(did, 0, {"count": 0, "offset": Vector3(64, 0, 0)})
+
+	assert_true(root.detach_duplicate_array(did), "The record should still be there to detach")
+
+
+# -- The cap holds on every path ---------------------------------------------
+
+
+func test_update_cannot_raise_an_array_past_the_cap():
+	_make_brush("b1")
+	var did: String = root.create_duplicate_array(_ids("b1"), 3, Vector3(64, 0, 0)).duplicator_id
+
+	var ok = root.update_duplicate_array(
+		did, 0, {"count": HFDuplicatorType.MAX_COPY_BRUSHES + 1, "offset": Vector3(64, 0, 0)}
+	)
+
+	assert_false(ok, "An update past the cap should be refused")
+	assert_eq(root.get_live_brush_count(), 4, "and the array should be as it was")
+
+
+func test_a_grid_over_the_cap_is_refused():
+	_make_brush("b1")
+	var dup = root.create_grid_array(_ids("b1"), Vector3i(12, 12, 12), Vector3(64, 64, 64))
+
+	assert_null(dup, "1727 copies is over the cap and should be refused")
+	assert_eq(root.get_live_brush_count(), 1, "and nothing should have been built")
+
+
+func test_a_grid_within_the_cap_still_builds():
+	_make_brush("b1")
+	var dup = root.create_grid_array(_ids("b1"), Vector3i(2, 1, 2), Vector3(64, 64, 64))
+
+	assert_not_null(dup, "Three copies is well inside the cap")
+	assert_eq(root.get_live_brush_count(), 4, "one source plus three copies")
+
+
+func test_a_radial_array_over_the_cap_is_refused():
+	_make_brush("b1")
+	var dup = root.create_radial_array(
+		_ids("b1"), HFDuplicatorType.MAX_COPY_BRUSHES + 1, 1, 5.0, Vector3.ZERO
+	)
+
+	assert_null(dup, "A radial array past the cap should be refused")
+	assert_eq(root.get_live_brush_count(), 1, "and nothing should have been built")
+
+
+func test_a_refused_create_does_not_take_the_existing_array_with_it():
+	_make_brush("b1")
+	root.create_duplicate_array(_ids("b1"), 3, Vector3(64, 0, 0))
+	assert_eq(root.get_live_brush_count(), 4, "The first array should be standing")
+
+	var second = root.create_duplicate_array(
+		_ids("b1"), HFDuplicatorType.MAX_COPY_BRUSHES + 1, Vector3(64, 0, 0)
+	)
+
+	assert_null(second, "The oversized array should be refused")
+	assert_eq(root.get_live_brush_count(), 4, "and the first one should be untouched")
+
+
+# -- grid_copy_count agrees with what a grid builds ---------------------------
+
+
+func test_grid_copy_count_matches_the_placements():
+	assert_eq(HFDuplicatorType.grid_copy_count(Vector3i(2, 1, 2)), 3, "2x1x2 makes three copies")
+	assert_eq(
+		HFDuplicatorType.grid_copy_count(Vector3i(2, 1, 2)),
+		HFDuplicatorType.grid_placements(Vector3i(2, 1, 2), Vector3.ONE).size(),
+		"and that is how many placements there are"
+	)
+	assert_eq(HFDuplicatorType.grid_copy_count(Vector3i(1, 1, 1)), 0, "1x1x1 makes none")
+	assert_eq(HFDuplicatorType.grid_copy_count(Vector3i(0, -4, 1)), 0, "and nor does a bad count")


### PR DESCRIPTION
Two sibling bugs in the duplicator. One fix covers the overlap: the check moves ahead of the teardown.

Fixes #299
Fixes #300

- `regenerate()` called `clear_instances()` before `_lay_out()` decided whether the new numbers produced anything, and `update_duplicate_array()` read the resulting false as a dead record and erased it. Typing 0 into a count deleted the array and its record with no way back. The check runs first now, on both sides. The erase stays for the case its comment was written for, every source brush deleted.
- `can_generate()` was called only from the dock. The check now sits in `generate()`, `generate_radial()`, `generate_grid()` and `regenerate()`, and in the three `create_*` methods on `HFBrushSystem`.

While wiring the create paths I found a third instance of the same shape: `_new_duplicator_for()` retires whatever array already owns the sources and clears its copies, so a refusal after that call would have destroyed an array the user already had. The create checks sit ahead of it.

`grid_copy_count()` and `requested_copy_count()` work out the size of a layout without building it. A test pins them against `placements_for()`, which is what the dock counts with.

New `tests/test_array_limits.gd`, 9 tests. Seven fail on main; the grid-under-the-cap guard passes on both, and the ninth covers the new helpers. Full suite 3301 passing, 0 failing.