### PR TITLE
Normalise a brush size at creation instead of building it inside out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -801,6 +801,26 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   - **Coverage** (`tests/test_bake_system.gd`): a brush outside the cordon, a
     hidden brush under Bake Visible Only, a fully cordoned out level reporting no
     chunks, and both filters off still counting everything.
+- **A brush cannot be created at a zero or negative size** (#289).
+  `create_brush_from_info()` took `info["size"]` as given, and it is the single
+  door into the level for undo restore, duplication, prefab instancing, `.map`
+  import and `.hflevel` load. A negative component gave the basis a negative
+  determinant, which inverts the face winding invisibly: every `FaceData` ended
+  up with a normal pointing the opposite way from the vertices it holds, which
+  only shows at bake or in an exported plane. A zero component gave a brush with
+  no volume. Both landed in the draft container with an id and counted as live.
+  Each component is now taken as its magnitude and floored at 0.1, the same
+  figure the validator's auto fix uses, with one warning naming the size that was
+  asked for and the one used.
+  - **The validator tells the two apart.** A negative size was being reported as
+    a "Zero-size brush", which sends the reader looking for the wrong thing. It
+    reads "Inverted brush" now, and a genuine zero extent still reads
+    "Zero-size brush".
+  - **Coverage** (`tests/test_brush_size_guard.gd`): a negative size building the
+    right way out with a positive determinant, every face normal agreeing with
+    its own winding, a zero size, a partly zero size moving only the bad axis, a
+    good size passing through untouched, a size that is not a Vector3, and both
+    validator messages.
 - **A prefab could wire its copy's outputs to the entities it was built from.**
   `HFPrefab.instantiate()` remapped I/O by turning each old node name into the new
   one and then looking that name back up. The lookup resolves an authored

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,418 tests across 177 test scripts (3,411 passing plus seven intentional no-assert safety tests; 17,411 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,427 tests across 178 test scripts (3,420 passing plus seven intentional no-assert safety tests; 17,433 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,418 tests** across **177 scripts** (**3,411 passing** plus seven intentional no-assert safety tests; **17,411 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,427 tests** across **178 scripts** (**3,420 passing** plus seven intentional no-assert safety tests; **17,433 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3411%20passing-brightgreen" alt="3411 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3420%20passing-brightgreen" alt="3420 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,418 tests across 177 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,427 tests across 178 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/systems/hf_brush_system.gd
+++ b/addons/hammerforge/systems/hf_brush_system.gd
@@ -76,11 +76,50 @@ func place_brush(
 	return true
 
 
+## The smallest floor a brush may be on any axis. The same figure the validator's
+## auto fix uses, so the two agree about what counts as too small.
+const MIN_BRUSH_EXTENT := 0.1
+
+
+## A size a brush can actually be built from, and a warning when it was not.
+##
+## create_brush_from_info() is the single door into the level for undo restore,
+## duplication, prefab instancing, .map import and .hflevel load, so a bad size
+## from any of those used to become a brush that looked fine in the tree. A
+## negative component gives the basis a negative determinant, which inverts the
+## face winding invisibly: each FaceData ends up with a normal pointing the
+## opposite way from the vertices it holds, and that only shows up at bake or in
+## an exported plane. A zero component gives a brush with no volume at all. Both
+## landed in the draft container with an id and counted as live.
+##
+## The validator did catch them, but only if somebody ran Validate.
+static func _usable_size(raw) -> Vector3:
+	if not (raw is Vector3):
+		return Vector3(MIN_BRUSH_EXTENT, MIN_BRUSH_EXTENT, MIN_BRUSH_EXTENT)
+	var size: Vector3 = raw
+	var fixed := Vector3(
+		maxf(MIN_BRUSH_EXTENT, absf(size.x)),
+		maxf(MIN_BRUSH_EXTENT, absf(size.y)),
+		maxf(MIN_BRUSH_EXTENT, absf(size.z))
+	)
+	if not fixed.is_equal_approx(size):
+		HFLog.warn(
+			(
+				(
+					"Brush size %s cannot be built. Using %s instead. A negative size builds the "
+					+ "brush inside out and a zero size builds no volume."
+				)
+				% [str(size), str(fixed)]
+			)
+		)
+	return fixed
+
+
 func create_brush_from_info(info: Dictionary) -> Node:
 	if info.is_empty():
 		return null
 	var shape = info.get("shape", root.BrushShape.BOX)
-	var size = info.get("size", root.drag_size_default)
+	var size = _usable_size(info.get("size", root.drag_size_default))
 	var sides = int(info.get("sides", 4))
 	var operation = info.get("operation", CSGShape3D.OPERATION_UNION)
 	var committed = bool(info.get("committed", false))

--- a/addons/hammerforge/systems/hf_validation_system.gd
+++ b/addons/hammerforge/systems/hf_validation_system.gd
@@ -87,7 +87,13 @@ func validate(auto_fix: bool = false) -> Dictionary:
 		var brush := node as DraftBrush
 		var size = brush.size
 		if size.x <= 0.0 or size.y <= 0.0 or size.z <= 0.0:
-			issues.append("Zero-size brush: %s" % brush.name)
+			# A negative size is not a zero size. It builds the brush inside out,
+			# with every face normal pointing the opposite way from the vertices
+			# it holds, and saying "zero" sends the reader looking for the wrong
+			# thing.
+			var negative: bool = size.x < 0.0 or size.y < 0.0 or size.z < 0.0
+			var label: String = "Inverted brush" if negative else "Zero-size brush"
+			issues.append("%s: %s" % [label, brush.name])
 			if auto_fix:
 				var next = Vector3(
 					max(0.1, abs(size.x)), max(0.1, abs(size.y)), max(0.1, abs(size.z))

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,418 tests across 177 scripts**: **3,411 passing tests**, seven intentional no-assert safety tests, and **17,411 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,427 tests across 178 scripts**: **3,420 passing tests**, seven intentional no-assert safety tests, and **17,433 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_brush_size_guard.gd
+++ b/tests/test_brush_size_guard.gd
@@ -1,0 +1,114 @@
+extends GutTest
+
+## create_brush_from_info() is the single door into the level for undo restore,
+## duplication, prefab instancing, .map import and .hflevel load. A size it
+## cannot build has to be refused there rather than becoming a brush that looks
+## fine in the tree and bakes to nothing.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+const HFBrushSystemType = preload("res://addons/hammerforge/systems/hf_brush_system.gd")
+
+var root: LevelRoot
+
+
+func before_each():
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func _make(size) -> DraftBrush:
+	return root.create_brush_from_info({"size": size, "center": Vector3.ZERO}) as DraftBrush
+
+
+func test_a_negative_size_is_built_the_right_way_out():
+	var brush := _make(Vector3(-32, 32, 32))
+
+	assert_not_null(brush, "The brush is still created")
+	assert_eq(brush.size, Vector3(32, 32, 32), "at the size it asked for, the right way round")
+	assert_gt(brush.global_transform.basis.determinant(), 0.0, "with a basis that does not invert")
+
+
+func test_every_face_normal_agrees_with_its_own_vertices():
+	var brush := _make(Vector3(-32, 32, 32))
+
+	for face in brush.faces:
+		# FaceData winds clockwise seen from outside, so (c - a) x (b - a) is the
+		# outward normal. A negative determinant used to flip one and not the
+		# other.
+		var a: Vector3 = face.local_verts[0]
+		var b: Vector3 = face.local_verts[1]
+		var c: Vector3 = face.local_verts[2]
+		var from_verts: Vector3 = (c - a).cross(b - a).normalized()
+		assert_gt(from_verts.dot(face.normal), 0.9, "The stored normal should match the winding")
+
+
+func test_a_zero_size_becomes_a_brush_with_volume():
+	var brush := _make(Vector3.ZERO)
+
+	assert_not_null(brush, "The brush is still created")
+	assert_gt(brush.size.x, 0.0, "with an x extent")
+	assert_gt(brush.size.y, 0.0, "a y extent")
+	assert_gt(brush.size.z, 0.0, "and a z extent")
+
+
+func test_a_partly_zero_size_only_moves_the_axis_that_was_wrong():
+	var brush := _make(Vector3(64, 0, 16))
+
+	assert_eq(brush.size.x, 64.0, "A good axis is left alone")
+	assert_eq(brush.size.z, 16.0, "and so is the other one")
+	assert_gt(brush.size.y, 0.0, "while the bad one gets the floor")
+
+
+func test_a_good_size_is_untouched():
+	var brush := _make(Vector3(48, 16, 8))
+
+	assert_eq(brush.size, Vector3(48, 16, 8), "A usable size passes straight through")
+
+
+func test_a_size_that_is_not_a_vector3_still_builds_something():
+	var brush := root.create_brush_from_info({"size": "not a size"}) as DraftBrush
+
+	assert_not_null(brush, "A junk size should not produce a null brush")
+	assert_gt(brush.size.x, 0.0, "and the brush should have volume")
+
+
+func test_the_validator_finds_nothing_to_fix_after_a_bad_size():
+	_make(Vector3(-32, 32, 32))
+	_make(Vector3.ZERO)
+
+	var report: Dictionary = root.validate_level(false)
+
+	var brush_issues: Array = []
+	for issue in report["issues"]:
+		if str(issue).contains("brush"):
+			brush_issues.append(str(issue))
+	assert_eq(brush_issues, [], "Validate should have nothing to say about a brush now")
+
+
+func test_the_validator_calls_an_inverted_brush_inverted():
+	var brush := _make(Vector3(32, 32, 32))
+	# Reach past the guard, the way a brush that predates it would look.
+	brush.size = Vector3(-32, 32, 32)
+
+	var report: Dictionary = root.validate_level(false)
+
+	var found := false
+	for issue in report["issues"]:
+		if str(issue).begins_with("Inverted brush"):
+			found = true
+	assert_true(found, "A negative size is inverted, not zero-size")
+
+
+func test_the_validator_still_calls_a_zero_brush_zero_size():
+	var brush := _make(Vector3(32, 32, 32))
+	brush.size = Vector3(0, 32, 32)
+
+	var report: Dictionary = root.validate_level(false)
+
+	var found := false
+	for issue in report["issues"]:
+		if str(issue).begins_with("Zero-size brush"):
+			found = true
+	assert_true(found, "A zero extent is still zero-size")


### PR DESCRIPTION
Fixes #289

`create_brush_from_info()` is the single door into the level for undo restore, duplication, prefab instancing, .map import and .hflevel load, and it took `info["size"]` as given. A negative component gives the basis a negative determinant, which inverts the face winding invisibly, so every FaceData ends up with a normal pointing the opposite way from the vertices it holds and it only shows at bake or in an exported plane. A zero component builds no volume.

Each component is taken as its magnitude and floored at 0.1, the same figure the validator's auto fix uses, with one warning naming the size asked for and the one used.

The validator also called a negative brush a "Zero-size brush", which sends the reader looking for the wrong thing. It says "Inverted brush" now, and a genuine zero extent still says "Zero-size brush".

New `tests/test_brush_size_guard.gd`, 9 tests. Six fail on main; three are guards that a good size, a partly good size and the zero-size message are left alone. Full suite 3301 passing, 0 failing.