### PR TITLE
Refuse a visgroup rename onto a name that is taken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -775,6 +775,19 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   - **Coverage** (`tests/test_plugin_numeric_input.gd`): a keypad-typed decimal
     driving the preview, `KEY_KP_0` at the far end of the range, keypad Enter
     committing a keypad-typed value, and one decimal point whichever key typed it.
+- **Renaming a visgroup onto an existing name is refused** (#296).
+  `HFVisgroupSystem.rename_visgroup()` guarded an empty name, an unchanged name
+  and a missing source, but not the target already existing. Renaming A to B when
+  B existed overwrote B's record, colour and visibility and all, then rewrote the
+  name on every node that carried A, so two memberships silently became one. The
+  loss showed up later rather than at the time: B's members were hidden, B's
+  record was gone, and the next `refresh_visibility()` made them visible again
+  with nothing to say why. It returns whether the rename happened, so a rename
+  field can say the name is taken. Merging two visgroups is a different
+  operation, and one somebody should have to ask for.
+  - **Coverage** (`tests/test_visgroup_system.gd`): a refused rename leaving both
+    records, both memberships and B's hidden state alone, plus the return value
+    across a working rename, a missing source and an empty name.
 - **A prefab could wire its copy's outputs to the entities it was built from.**
   `HFPrefab.instantiate()` remapped I/O by turning each old node name into the new
   one and then looking that name back up. The lookup resolves an authored

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,412 tests across 177 test scripts (3,405 passing plus seven intentional no-assert safety tests; 17,397 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,414 tests across 177 test scripts (3,407 passing plus seven intentional no-assert safety tests; 17,406 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,412 tests** across **177 scripts** (**3,405 passing** plus seven intentional no-assert safety tests; **17,397 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,414 tests** across **177 scripts** (**3,407 passing** plus seven intentional no-assert safety tests; **17,406 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3405%20passing-brightgreen" alt="3405 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3407%20passing-brightgreen" alt="3407 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,412 tests across 177 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,414 tests across 177 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/systems/hf_visgroup_system.gd
+++ b/addons/hammerforge/systems/hf_visgroup_system.gd
@@ -37,11 +37,25 @@ func remove_visgroup(vg_name: String) -> void:
 	refresh_visibility()
 
 
-func rename_visgroup(old_name: String, new_name: String) -> void:
+## Rename a visgroup. Returns whether it happened.
+##
+## Refuses a name another visgroup already has. Without that guard, renaming A to
+## an existing B overwrote B's record, colour and visibility and all, and then
+## rewrote the name on every node that carried A, so the two memberships silently
+## became one. The user asked to rename one visgroup and lost a different one,
+## and the loss showed up later: B's members were hidden, B's record was gone,
+## and the next refresh_visibility() made them visible again with nothing in the
+## UI to say why.
+##
+## Merging two visgroups is a different operation, and one somebody should have
+## to ask for by name.
+func rename_visgroup(old_name: String, new_name: String) -> bool:
 	if old_name == "" or new_name == "" or old_name == new_name:
-		return
+		return false
 	if not visgroups.has(old_name):
-		return
+		return false
+	if visgroups.has(new_name):
+		return false
 	visgroups[new_name] = visgroups[old_name]
 	visgroups.erase(old_name)
 	for node in _all_managed_nodes():
@@ -50,6 +64,7 @@ func rename_visgroup(old_name: String, new_name: String) -> void:
 		if idx >= 0:
 			vgs[idx] = new_name
 			node.set_meta("visgroups", vgs)
+	return true
 
 
 func set_visgroup_visible(vg_name: String, visible: bool) -> void:

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,412 tests across 177 scripts**: **3,405 passing tests**, seven intentional no-assert safety tests, and **17,397 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,414 tests across 177 scripts**: **3,407 passing tests**, seven intentional no-assert safety tests, and **17,406 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_visgroup_system.gd
+++ b/tests/test_visgroup_system.gd
@@ -107,6 +107,34 @@ func test_rename_visgroup():
 	assert_eq(names[0], "detail")
 
 
+func test_rename_onto_an_existing_name_is_refused():
+	var draft_parent = root.get_node("DraftBrushes")
+	var b1 = _make_brush(draft_parent)
+	var b2 = _make_brush(draft_parent)
+	sys.create_visgroup("A", Color.RED)
+	sys.create_visgroup("B", Color.BLUE)
+	sys.add_to_visgroup(b1, "A")
+	sys.add_to_visgroup(b2, "B")
+	sys.set_visgroup_visible("B", false)
+
+	assert_false(sys.rename_visgroup("A", "B"), "The name is taken, so the rename is refused")
+
+	var names = sys.get_visgroup_names()
+	assert_eq(names.size(), 2, "Both visgroups should survive")
+	assert_true(names.has("A"), "A should still be there")
+	assert_true(names.has("B"), "and so should B")
+	assert_false(sys.is_visgroup_visible("B"), "B should still be hidden")
+	assert_eq(sys.get_members_of("B").size(), 1, "and it should not have absorbed A's member")
+
+
+func test_rename_reports_whether_it_happened():
+	sys.create_visgroup("walls")
+
+	assert_true(sys.rename_visgroup("walls", "detail"), "A rename that works says so")
+	assert_false(sys.rename_visgroup("gone", "detail2"), "A missing source does not")
+	assert_false(sys.rename_visgroup("detail", ""), "and nor does an empty name")
+
+
 func test_rename_updates_membership():
 	var draft_parent = root.get_node("DraftBrushes")
 	var b = _make_brush(draft_parent)


### PR DESCRIPTION
Fixes #296

`rename_visgroup()` guarded an empty name, an unchanged name and a missing source, but not the target already existing. Renaming A to B when B existed overwrote B's record, colour and visibility and all, then rewrote the name on every node carrying A, merging the two memberships.

It returns bool now, so a rename field can say the name is taken. Merging two visgroups is a different operation and should be asked for by name.

Two new tests in `tests/test_visgroup_system.gd`. The collision one fails on main with exactly the destruction the issue describes: one visgroup left instead of two, A gone, B's hidden state gone with its record, and both brushes in one group. Full suite 3294 passing, 0 failing.