### PR TITLE
Report a connection source by its authored name and carry wiring into .map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -729,6 +729,40 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   - **Coverage** (`tests/test_untrusted_payloads.gd`): 16 tests over all four,
     including a good value on each path so the validation cannot start refusing
     what it should accept. Twelve fail on the previous code.
+- **A connection reports its source under the name it is addressed by** (#288).
+  `HFEntitySystem.get_all_connections()` built the source side from the scene
+  tree name and the target side from the stored output, which is the authored
+  `entity_name`, so the two halves of every record were in different namespaces.
+  For a brush entity the tree name is whatever Godot generated, so a source never
+  matched an authored name and `get_connection_summary()` reported every wired
+  entity as triggering nothing. `source_name` is the authored name when there is
+  one and the node name otherwise, `source_node_name` carries the other, and the
+  summary answers to either address rather than making the caller know which one
+  it is holding.
+- **`.map` export carries entity names and I/O outputs** (#287). The authored
+  name and the `entity_io_outputs` metadata were never read, on point entities or
+  brush entities, so a level wired up in the Objects tab exported inert. The
+  authored name is written as `targetname`, and each connection is one key/value
+  line with the output name as the key and
+  `target,input,parameter,delay,fire_once` as the value, which is the order
+  Hammer writes a VMF connection. `parse_map_text()` reads them back.
+  - **No connections block.** A `.map` entity body is key/value lines and nothing
+    else: a nested brace inside an entity is read as a brush by every parser
+    including this one, so a Source style block would not survive its own round
+    trip.
+  - **One line per connection**, so two outputs on the same event both reach the
+    file. The parser now keeps the key/value lines in file order alongside the
+    properties dictionary, which would otherwise keep only the last of a repeated
+    key.
+  - **Wiring is told apart from settings by shape, not by a naming rule.** A line
+    is read as a connection only with five comma-separated fields, a numeric
+    delay, and a target and input that are there. An imported output does not
+    also land in `entity_data`.
+  - **Coverage** (`tests/test_entity_names_and_io.gd`): the source namespace, the
+    summary from either address, an entity with no authored name, the value shape
+    both ways, four ordinary properties that must not read as connections, both
+    entity kinds exporting, two outputs on one event, an unwired block gaining
+    nothing, and a round trip for each entity kind.
 - **A prefab could wire its copy's outputs to the entities it was built from.**
   `HFPrefab.instantiate()` remapped I/O by turning each old node name into the new
   one and then looking that name back up. The lookup resolves an authored

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,394 tests across 176 test scripts (3,387 passing plus seven intentional no-assert safety tests; 17,348 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,408 tests across 177 test scripts (3,401 passing plus seven intentional no-assert safety tests; 17,390 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,394 tests** across **176 scripts** (**3,387 passing** plus seven intentional no-assert safety tests; **17,348 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,408 tests** across **177 scripts** (**3,401 passing** plus seven intentional no-assert safety tests; **17,390 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3387%20passing-brightgreen" alt="3387 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3401%20passing-brightgreen" alt="3401 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,394 tests across 176 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,408 tests across 177 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/map_io.gd
+++ b/addons/hammerforge/map_io.gd
@@ -50,7 +50,11 @@ static func parse_map_text(text: String) -> Dictionary:
 		if line == "{":
 			if not in_entity:
 				in_entity = true
-				current_entity = {"properties": {}, "brushes": []}
+				# `pairs` keeps every key/value line in file order. `properties`
+				# is a Dictionary, so a repeated key overwrites, and I/O outputs
+				# are written one line per connection with the output name as the
+				# key. Two outputs on the same event would collide there.
+				current_entity = {"properties": {}, "brushes": [], "pairs": []}
 				continue
 			if in_entity and not in_brush:
 				in_brush = true
@@ -86,6 +90,7 @@ static func parse_map_text(text: String) -> Dictionary:
 			var kv = _parse_key_value(line)
 			if kv.size() == 2:
 				current_entity["properties"][kv[0]] = kv[1]
+				current_entity["pairs"].append([kv[0], kv[1]])
 			else:
 				errors.append("Line %d: not a key value pair" % line_no)
 			continue
@@ -105,8 +110,18 @@ static func parse_map_text(text: String) -> Dictionary:
 		var entity_class = str(props.get("classname", ""))
 		var origin = _parse_origin(str(props.get("origin", "")))
 		var has_brushes = entity.get("brushes", []).size() > 0
+		var authored := str(props.get("targetname", ""))
+		var connections := _connections_from_pairs(entity.get("pairs", []))
 		if not has_brushes and entity_class != "":
-			entity_points.append({"classname": entity_class, "origin": origin, "properties": props})
+			entity_points.append(
+				{
+					"classname": entity_class,
+					"origin": origin,
+					"properties": props,
+					"entity_name": authored,
+					"entity_io_outputs": connections
+				}
+			)
 		for brush in entity.get("brushes", []):
 			var info = (
 				_brush_from_faces(brush.get("faces", [])) if bool(brush.get("usable", true)) else {}
@@ -116,10 +131,33 @@ static func parse_map_text(text: String) -> Dictionary:
 				continue
 			if entity_class != "" and entity_class != "worldspawn":
 				info["brush_entity_class"] = entity_class
+				if authored != "":
+					info["entity_name"] = authored
+				if not connections.is_empty():
+					info["entity_io_outputs"] = connections
 			brushes.append(info)
 	if entities.is_empty() and text.strip_edges() != "":
 		errors.append("No map blocks found")
 	return {"entities": entity_points, "brushes": brushes, "errors": errors}
+
+
+## The I/O connections among an entity's key/value lines.
+##
+## Read from the ordered pairs rather than the properties dictionary, so two
+## outputs on the same event both survive. A reserved key is never a connection,
+## and everything else has to look like one to be taken as one.
+static func _connections_from_pairs(pairs: Array) -> Array:
+	var out: Array = []
+	for pair in pairs:
+		if not (pair is Array) or pair.size() != 2:
+			continue
+		var key := str(pair[0])
+		if key in RESERVED_ENTITY_KEYS:
+			continue
+		var connection := parse_connection(key, str(pair[1]))
+		if not connection.is_empty():
+			out.append(connection)
+	return out
 
 
 ## Write the level out as `.map` text.
@@ -157,7 +195,7 @@ static func export_map_from_level(level_root: Node, adapter: HFMapAdapterType = 
 			continue
 		var bec := str(node.get_meta("brush_entity_class", ""))
 		if bec != "":
-			entity_brush_blocks.append({"classname": bec, "lines": brush_lines})
+			entity_brush_blocks.append({"classname": bec, "lines": brush_lines, "node": node})
 			continue
 		lines.append("{")
 		lines.append_array(brush_lines)
@@ -166,6 +204,10 @@ static func export_map_from_level(level_root: Node, adapter: HFMapAdapterType = 
 	for block in entity_brush_blocks:
 		lines.append("{")
 		lines.append('"classname" "%s"' % escape_property(str(block["classname"])))
+		# The authored name is the address every connection targets, and the
+		# outputs are the wiring itself. Both live in metadata rather than in
+		# entity_data, so neither was reaching the file.
+		lines.append_array(_entity_identity_lines(block.get("node", null), adapter))
 		lines.append("{")
 		lines.append_array(block["lines"])
 		lines.append("}")
@@ -234,6 +276,62 @@ static func _face_for_normal(brush: DraftBrush, world_normal: Vector3) -> Varian
 			best_dot = dot
 			best = face
 	return best
+## Keys HammerForge writes itself, which are never I/O outputs.
+const RESERVED_ENTITY_KEYS := ["classname", "origin", "targetname"]
+
+
+## One connection as a `.map` value.
+##
+## `.map` has no connections block. Its entity body is key/value lines and
+## nothing else, and a nested brace inside an entity is read as a brush by every
+## parser including this one, so a Source style block would not survive a round
+## trip. Each connection is therefore a line of its own with the output name as
+## the key, and the value in the order Hammer writes a VMF connection:
+##
+##     "OnOpen" "lamp,TurnOn,,0,0"
+##
+## Commas are stripped from the fields rather than escaped, because the format
+## defines no escape for one and a reader splitting on the comma would get a
+## different number of fields than the writer wrote.
+static func format_connection(connection: Dictionary) -> String:
+	return (
+		"%s,%s,%s,%s,%s"
+		% [
+			_no_commas(str(connection.get("target_name", ""))),
+			_no_commas(str(connection.get("input_name", ""))),
+			_no_commas(str(connection.get("parameter", ""))),
+			_snapped(float(connection.get("delay", 0.0))),
+			"1" if bool(connection.get("fire_once", false)) else "0",
+		]
+	)
+
+
+## A connection read back from a `.map` value, or an empty dictionary when the
+## value is not one.
+##
+## Five comma separated fields with a numeric delay and a target and input that
+## are actually there. An ordinary entity property does not look like that, so
+## wiring is told apart from settings without a naming convention on the key.
+static func parse_connection(output_name: String, value: String) -> Dictionary:
+	var parts := value.split(",", true)
+	if parts.size() != 5:
+		return {}
+	if not str(parts[3]).strip_edges().is_valid_float():
+		return {}
+	if str(parts[0]).strip_edges() == "" or str(parts[1]).strip_edges() == "":
+		return {}
+	return {
+		"output_name": output_name,
+		"target_name": str(parts[0]),
+		"input_name": str(parts[1]),
+		"parameter": str(parts[2]),
+		"delay": float(parts[3]),
+		"fire_once": str(parts[4]).strip_edges() == "1",
+	}
+
+
+static func _no_commas(text: String) -> String:
+	return text.replace(",", " ")
 
 
 ## True when a brush cuts geometry away rather than adding it.
@@ -250,6 +348,38 @@ static func _is_cutter(node: DraftBrush) -> bool:
 		return true
 	var parent: Node = node.get_parent()
 	return parent != null and parent.name in ["PendingCuts", "CommittedCuts"]
+
+
+## The `targetname` and the I/O output lines for one entity, in that order.
+##
+## Empty for an entity with neither, so an unwired entity block is unchanged.
+static func _entity_identity_lines(entity, adapter: HFMapAdapterType = null) -> Array[String]:
+	var out: Array[String] = []
+	if entity == null or not is_instance_valid(entity):
+		return out
+	# An ordered list rather than a Dictionary, because two outputs on the same
+	# event share a key and a Dictionary would keep only the last of them.
+	var pairs: Array = []
+	var authored := str(entity.get_meta("entity_name", ""))
+	if authored != "":
+		pairs.append(["targetname", authored])
+	var outputs = entity.get_meta("entity_io_outputs", [])
+	if outputs is Array:
+		for connection in outputs:
+			if not (connection is Dictionary):
+				continue
+			var output_name := str(connection.get("output_name", ""))
+			if output_name == "":
+				continue
+			pairs.append([output_name, format_connection(connection)])
+	for pair in pairs:
+		# One pair at a time keeps the order and the repeats while still going
+		# through the adapter, which is what escapes the key and the value.
+		if adapter:
+			out.append_array(adapter.format_entity_properties({pair[0]: pair[1]}))
+		else:
+			out.append('"%s" "%s"' % [escape_property(str(pair[0])), escape_property(str(pair[1]))])
+	return out
 
 
 static func _entity_to_map_lines(
@@ -281,6 +411,9 @@ static func _entity_to_map_lines(
 			lines.append(
 				'"%s" "%s"' % [escape_property(str(key)), escape_property(str(props[key]))]
 			)
+	# entity_data carries the authored keys. The name and the I/O outputs live in
+	# metadata, so they come from there.
+	lines.append_array(_entity_identity_lines(entity, adapter))
 	lines.append("}")
 	return lines
 

--- a/addons/hammerforge/map_io.gd
+++ b/addons/hammerforge/map_io.gd
@@ -276,6 +276,8 @@ static func _face_for_normal(brush: DraftBrush, world_normal: Vector3) -> Varian
 			best_dot = dot
 			best = face
 	return best
+
+
 ## Keys HammerForge writes itself, which are never I/O outputs.
 const RESERVED_ENTITY_KEYS := ["classname", "origin", "targetname"]
 

--- a/addons/hammerforge/systems/hf_entity_system.gd
+++ b/addons/hammerforge/systems/hf_entity_system.gd
@@ -100,9 +100,19 @@ func create_entity_from_map(info: Dictionary) -> DraftEntity:
 	var props = info.get("properties", {})
 	if props is Dictionary:
 		var data = props.duplicate(true)
-		data.erase("classname")
-		data.erase("origin")
+		for reserved in MapIO.RESERVED_ENTITY_KEYS:
+			data.erase(reserved)
+		# The output lines are wiring, not settings, and go back into metadata.
+		for connection in info.get("entity_io_outputs", []):
+			if connection is Dictionary:
+				data.erase(str(connection.get("output_name", "")))
 		entity.entity_data = data
+	var authored := str(info.get("entity_name", ""))
+	if authored != "":
+		entity.set_meta("entity_name", authored)
+	var outputs = info.get("entity_io_outputs", [])
+	if outputs is Array and not outputs.is_empty():
+		entity.set_meta("entity_io_outputs", outputs.duplicate(true))
 	add_entity(entity)
 	var origin = info.get("origin", Vector3.ZERO)
 	if origin is Vector3:
@@ -537,6 +547,21 @@ func _iter_io_sources() -> Array:
 	return nodes
 
 
+## The name an entity is addressed by: its authored `entity_name` when it has
+## one, its node name otherwise.
+##
+## The two halves of a connection record used to be in different namespaces. The
+## target side is whatever the output was aimed at, which is the authored name,
+## while the source side was the scene tree name. For a brush entity that is
+## whatever Godot generated, so a source never matched an authored name and
+## get_connection_summary() reported every wired entity as wired to nothing.
+static func authored_address(entity: Node) -> String:
+	if entity == null:
+		return ""
+	var authored := str(entity.get_meta("entity_name", ""))
+	return authored if authored != "" else str(entity.name)
+
+
 ## Get all I/O connections in the scene (for visualization).
 func get_all_connections() -> Array:
 	var connections: Array = []
@@ -550,7 +575,8 @@ func get_all_connections() -> Array:
 				. append(
 					{
 						"source": child,
-						"source_name": child.name,
+						"source_name": authored_address(child),
+						"source_node_name": str(child.name),
 						"output_name": str(conn.get("output_name", "")),
 						"target_name": str(conn.get("target_name", "")),
 						"input_name": str(conn.get("input_name", "")),

--- a/addons/hammerforge/systems/hf_io_visualizer.gd
+++ b/addons/hammerforge/systems/hf_io_visualizer.gd
@@ -494,11 +494,15 @@ func get_connection_summary(entity_name: String) -> Dictionary:
 	for conn in connections:
 		if not (conn is Dictionary):
 			continue
+		# An entity has two addresses, its authored name and its node name, and an
+		# output can be aimed at either. The summary answers for both rather than
+		# making the caller know which one it holds.
 		var src = str(conn.get("source_name", ""))
+		var src_node = str(conn.get("source_node_name", src))
 		var tgt = str(conn.get("target_name", ""))
 		var out_name = str(conn.get("output_name", ""))
 		var inp_name = str(conn.get("input_name", ""))
-		if src == entity_name:
+		if src == entity_name or src_node == entity_name:
 			summary["triggers"] += 1
 			if not summary["target_names"].has(tgt):
 				summary["target_names"].append(tgt)

--- a/docs/HammerForge_Data_Portability.md
+++ b/docs/HammerForge_Data_Portability.md
@@ -38,6 +38,21 @@ This document describes how to move data in and out of HammerForge safely.
   - The texture field is positional and whitespace delimited, so a palette name with a space in it is written with underscores (`Red Brick` becomes `Red_Brick`). Import matches on the same token.
   - A `.map` names a texture without saying where it lives, so a name the current palette does not hold leaves the face unset rather than adding a material. Load the palette first, then import.
 - UV offset, rotation and scale are written in both formats. Valve 220 additionally carries the texture axes; Classic Quake has no field for them.
+- Authored entity names round-trip as `targetname`, on both point entities and brush entities. The authored name is the address every I/O connection is aimed at, so without it a wired level comes back inert.
+- **Entity I/O connections round-trip, one key/value line per connection.** The key is the output name and the value is `target,input,parameter,delay,fire_once`, which is the order Hammer writes a VMF connection:
+
+  ```
+  {
+  "classname" "func_button"
+  "targetname" "btn"
+  "OnPressed" "door,Open,,0.0,0"
+  }
+  ```
+
+  - There is no `connections { }` block, because `.map` entity bodies are key/value lines and nothing else: a nested brace inside an entity is read as a brush by every parser including this one, so a block would not survive its own round trip.
+  - One line per connection, so two outputs on the same event both reach the file. The import reads the key/value lines in file order rather than through a dictionary, which would keep only the last of a repeated key.
+  - A line is read back as a connection only if it has five comma-separated fields, a numeric delay, and a target and input that are actually there. An ordinary entity property does not look like that, so wiring is told apart from settings without a naming rule on the key.
+  - The format defines no escape for a comma, so a comma inside a field is written as a space rather than escaped. A reader splitting on the comma would otherwise get a different number of fields than the writer wrote.
 - HammerForge surface-paint layers are not preserved, so `.hflevel` remains the editable source of truth.
 - Treat `.map` as a blockout exchange format, not a full fidelity export.
 - Cutters are not exported. A `.map` worldspawn holds additive solids only, so a subtraction brush written into one would fill the hole it was made for instead of cutting it. Carved shapes export uncut; bake or export `.glb` when the carve has to come with them.

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,394 tests across 176 scripts**: **3,387 passing tests**, seven intentional no-assert safety tests, and **17,348 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,408 tests across 177 scripts**: **3,401 passing tests**, seven intentional no-assert safety tests, and **17,390 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_entity_names_and_io.gd
+++ b/tests/test_entity_names_and_io.gd
@@ -1,0 +1,222 @@
+extends GutTest
+
+## An entity has two addresses: the node name Godot gave it, and the authored
+## `entity_name` that every connection is aimed at. These tests cover the places
+## the two were being mixed up, and the `.map` export that carried neither.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+const MapIOType = preload("res://addons/hammerforge/map_io.gd")
+const QuakeAdapter = preload("res://addons/hammerforge/map_adapters/hf_map_quake.gd")
+
+var root: LevelRoot
+
+
+func before_each():
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func _box(brush_id: String) -> DraftBrush:
+	return (
+		root.create_brush_from_info(
+			{"size": Vector3(32, 32, 32), "center": Vector3.ZERO, "brush_id": brush_id}
+		)
+		as DraftBrush
+	)
+
+
+## A point entity in the level.
+func _point_entity(entity_class: String) -> DraftEntity:
+	return root._create_entity_from_map({"classname": entity_class, "origin": Vector3.ZERO})
+
+
+## A brush entity with an authored name whose node name is something else.
+func _wired_button() -> DraftBrush:
+	var brush := _box("b1")
+	root.tie_brushes_to_entity(["b1"], "func_button")
+	brush.set_meta("entity_name", "btn")
+	root.add_entity_output(brush, "OnPressed", "door", "Open", "", 0.0, false)
+	return brush
+
+
+# -- Connection records use one namespace -------------------------------------
+
+
+func test_a_connection_reports_its_source_under_the_authored_name():
+	var brush := _wired_button()
+
+	var connections: Array = root.get_all_entity_connections()
+
+	assert_eq(connections.size(), 1, "One output means one connection")
+	assert_eq(connections[0]["source_name"], "btn", "The source is the name it is addressed by")
+	assert_eq(
+		connections[0]["source_node_name"], str(brush.name), "with the node name still available"
+	)
+
+
+func test_the_summary_counts_a_brush_entity_as_triggering():
+	_wired_button()
+
+	var summary: Dictionary = root.get_connection_summary("btn")
+
+	assert_eq(summary["triggers"], 1, "The button triggers one thing")
+	assert_eq(summary["target_names"], ["door"], "and it is the door")
+
+
+func test_the_summary_also_answers_to_the_node_name():
+	var brush := _wired_button()
+
+	var summary: Dictionary = root.get_connection_summary(str(brush.name))
+
+	assert_eq(summary["triggers"], 1, "An entity answers to both of its addresses")
+
+
+func test_an_entity_with_no_authored_name_still_reports_its_node_name():
+	var brush := _box("b1")
+	root.tie_brushes_to_entity(["b1"], "func_button")
+	root.add_entity_output(brush, "OnPressed", "door", "Open", "", 0.0, false)
+
+	var connections: Array = root.get_all_entity_connections()
+
+	assert_eq(connections[0]["source_name"], str(brush.name), "The node name is the fallback")
+
+
+func test_the_target_side_is_unchanged():
+	_wired_button()
+
+	var summary: Dictionary = root.get_connection_summary("door")
+
+	assert_eq(summary["triggered_by"], 1, "The door is triggered by one thing")
+	assert_eq(summary["source_names"], ["btn"], "named the way it is addressed")
+
+
+# -- The .map value shape -----------------------------------------------------
+
+
+func test_a_connection_round_trips_through_its_map_value():
+	var value := MapIOType.format_connection(
+		{
+			"target_name": "lamp",
+			"input_name": "TurnOn",
+			"parameter": "bright",
+			"delay": 1.5,
+			"fire_once": true
+		}
+	)
+	assert_eq(value, "lamp,TurnOn,bright,1.5,1", "Target, input, parameter, delay, once")
+
+	var parsed := MapIOType.parse_connection("OnOpen", value)
+
+	assert_eq(parsed["output_name"], "OnOpen", "The key is the output name")
+	assert_eq(parsed["target_name"], "lamp", "target")
+	assert_eq(parsed["input_name"], "TurnOn", "input")
+	assert_eq(parsed["parameter"], "bright", "parameter")
+	assert_eq(parsed["delay"], 1.5, "delay")
+	assert_true(parsed["fire_once"], "fire once")
+
+
+func test_an_ordinary_property_is_not_read_as_a_connection():
+	assert_true(MapIOType.parse_connection("angle", "90").is_empty(), "One field is not wiring")
+	assert_true(MapIOType.parse_connection("color", "1,0,0").is_empty(), "and nor are three")
+	assert_true(
+		MapIOType.parse_connection("x", "a,b,c,not_a_number,0").is_empty(),
+		"The delay field has to be a number"
+	)
+	assert_true(
+		MapIOType.parse_connection("x", ",Open,,0.0,0").is_empty(), "and a target has to be there"
+	)
+
+
+# -- Export and import --------------------------------------------------------
+
+
+func test_a_brush_entity_writes_its_name_and_its_outputs():
+	_wired_button()
+
+	var text: String = MapIOType.export_map_from_level(root, QuakeAdapter.new())
+
+	assert_string_contains(text, '"classname" "func_button"')
+	assert_string_contains(text, '"targetname" "btn"')
+	assert_string_contains(text, '"OnPressed" "door,Open,,0.0,0"')
+
+
+func test_a_point_entity_writes_its_name_and_its_outputs():
+	var entity = _point_entity("light_point")
+	entity.set_meta("entity_name", "lamp")
+	root.add_entity_output(entity, "OnLit", "btn", "Lock", "", 0.0, false)
+
+	var text: String = MapIOType.export_map_from_level(root, QuakeAdapter.new())
+
+	assert_string_contains(text, '"targetname" "lamp"')
+	assert_string_contains(text, '"OnLit" "btn,Lock,,0.0,0"')
+
+
+func test_two_outputs_on_the_same_event_both_reach_the_file():
+	var brush := _box("b1")
+	root.tie_brushes_to_entity(["b1"], "func_button")
+	brush.set_meta("entity_name", "btn")
+	root.add_entity_output(brush, "OnPressed", "door_a", "Open", "", 0.0, false)
+	root.add_entity_output(brush, "OnPressed", "door_b", "Open", "", 0.0, false)
+
+	var text: String = MapIOType.export_map_from_level(root, QuakeAdapter.new())
+
+	assert_string_contains(text, '"OnPressed" "door_a,Open,,0.0,0"')
+	assert_string_contains(text, '"OnPressed" "door_b,Open,,0.0,0"')
+
+
+func test_an_unwired_entity_block_gains_nothing():
+	_box("b1")
+	root.tie_brushes_to_entity(["b1"], "func_detail")
+
+	var text: String = MapIOType.export_map_from_level(root, QuakeAdapter.new())
+
+	assert_false(text.contains("targetname"), "An entity with no name writes no targetname")
+
+
+func test_a_wired_brush_entity_survives_an_export_and_import():
+	_wired_button()
+	var path := "user://hf_test_entity_io.map"
+	assert_eq(root.export_map(path), OK, "Export should succeed")
+
+	assert_eq(root.import_map(path), OK, "Import should succeed")
+
+	var connections: Array = root.get_all_entity_connections()
+	assert_eq(connections.size(), 1, "The connection should come back")
+	assert_eq(connections[0]["source_name"], "btn", "under its authored name")
+	assert_eq(connections[0]["target_name"], "door", "aimed where it was aimed")
+	assert_eq(connections[0]["input_name"], "Open", "at the input it named")
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+
+
+func test_a_wired_point_entity_survives_an_export_and_import():
+	var entity = _point_entity("light_point")
+	entity.set_meta("entity_name", "lamp")
+	root.add_entity_output(entity, "OnLit", "btn", "Lock", "", 2.0, true)
+	var path := "user://hf_test_entity_io_point.map"
+	root.export_map(path)
+
+	root.import_map(path)
+
+	var connections: Array = root.get_all_entity_connections()
+	assert_eq(connections.size(), 1, "The connection should come back")
+	assert_eq(connections[0]["source_name"], "lamp", "under its authored name")
+	assert_eq(connections[0]["delay"], 2.0, "with its delay")
+	assert_true(connections[0]["fire_once"], "and its fire once flag")
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+
+
+func test_an_imported_output_is_not_also_an_entity_property():
+	var entity = _point_entity("light_point")
+	entity.set_meta("entity_name", "lamp")
+	root.add_entity_output(entity, "OnLit", "btn", "Lock", "", 0.0, false)
+	var path := "user://hf_test_entity_io_props.map"
+	root.export_map(path)
+
+	root.import_map(path)
+
+	for node in root.entities_node.get_children():
+		assert_false(node.entity_data.has("OnLit"), "Wiring should not land in entity_data")
+		assert_false(node.entity_data.has("targetname"), "and nor should the name")
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(path))


### PR DESCRIPTION
Two bugs about the same thing: an entity has two addresses and the code kept mixing them, or dropping the one that matters.

Fixes #287
Fixes #288

- `get_all_connections()` built the source side from the node name and the target side from the authored name. For a brush entity the node name is whatever Godot generated, so `get_connection_summary()` reported every wired entity as triggering nothing. `source_name` is the authored name when there is one, `source_node_name` carries the other, and the summary answers to either address.
- `.map` export never read the authored name or the outputs. The name is written as `targetname`, and each connection is one key/value line: the output name as the key, `target,input,parameter,delay,fire_once` as the value, which is the order Hammer writes a VMF connection.

On the shape, since the issue left it to me: there is no `connections { }` block. A .map entity body is key/value lines and nothing else, and a nested brace inside an entity is read as a brush by every parser including this one, so a Source style block would not survive its own round trip.

One line per connection, so two outputs on the same event both reach the file. That meant the parser had to keep the key/value lines in file order alongside the properties dictionary, which keeps only the last of a repeated key.

A line reads back as a connection only with five comma-separated fields, a numeric delay, and a target and input that are there, so wiring is told apart from settings by shape rather than by a naming rule on the key. The shape is documented in the portability notes.

New `tests/test_entity_names_and_io.gd`, 14 tests. Nine fail on main. Full suite 3306 passing, 0 failing.