### PR TITLE
Count the dry run through the same filters the bake uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -788,6 +788,19 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   - **Coverage** (`tests/test_visgroup_system.gd`): a refused rename leaving both
     records, both memberships and B's hidden state alone, plus the return value
     across a working rename, a missing source and an empty name.
+- **The bake dry run counts what the bake will actually take** (#295).
+  `count_brushes_in()` counted container children and checked neither the cordon
+  nor `bake_visible_only`, while the bake checks each of them in seven places. So
+  the preflight, which is the thing that tells a user what a bake is about to do,
+  reported brushes the bake was going to skip: a cordon with one brush inside it
+  and one outside reported two and baked one. A single `brush_bakes()` predicate
+  now answers the question, and the two `_container_has_effective_*` loops ask it
+  too, so the counting and the baking cannot drift apart again. Subtraction is
+  deliberately not part of it, since a subtractor is a brush the bake takes and
+  uses, and pending cuts get their own line in the dry run.
+  - **Coverage** (`tests/test_bake_system.gd`): a brush outside the cordon, a
+    hidden brush under Bake Visible Only, a fully cordoned out level reporting no
+    chunks, and both filters off still counting everything.
 - **A prefab could wire its copy's outputs to the entities it was built from.**
   `HFPrefab.instantiate()` remapped I/O by turning each old node name into the new
   one and then looking that name back up. The lookup resolves an authored

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,414 tests across 177 test scripts (3,407 passing plus seven intentional no-assert safety tests; 17,406 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,418 tests across 177 test scripts (3,411 passing plus seven intentional no-assert safety tests; 17,411 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,414 tests** across **177 scripts** (**3,407 passing** plus seven intentional no-assert safety tests; **17,406 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,418 tests** across **177 scripts** (**3,411 passing** plus seven intentional no-assert safety tests; **17,411 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3407%20passing-brightgreen" alt="3407 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3411%20passing-brightgreen" alt="3411 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,414 tests across 177 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,418 tests across 177 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/systems/hf_bake_system.gd
+++ b/addons/hammerforge/systems/hf_bake_system.gd
@@ -449,9 +449,7 @@ func _has_positive_structural_brush(container: Node3D) -> bool:
 		var brush := child as DraftBrush
 		if brush.operation == CSGShape3D.OPERATION_SUBTRACTION:
 			continue
-		if root.bake_visible_only and not brush.visible:
-			continue
-		if root.cordon_enabled and not _brush_in_cordon(brush):
+		if not brush_bakes(brush):
 			continue
 		if not _is_structural_brush(brush):
 			continue
@@ -475,9 +473,7 @@ func _container_has_effective_subtractor(container: Node3D, force_subtract: bool
 		if not (child is DraftBrush) or root.is_entity_node(child):
 			continue
 		var brush := child as DraftBrush
-		if root.bake_visible_only and not brush.visible:
-			continue
-		if root.cordon_enabled and not _brush_in_cordon(brush):
+		if not brush_bakes(brush):
 			continue
 		if not _is_structural_brush(brush):
 			continue
@@ -850,12 +846,34 @@ func _attach_io_dispatcher(container: Node3D) -> void:
 	root._assign_owner_recursive(dispatcher)
 
 
+## Whether the bake will take this brush at all.
+##
+## The cordon and `bake_visible_only` are each checked in seven places along the
+## bake path and in none of the counting. So the dry run, which is the preflight
+## the user reads before committing to a bake, reported brushes the bake was
+## going to skip. One predicate, so the two cannot drift apart again.
+##
+## Subtraction is deliberately not part of this. A subtractor is a brush the bake
+## takes and uses, and the dry run reports pending cuts on their own line.
+func brush_bakes(brush: DraftBrush) -> bool:
+	if brush == null or not is_instance_valid(brush):
+		return false
+	if root.is_entity_node(brush):
+		return false
+	if root.bake_visible_only and not brush.visible:
+		return false
+	if root.cordon_enabled and not _brush_in_cordon(brush):
+		return false
+	return true
+
+
+## How many brushes in this container the bake will take.
 func count_brushes_in(container: Node3D) -> int:
 	if not container:
 		return 0
 	var count := 0
 	for child in container.get_children():
-		if child is DraftBrush and not root.is_entity_node(child):
+		if child is DraftBrush and brush_bakes(child as DraftBrush):
 			count += 1
 	return count
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -159,7 +159,7 @@ Grid-based paint layers with chunked storage for large worlds:
 | **LODs** | Auto-generate level-of-detail meshes |
 | **Lightmap UV2** | Unwrap for lightmap baking |
 | **Navmesh** | Bake navigation mesh |
-| **Dry run** | Preview bake counts without building |
+| **Dry run** | Preview bake counts without building. Counts through the cordon and Bake Visible Only, so the number matches what the bake takes |
 | **Bake Selected** | Bake only selected brushes (merged into existing output) |
 | **Bake Changed** | Bake only dirty-tagged brushes since last successful bake |
 | **Preview modes** | Full / Wireframe / Proxy toggle for ultra-fast iteration |

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,414 tests across 177 scripts**: **3,407 passing tests**, seven intentional no-assert safety tests, and **17,406 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,418 tests across 177 scripts**: **3,411 passing tests**, seven intentional no-assert safety tests, and **17,411 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_bake_system.gd
+++ b/tests/test_bake_system.gd
@@ -607,6 +607,51 @@ func test_dry_run_with_draft_brushes():
 	assert_eq(result["chunk_count"], 1, "Non-chunked bake should report 1 chunk when brushes exist")
 
 
+func test_dry_run_counts_through_the_cordon():
+	root.cordon_enabled = true
+	root.cordon_aabb = AABB(Vector3(-16, -16, -16), Vector3(32, 32, 32))
+	_make_brush(root.draft_brushes_node, Vector3.ZERO, Vector3(8, 8, 8))
+	_make_brush(root.draft_brushes_node, Vector3(500, 0, 0), Vector3(8, 8, 8))
+
+	var result = bake_sys.bake_dry_run()
+
+	assert_eq(result["draft"], 1, "The dry run should count what the bake will take")
+
+
+func test_dry_run_counts_through_bake_visible_only():
+	root.bake_visible_only = true
+	_make_brush(root.draft_brushes_node)
+	var hidden = _make_brush(root.draft_brushes_node)
+	hidden.visible = false
+
+	var result = bake_sys.bake_dry_run()
+
+	assert_eq(result["draft"], 1, "A hidden brush is not going to bake, so it is not counted")
+
+
+func test_dry_run_counts_everything_when_neither_filter_is_on():
+	root.cordon_enabled = false
+	root.bake_visible_only = false
+	_make_brush(root.draft_brushes_node, Vector3(500, 0, 0), Vector3(8, 8, 8))
+	var hidden = _make_brush(root.draft_brushes_node)
+	hidden.visible = false
+
+	var result = bake_sys.bake_dry_run()
+
+	assert_eq(result["draft"], 2, "With both filters off, everything counts")
+
+
+func test_a_fully_cordoned_out_level_reports_no_chunks():
+	root.cordon_enabled = true
+	root.cordon_aabb = AABB(Vector3(-16, -16, -16), Vector3(32, 32, 32))
+	_make_brush(root.draft_brushes_node, Vector3(500, 0, 0), Vector3(8, 8, 8))
+
+	var result = bake_sys.bake_dry_run()
+
+	assert_eq(result["draft"], 0, "Nothing is in the cordon")
+	assert_eq(result["chunk_count"], 0, "so there is nothing to chunk")
+
+
 func test_dry_run_with_pending_brushes():
 	_make_brush(root.pending_node)
 	var result = bake_sys.bake_dry_run()


### PR DESCRIPTION
Fixes #295

`count_brushes_in()` counted container children and checked neither the cordon nor `bake_visible_only`, while the bake checks each of them in seven places. The preflight therefore reported brushes the bake would skip: a cordon with one brush inside and one outside reported two and baked one.

A single `brush_bakes()` predicate answers it now, and the two `_container_has_effective_*` loops go through it as well, so the counting and the baking share one statement of the rule.

Subtraction is deliberately not part of the predicate. A subtractor is a brush the bake takes and uses, and pending cuts already get their own line in the dry run.

Four new tests in `tests/test_bake_system.gd`. Three fail on main; the fourth is a guard that both filters off still counts everything. Full suite 3296 passing, 0 failing.