### PR TITLE
Validate what four loaders are handed instead of trusting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -690,6 +690,45 @@ The format is based on Keep a Changelog, and this project follows semantic versi
     UV tail, the plane count at three side counts, no two planes coincident, every
     plane facing outward, a whole-brush and a per-face round trip, and a texture
     the palette does not hold.
+- **Four loaders stop trusting the payload they are handed.** Each sits behind a
+  file that can be hand edited, synced between machines or truncated mid write,
+  and in each case a bad value did not fail where it was read.
+  - **A displacement face comes back flat rather than half restored** (#290).
+    `HFDisplacementData.from_dict()` took the power on trust and sized the arrays
+    from the payload, while `get_dim()` and every read assume the two agree. A
+    mismatch sent each `row * dim + col` to the wrong cell, and because
+    `set_distance()` and `add_noise()` both guard on `idx < size()`, the writes
+    past the end were dropped in silence. The power is clamped the way
+    `init_flat()` clamps it, each array is checked against the vertex count that
+    power implies, and a mismatch is a warning naming both numbers.
+  - **A typo in the keymap file no longer errors on every keystroke** (#292).
+    `HFKeymap.load_or_default()` accepted whatever JSON was there, so a value of
+    the wrong type errored inside `matches()`, which runs on every key event in
+    the viewport, with a message naming `hf_keymap.gd` rather than the file the
+    user actually got wrong. Entries that are not dictionaries, entries with no
+    usable `keycode`, and keys that are not HammerForge actions are reported once
+    on load, naming the file and the key, and the default is used instead.
+  - **A wrong-typed generator setting comes back as a result** (#293).
+    `HFGeneratorSchema._coerce()` called `int({})`, which is not a valid
+    constructor call: it errored, evaluated to null, and the null was written into
+    the settings. From there the builder's `validate()` never returned,
+    `HFGeneratorSystem.create()` read `.ok` off nothing, and
+    `LevelRoot.create_generator()` handed back null from a function declared
+    `-> HFOpResult`. `_coerce()` is total now, falling back to the field's default
+    with a warning; a numeric string still counts as a number. `validate()` also
+    treats a null builder result as a failure, so no future builder can put a
+    null back into that path.
+  - **One junk preset no longer empties the preset list** (#294).
+    `HFIOPresets.load_presets()` tested only that the file parsed to an Array, so
+    `[1, 2, 3]` was accepted and `get_all_presets()` then errored on the first
+    element and returned nothing, dropping the real presets below it. Elements
+    are kept only if they are dictionaries with a name and a connections array,
+    and a rejection names the file and the index. `add_user_preset()` refuses an
+    empty name and returns whether it added anything, so a bad entry cannot be
+    made from inside the editor either.
+  - **Coverage** (`tests/test_untrusted_payloads.gd`): 16 tests over all four,
+    including a good value on each path so the validation cannot start refusing
+    what it should accept. Twelve fail on the previous code.
 - **A prefab could wire its copy's outputs to the entities it was built from.**
   `HFPrefab.instantiate()` remapped I/O by turning each old node name into the new
   one and then looking that name back up. The lookup resolves an authored

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,378 tests across 175 test scripts (3,371 passing plus seven intentional no-assert safety tests; 17,238 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,394 tests across 176 test scripts (3,387 passing plus seven intentional no-assert safety tests; 17,348 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,378 tests** across **175 scripts** (**3,371 passing** plus seven intentional no-assert safety tests; **17,238 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,394 tests** across **176 scripts** (**3,387 passing** plus seven intentional no-assert safety tests; **17,348 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3371%20passing-brightgreen" alt="3371 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3387%20passing-brightgreen" alt="3387 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,378 tests across 175 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,394 tests across 176 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/displacement_data.gd
+++ b/addons/hammerforge/displacement_data.gd
@@ -270,28 +270,62 @@ func to_dict() -> Dictionary:
 
 
 ## Deserialize from dictionary.
+## The power is clamped the way init_flat() clamps it, and every array is
+## checked against the vertex count that power implies.
+##
+## get_dim() returns (1 << power) + 1 and every read is a `row * dim + col`, so a
+## power that does not match the array lengths sends each index to the wrong
+## cell. set_distance() and add_noise() both guard on `idx < size()`, which means
+## the writes past the end are dropped in silence: the surface part flattens and
+## part scrambles with nothing to trace it back to. A face that cannot be trusted
+## comes back flat instead.
 static func from_dict(data: Dictionary) -> HFDisplacementData:
 	var disp = HFDisplacementData.new()
-	disp.power = int(data.get("power", 3))
+	var raw_power := int(data.get("power", 3))
+	var power_value := clampi(raw_power, 2, 4)
+	if power_value != raw_power:
+		HFLog.warn(
+			"Displacement: power %d is outside 2 to 4. Clamped to %d." % [raw_power, power_value]
+		)
+	disp.init_flat(power_value)
 	disp.elevation = float(data.get("elevation", 1.0))
 	disp.sew_group = int(data.get("sew_group", -1))
+	var expected := disp.get_vertex_count()
 	var dist_arr: Array = data.get("distances", [])
-	disp.distances = PackedFloat32Array()
-	disp.distances.resize(dist_arr.size())
-	for i in range(dist_arr.size()):
-		disp.distances[i] = float(dist_arr[i])
+	if dist_arr.size() == expected:
+		for i in range(expected):
+			disp.distances[i] = float(dist_arr[i])
+	elif dist_arr.size() > 0:
+		HFLog.warn(
+			(
+				"Displacement: %d distances for a power %d face, which needs %d. Face left flat."
+				% [dist_arr.size(), power_value, expected]
+			)
+		)
 	var off_arr: Array = data.get("offsets", [])
-	if off_arr.size() > 0:
-		disp.offsets = PackedVector3Array()
-		disp.offsets.resize(off_arr.size())
-		for i in range(off_arr.size()):
+	if off_arr.size() == expected:
+		# init_flat() leaves offsets empty, since a flat face has none.
+		disp.offsets.resize(expected)
+		for i in range(expected):
 			var e: Array = off_arr[i]
 			if e.size() >= 3:
 				disp.offsets[i] = Vector3(float(e[0]), float(e[1]), float(e[2]))
+	elif off_arr.size() > 0:
+		HFLog.warn(
+			(
+				"Displacement: %d offsets for a power %d face, which needs %d. Offsets dropped."
+				% [off_arr.size(), power_value, expected]
+			)
+		)
 	var alpha_arr: Array = data.get("alphas", [])
-	if alpha_arr.size() > 0:
-		disp.alphas = PackedFloat32Array()
-		disp.alphas.resize(alpha_arr.size())
-		for i in range(alpha_arr.size()):
+	if alpha_arr.size() == expected:
+		for i in range(expected):
 			disp.alphas[i] = float(alpha_arr[i])
+	elif alpha_arr.size() > 0:
+		HFLog.warn(
+			(
+				"Displacement: %d alphas for a power %d face, which needs %d. Alphas dropped."
+				% [alpha_arr.size(), power_value, expected]
+			)
+		)
 	return disp

--- a/addons/hammerforge/hf_generator_schema.gd
+++ b/addons/hammerforge/hf_generator_schema.gd
@@ -74,11 +74,40 @@ static func field(schema: Array, key: String) -> Dictionary:
 	return {}
 
 
+## A value in the type the field says, or the field's default if it cannot be.
+##
+## Total by construction. `int({})` is not a valid constructor call: it errors and
+## evaluates to null, and a null written into the settings dictionary reaches the
+## builder's `validate()`, which then never returns, which makes `create()`
+## dereference null and hand a caller declared `-> HFOpResult` nothing at all.
+## Refusing a value here is what keeps that cascade from starting.
 static func _coerce(field: Dictionary, value):
-	match str(field.get("type", TYPE_FLOAT)):
+	var type_name := str(field.get("type", TYPE_FLOAT))
+	if not _is_number_like(value):
+		var fallback = field.get("default", 0.0)
+		HFLog.warn(
+			(
+				"Generator setting '%s' cannot be a %s, so the default is used instead."
+				% [str(field.get("key", "?")), type_string(typeof(value))]
+			)
+		)
+		value = fallback if _is_number_like(fallback) else 0.0
+	match type_name:
 		TYPE_INT, TYPE_ENUM:
 			return int(value)
 		TYPE_BOOL:
 			return bool(value)
 		_:
 			return float(value)
+
+
+## Whether int(), bool() and float() will take this value rather than error.
+##
+## Written with `is` rather than `typeof` because this class defines its own
+## TYPE_INT and TYPE_BOOL as strings, which shadow the engine constants of the
+## same name. A string counts only when it reads as a number, so a stray label
+## does not quietly become zero.
+static func _is_number_like(value) -> bool:
+	if value is String or value is StringName:
+		return str(value).is_valid_float()
+	return value is int or value is float or value is bool

--- a/addons/hammerforge/hf_keymap.gd
+++ b/addons/hammerforge/hf_keymap.gd
@@ -21,13 +21,44 @@ static func load_or_default(path: String = "") -> HFKeymap:
 			if data is Dictionary:
 				# Merge: user overrides take priority, but new default
 				# actions are added so new features work out of the box.
-				for action in defaults:
-					if not data.has(action):
-						data[action] = defaults[action]
-				km._bindings = data
+				km._bindings = _validated(data, defaults, path)
 				return km
 	km._bindings = defaults
 	return km
+
+
+## The bindings from a user file, with anything unusable dropped.
+##
+## This is the one file a user is obliged to hand edit, so a typo in it must not
+## become an error on every key event in the viewport. `matches()` runs on each
+## one and starts by assigning the entry to a Dictionary, so a value of the wrong
+## type errors there, naming this script rather than the file the user got wrong.
+## Each rejection is reported once, on load, naming the file and the key.
+static func _validated(data: Dictionary, defaults: Dictionary, path: String) -> Dictionary:
+	var out: Dictionary = {}
+	for action in data:
+		var key := str(action)
+		if not defaults.has(key):
+			HFLog.warn("%s: '%s' is not a HammerForge action. Ignored." % [path, key])
+			continue
+		var binding = data[action]
+		if not (binding is Dictionary):
+			HFLog.warn(
+				(
+					"%s: '%s' is a %s, not a binding. The default is used."
+					% [path, key, type_string(typeof(binding))]
+				)
+			)
+			continue
+		var keycode = binding.get("keycode", null)
+		if not (keycode is int or keycode is float) or int(keycode) == 0:
+			HFLog.warn("%s: '%s' has no usable keycode. The default is used." % [path, key])
+			continue
+		out[key] = binding
+	for action in defaults:
+		if not out.has(action):
+			out[action] = defaults[action]
+	return out
 
 
 static func _default_bindings() -> Dictionary:

--- a/addons/hammerforge/systems/hf_generator_system.gd
+++ b/addons/hammerforge/systems/hf_generator_system.gd
@@ -97,7 +97,16 @@ static func validate(type: String, settings: Dictionary) -> HFOpResult:
 			"Generator: '%s' is not a generator type" % type,
 			"Known types: %s" % ", ".join(known_types())
 		)
-	return builder.validate(settings)
+	var result = builder.validate(settings)
+	# A builder that returns nothing is a bug in the builder, but it must not
+	# become a null out of create_generator(), which is declared to hand back a
+	# result every caller then reads `.ok` off.
+	if result == null:
+		return HFOpResult.fail(
+			"Generator: '%s' could not check those settings" % type,
+			"Check the settings for a value of the wrong type"
+		)
+	return result
 
 
 ## One face set per piece the structure is made of, in the structure's own space.

--- a/addons/hammerforge/systems/hf_io_presets.gd
+++ b/addons/hammerforge/systems/hf_io_presets.gd
@@ -111,7 +111,39 @@ func load_presets(path: String = "") -> void:
 	var text = file.get_as_text()
 	var data = JSON.parse_string(text)
 	if data is Array:
-		_user_presets = data
+		_user_presets = _validated_presets(data, _presets_path)
+
+
+## The presets from a user file, with anything the rest of this class cannot read
+## left out.
+##
+## Being an array was the whole test before, so a file holding `[1, 2, 3]` was
+## accepted and `get_all_presets()` then errored on `duplicate()` at the first
+## element and returned nothing, dropping the real presets below it. This file
+## lives under `user://`, where it can be hand edited, synced or truncated mid
+## write, so a bad element is reported by index and skipped rather than trusted.
+func _validated_presets(data: Array, path: String) -> Array:
+	var out: Array = []
+	for i in data.size():
+		var entry = data[i]
+		if not (entry is Dictionary):
+			HFLog.warn(
+				(
+					"%s: entry %d is a %s, not a preset. Skipped."
+					% [path, i, type_string(typeof(entry))]
+				)
+			)
+			continue
+		if str(entry.get("name", "")).strip_edges() == "":
+			HFLog.warn("%s: entry %d has no name. Skipped." % [path, i])
+			continue
+		if not (entry.get("connections", null) is Array):
+			HFLog.warn(
+				"%s: preset '%s' has no connections list. Skipped." % [path, str(entry["name"])]
+			)
+			continue
+		out.append(entry)
+	return out
 
 
 ## Save user presets to file.
@@ -147,7 +179,12 @@ func get_user_presets() -> Array:
 
 
 ## Add a new user preset.
-func add_user_preset(name: String, description: String, connections: Array) -> void:
+## Refuses a preset with no name, so a bad entry cannot be made from inside the
+## editor either. Returns whether it was added.
+func add_user_preset(name: String, description: String, connections: Array) -> bool:
+	if name.strip_edges() == "":
+		HFLog.warn("HFIOPresets: a preset needs a name.")
+		return false
 	(
 		_user_presets
 		. append(
@@ -160,6 +197,7 @@ func add_user_preset(name: String, description: String, connections: Array) -> v
 		)
 	)
 	save_presets()
+	return true
 
 
 ## Remove a user preset by index (in the user array, not combined).

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -1157,7 +1157,9 @@ All keyboard shortcuts are data-driven and can be customized. The default bindin
 | Command palette | Shift+? / F1 / Ctrl+K | Searchable action palette with fuzzy search |
 | Operation timeline | Ctrl+Shift+T | Toggle operation replay timeline |
 
-**Rebinding:** Edit `user://hammerforge_keymap.json` (created on first run). Each entry maps an action name to `{"keycode": KEY_*, "ctrl": bool, "shift": bool, "alt": bool}`. Restart the plugin after editing.
+**Rebinding:** Edit `user://hammerforge_keymap.json` (created on first run). Each entry maps an action name to `{"keycode": KEY_*, "ctrl": bool, "shift": bool, "alt": bool}`. Restart the plugin after editing. The JSON file is the interface; there is no rebinding UI.
+
+An entry that is not a binding, one with no usable `keycode`, or a key that is not a HammerForge action is reported once on load, naming the file and the key, and the default is used for it. Before, a typo in this file turned every keystroke in the viewport into an error that named `hf_keymap.gd` rather than the file you got wrong.
 
 **Toolbar labels** and **tooltips** update automatically from the keymap, so custom bindings are always reflected in the UI. Press the **?** button on the toolbar to open a searchable shortcut dialog showing all current keybindings grouped by category (Tools, Editing, Selection, Paint, Axis Lock).
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,378 tests across 175 scripts**: **3,371 passing tests**, seven intentional no-assert safety tests, and **17,238 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,394 tests across 176 scripts**: **3,387 passing tests**, seven intentional no-assert safety tests, and **17,348 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_untrusted_payloads.gd
+++ b/tests/test_untrusted_payloads.gd
@@ -1,0 +1,206 @@
+extends GutTest
+
+## Four loaders that took a payload on trust. Each one sits behind a file a user
+## can hand edit, sync, or truncate, and in each case a bad value did not fail
+## where it was read: it became a cascade of engine errors somewhere else, or a
+## silent half restore with nothing to trace it back to.
+
+const HFKeymapType = preload("res://addons/hammerforge/hf_keymap.gd")
+const HFIOPresetsType = preload("res://addons/hammerforge/systems/hf_io_presets.gd")
+const HFDisplacementDataType = preload("res://addons/hammerforge/displacement_data.gd")
+const HFGeneratorSchemaType = preload("res://addons/hammerforge/hf_generator_schema.gd")
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+
+const KEYMAP_PATH := "user://hf_test_keymap.json"
+const PRESETS_PATH := "user://hf_test_io_presets.json"
+
+
+func after_each():
+	for path in [KEYMAP_PATH, PRESETS_PATH]:
+		if FileAccess.file_exists(path):
+			DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+
+
+## HFIOPresets keeps a level root reference it does not need for load or save.
+func _preset_host() -> Node3D:
+	var host := Node3D.new()
+	add_child_autoqfree(host)
+	return host
+
+
+func _write(path: String, text: String) -> void:
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	file.store_string(text)
+	file.close()
+
+
+# -- Keymap -------------------------------------------------------------------
+
+
+func test_a_keymap_entry_that_is_not_a_binding_falls_back_to_the_default():
+	_write(KEYMAP_PATH, '{"tool_draw": 68}')
+
+	var km = HFKeymapType.load_or_default(KEYMAP_PATH)
+
+	var binding = km.get_all_bindings().get("tool_draw", {})
+	assert_true(binding is Dictionary, "The entry should be a binding, not the raw number")
+	assert_eq(int(binding.get("keycode", 0)), KEY_D, "and it should be the default binding")
+
+
+func test_a_keymap_entry_with_no_keycode_falls_back_to_the_default():
+	_write(KEYMAP_PATH, '{"tool_draw": {"ctrl": true}}')
+
+	var km = HFKeymapType.load_or_default(KEYMAP_PATH)
+
+	var binding = km.get_all_bindings().get("tool_draw", {})
+	assert_eq(int(binding.get("keycode", 0)), KEY_D, "A binding with no keycode is not a binding")
+	assert_false(bool(binding.get("ctrl", false)), "and the default carries no ctrl")
+
+
+func test_a_keymap_key_that_is_not_an_action_is_dropped():
+	var default_count: int = HFKeymapType.load_or_default("").get_actions().size()
+	_write(KEYMAP_PATH, '{"junk_action": {"keycode": 90}}')
+
+	var km = HFKeymapType.load_or_default(KEYMAP_PATH)
+
+	assert_eq(km.get_actions().size(), default_count, "An unknown action should not be added")
+	assert_false(km.get_actions().has("junk_action"), "and it should not be in the list")
+
+
+func test_a_good_keymap_entry_still_wins():
+	_write(KEYMAP_PATH, '{"tool_draw": {"keycode": 87, "shift": true}}')
+
+	var km = HFKeymapType.load_or_default(KEYMAP_PATH)
+
+	var binding = km.get_all_bindings().get("tool_draw", {})
+	assert_eq(int(binding.get("keycode", 0)), KEY_W, "A usable override should be kept")
+	assert_true(bool(binding.get("shift", false)), "with its modifiers")
+
+
+func test_get_display_string_does_not_error_on_a_bad_file():
+	_write(KEYMAP_PATH, '{"tool_draw": 68, "junk_action": {"keycode": 90}}')
+	var km = HFKeymapType.load_or_default(KEYMAP_PATH)
+
+	assert_ne(km.get_display_string("tool_draw"), "", "The display string should still resolve")
+
+
+# -- I/O presets --------------------------------------------------------------
+
+
+func test_a_junk_preset_entry_does_not_take_the_list_with_it():
+	_write(
+		PRESETS_PATH,
+		'[1, {"name": "good_a", "connections": []}, ' + '{"name": "good_b", "connections": []}]'
+	)
+	var presets = HFIOPresetsType.new(_preset_host())
+
+	presets.load_presets(PRESETS_PATH)
+
+	assert_eq(presets.get_user_presets().size(), 2, "The two real presets should survive")
+	var all_presets: Array = presets.get_all_presets()
+	assert_gt(all_presets.size(), 2, "and get_all_presets should return them plus the builtins")
+
+
+func test_a_preset_with_no_name_is_dropped_on_load():
+	_write(PRESETS_PATH, '[{"name": "", "connections": []}]')
+	var presets = HFIOPresetsType.new(_preset_host())
+
+	presets.load_presets(PRESETS_PATH)
+
+	assert_eq(presets.get_user_presets().size(), 0, "A preset with no label is not a preset")
+
+
+func test_a_preset_with_no_connections_list_is_dropped_on_load():
+	_write(PRESETS_PATH, '[{"name": "no_conns"}]')
+	var presets = HFIOPresetsType.new(_preset_host())
+
+	presets.load_presets(PRESETS_PATH)
+
+	assert_eq(presets.get_user_presets().size(), 0, "The rest of the class reads connections")
+
+
+func test_add_user_preset_refuses_an_empty_name():
+	var presets = HFIOPresetsType.new(_preset_host())
+	presets._presets_path = PRESETS_PATH
+
+	assert_false(presets.add_user_preset("", "no label", []), "An empty name is refused")
+	assert_eq(presets.get_user_presets().size(), 0, "and nothing is added")
+	assert_true(presets.add_user_preset("real", "", []), "A named preset is still accepted")
+
+
+# -- Displacement -------------------------------------------------------------
+
+
+func test_from_dict_clamps_the_power():
+	var disp = HFDisplacementDataType.from_dict({"power": 9})
+
+	assert_eq(disp.power, 4, "Power 9 is a 513 by 513 grid on one face")
+	assert_eq(disp.distances.size(), disp.get_vertex_count(), "and the arrays match it")
+
+
+func test_from_dict_refuses_a_distance_array_that_does_not_match_the_power():
+	var disp = HFDisplacementDataType.from_dict({"power": 3, "distances": [1.0, 2.0, 3.0]})
+
+	assert_eq(disp.distances.size(), disp.get_vertex_count(), "The array should be the right size")
+	for d in disp.distances:
+		assert_eq(d, 0.0, "A face that cannot be trusted comes back flat")
+
+
+func test_a_matching_payload_still_round_trips():
+	var original = HFDisplacementDataType.new()
+	original.init_flat(3)
+	original.set_distance(2, 2, 12.5)
+	original.elevation = 3.0
+
+	var restored = HFDisplacementDataType.from_dict(original.to_dict())
+
+	assert_eq(restored.power, 3, "Power should survive")
+	assert_eq(restored.elevation, 3.0, "and so should elevation")
+	assert_eq(restored.get_distance(2, 2), 12.5, "and the distance that was set")
+
+
+# -- Generator settings -------------------------------------------------------
+
+
+func test_a_wrong_typed_setting_returns_a_result_rather_than_null():
+	var root: LevelRoot = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+	var result = root.create_generator("stairs", {"steps": {}, "step_height": []}, Transform3D())
+
+	assert_not_null(result, "create_generator is declared to hand back a result")
+	assert_true(result.ok or not result.ok, "and the caller can read .ok off it")
+
+
+func test_coerce_falls_back_to_the_field_default():
+	var schema: Array = [{"key": "steps", "type": "int", "default": 8}]
+
+	var merged: Dictionary = HFGeneratorSchemaType.merge(schema, {"steps": {}})
+
+	assert_eq(merged["steps"], 8, "A value that cannot be an int becomes the field's default")
+
+
+func test_coerce_still_takes_a_numeric_string():
+	var schema: Array = [{"key": "steps", "type": "int", "default": 8}]
+
+	var merged: Dictionary = HFGeneratorSchemaType.merge(schema, {"steps": "12"})
+
+	assert_eq(merged["steps"], 12, "A number written as text is still a number")
+
+
+func test_coerce_leaves_a_good_value_alone():
+	var schema: Array = [
+		{"key": "steps", "type": "int", "default": 8},
+		{"key": "height", "type": "float", "default": 1.0},
+		{"key": "railing", "type": "bool", "default": false}
+	]
+
+	var merged: Dictionary = HFGeneratorSchemaType.merge(
+		schema, {"steps": 20, "height": 2.5, "railing": true}
+	)
+
+	assert_eq(merged["steps"], 20, "int survives")
+	assert_eq(merged["height"], 2.5, "float survives")
+	assert_eq(merged["railing"], true, "bool survives")


### PR DESCRIPTION
Four loaders with the same root cause: a payload is accepted without being checked, and the bad value does not fail where it was read. It becomes a cascade of engine errors somewhere else, or a silent half restore.

Fixes #290
Fixes #292
Fixes #293
Fixes #294

- `HFDisplacementData.from_dict()` clamps the power the way `init_flat()` does and checks each array against the vertex count that power implies. A face that does not add up comes back flat with a warning naming both numbers.
- `HFKeymap.load_or_default()` drops entries that are not bindings, entries with no usable keycode, and keys that are not actions, reporting each once with the file and the key.
- `HFGeneratorSchema._coerce()` is total. `int({})` errored to null and that null reached the builder, so `create_generator()` returned null from a function declared `-> HFOpResult`. `HFGeneratorSystem.validate()` also treats a null builder result as a failure.
- `HFIOPresets.load_presets()` keeps only elements that are dictionaries with a name and a connections array. `add_user_preset()` refuses an empty name and returns whether it added anything.

On the other half of #292: I did not delete `set_binding()` and `save()`. They have tests and are a usable API for a script, and the user guide already names the JSON file as the interface. I added a line there saying rejected entries are now reported, rather than removing a tested public method.

New `tests/test_untrusted_payloads.gd`, 16 tests, including a good value on each path so the validation cannot start refusing what it should accept. Twelve fail on main. Full suite 3308 passing, 0 failing.