### PR TITLE
Accept the numeric keypad for dimension entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -763,6 +763,18 @@ The format is based on Keep a Changelog, and this project follows semantic versi
     both ways, four ordinary properties that must not read as connections, both
     entity kinds exporting, two outputs on one event, an unwired block gaining
     nothing, and a round trip for each entity kind.
+- **Numeric dimension entry accepts the keypad** (#297). `KEY_KP_0` through
+  `KEY_KP_9` and `KEY_KP_PERIOD` were not handled anywhere, while `KEY_KP_ENTER`
+  was accepted in six places including the commit key right below the digit
+  check. So typing a size on the keypad mid-drag put nothing in the buffer, and
+  then keypad Enter ended the gesture at whatever size the mouse happened to be
+  at. The half that worked made the half that did not look like the tool had
+  ignored the number rather than never having received it. Mapped by keycode
+  rather than by reading numlock, since with numlock off these keys arrive as
+  arrows and never reach the handler.
+  - **Coverage** (`tests/test_plugin_numeric_input.gd`): a keypad-typed decimal
+    driving the preview, `KEY_KP_0` at the far end of the range, keypad Enter
+    committing a keypad-typed value, and one decimal point whichever key typed it.
 - **A prefab could wire its copy's outputs to the entities it was built from.**
   `HFPrefab.instantiate()` remapped I/O by turning each old node name into the new
   one and then looking that name back up. The lookup resolves an authored

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,408 tests across 177 test scripts (3,401 passing plus seven intentional no-assert safety tests; 17,390 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,412 tests across 177 test scripts (3,405 passing plus seven intentional no-assert safety tests; 17,397 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,408 tests** across **177 scripts** (**3,401 passing** plus seven intentional no-assert safety tests; **17,390 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,412 tests** across **177 scripts** (**3,405 passing** plus seven intentional no-assert safety tests; **17,397 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3401%20passing-brightgreen" alt="3401 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3405%20passing-brightgreen" alt="3405 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,408 tests across 177 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,412 tests across 177 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/plugin_numeric_input.gd
+++ b/addons/hammerforge/plugin_numeric_input.gd
@@ -13,12 +13,20 @@ static func handle(plugin: Object, event: InputEventKey, root: Node) -> int:
 		return PASS
 
 	var keycode := event.keycode
-	if keycode >= KEY_0 and keycode <= KEY_9:
-		plugin.numeric_buffer += str(keycode - KEY_0)
+	# The keypad counts. Typing a dimension mid-drag is the numeric entry path and
+	# a numeric keypad is where people type numbers, and KEY_KP_ENTER was already
+	# accepted below, so the keypad could end a gesture at whatever size the mouse
+	# happened to be at without ever having put a digit in the buffer.
+	#
+	# Mapped by keycode rather than by reading numlock, because with numlock off
+	# these keys arrive as arrows and navigation keys and never reach here at all.
+	var digit := _digit_of(keycode)
+	if digit >= 0:
+		plugin.numeric_buffer += str(digit)
 		update_preview(plugin, root)
 		return STOP
 
-	if keycode == KEY_PERIOD and "." not in plugin.numeric_buffer:
+	if keycode in [KEY_PERIOD, KEY_KP_PERIOD] and "." not in plugin.numeric_buffer:
 		plugin.numeric_buffer += "."
 		update_preview(plugin, root)
 		return STOP
@@ -37,6 +45,16 @@ static func handle(plugin: Object, event: InputEventKey, root: Node) -> int:
 		return STOP
 
 	return PASS
+
+
+## The digit a keycode types, on the top row or the keypad, or -1 for anything
+## else.
+static func _digit_of(keycode: int) -> int:
+	if keycode >= KEY_0 and keycode <= KEY_9:
+		return keycode - KEY_0
+	if keycode >= KEY_KP_0 and keycode <= KEY_KP_9:
+		return keycode - KEY_KP_0
+	return -1
 
 
 static func update_preview(plugin: Object, root: Node) -> void:

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,408 tests across 177 scripts**: **3,401 passing tests**, seven intentional no-assert safety tests, and **17,390 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,412 tests across 177 scripts**: **3,405 passing tests**, seven intentional no-assert safety tests, and **17,397 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_plugin_numeric_input.gd
+++ b/tests/test_plugin_numeric_input.gd
@@ -191,3 +191,63 @@ func test_plugin_callbacks_are_thin_numeric_delegates() -> void:
 		"HFPluginNumericInput.apply_value",
 	]:
 		assert_true(source.contains(call), "%s must be delegated" % call)
+
+
+func test_keypad_digits_and_decimal_fill_the_buffer() -> void:
+	# KEY_KP_ENTER was already accepted, so before this the keypad could end a
+	# gesture at whatever size the mouse was at without a digit ever landing.
+	var plugin := FakePlugin.new()
+	var root := FakeRoot.new()
+	root.input_state.dragging = true
+	root.input_state.drag_base = true
+	assert_eq(
+		HFPluginNumericInput.handle(plugin, _key(KEY_KP_1), root),
+		EditorPlugin.AFTER_GUI_INPUT_STOP,
+		"A keypad digit should be consumed, not passed on"
+	)
+	HFPluginNumericInput.handle(plugin, _key(KEY_KP_2), root)
+	HFPluginNumericInput.handle(plugin, _key(KEY_KP_PERIOD), root)
+	HFPluginNumericInput.handle(plugin, _key(KEY_KP_5), root)
+	assert_eq(plugin.numeric_buffer, "12.5", "The keypad should type the same as the top row")
+	assert_eq(root.input_state.drag_end, Vector3(12.5, 0.0, 12.5), "and drive the same preview")
+	root.free()
+
+
+func test_keypad_zero_is_a_digit_not_a_pass_through() -> void:
+	var plugin := FakePlugin.new()
+	var root := FakeRoot.new()
+	root.input_state.dragging = true
+	root.input_state.drag_base = true
+	HFPluginNumericInput.handle(plugin, _key(KEY_KP_1), root)
+	HFPluginNumericInput.handle(plugin, _key(KEY_KP_0), root)
+	assert_eq(plugin.numeric_buffer, "10", "KEY_KP_0 sits at the far end of the range")
+	root.free()
+
+
+func test_keypad_enter_commits_a_keypad_typed_value() -> void:
+	var plugin := FakePlugin.new()
+	var root := FakeRoot.new()
+	root.input_state.dragging = true
+	root.input_state.drag_base = true
+	HFPluginNumericInput.handle(plugin, _key(KEY_KP_1), root)
+	HFPluginNumericInput.handle(plugin, _key(KEY_KP_2), root)
+	HFPluginNumericInput.handle(plugin, _key(KEY_KP_8), root)
+
+	var result := HFPluginNumericInput.handle(plugin, _key(KEY_KP_ENTER), root)
+
+	assert_eq(result, EditorPlugin.AFTER_GUI_INPUT_STOP, "Keypad Enter still commits")
+	assert_eq(root.input_state.drag_end, Vector3(128.0, 0.0, 128.0), "at the size that was typed")
+	root.free()
+
+
+func test_a_second_keypad_decimal_is_ignored() -> void:
+	var plugin := FakePlugin.new()
+	var root := FakeRoot.new()
+	root.input_state.dragging = true
+	root.input_state.drag_base = true
+	HFPluginNumericInput.handle(plugin, _key(KEY_KP_1), root)
+	HFPluginNumericInput.handle(plugin, _key(KEY_KP_PERIOD), root)
+	HFPluginNumericInput.handle(plugin, _key(KEY_PERIOD), root)
+	HFPluginNumericInput.handle(plugin, _key(KEY_KP_5), root)
+	assert_eq(plugin.numeric_buffer, "1.5", "One decimal point, whichever key typed it")
+	root.free()


### PR DESCRIPTION
Fixes #297

`KEY_KP_0` through `KEY_KP_9` and `KEY_KP_PERIOD` were not handled anywhere, while `KEY_KP_ENTER` was accepted right below the digit check. Typing a size on the keypad mid-drag put nothing in the buffer, then keypad Enter ended the gesture at whatever size the mouse was at.

Mapped by keycode, not by reading numlock, since with numlock off these keys arrive as arrows and never reach the handler at all.

Four new tests in `tests/test_plugin_numeric_input.gd`, all four fail on main. Full suite 3296 passing, 0 failing.