### PR TITLE
Drop a paint chunk when its last cell is erased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -821,6 +821,33 @@ The format is based on Keep a Changelog, and this project follows semantic versi
     its own winding, a zero size, a partly zero size moving only the bad axis, a
     good size passing through untouched, a size that is not a Vector3, and both
     validator messages.
+- **Erasing paint gives the memory back** (#301). `HFPaintLayer.set_cell()`
+  allocated a chunk on demand and never released one, so clearing the last cell
+  in a chunk went down the same path as setting one. `remove_chunk()` sat
+  directly below it with no callers, and the only reclamation in the file was
+  region streaming eviction, which is unloading rather than erasing. A chunk is
+  dropped when its last bit clears, so `get_paint_memory_bytes()` goes back down
+  and painting an area to try it out and erasing it does not leave a level file
+  bigger than one that was never painted.
+  - `HFChunkData` keeps a live-cell counter, so "is this chunk empty" is a
+    comparison rather than a scan of every byte on each erase. It is recounted
+    whenever the bitset is written whole, which is what a load does.
+  - **The chunk is dropped before the dirty mark, not after.** `remove_chunk()`
+    clears the dirty flag too, and the reconciler needs to see the chunk to take
+    its geometry away. Region eviction reconciles removed chunk ids the same way.
+  - **`HFStateSystem.capture_paint_layers()` skips an empty chunk**, so one that
+    was created and never filled cannot reach a `.hflevel` save or an undo
+    snapshot carrying its bits, material ids and three blend weight arrays for
+    paint that is not there.
+  - **Erasing no longer allocates.** `set_cell()` went through
+    `_get_or_create_chunk()` on the way out as well as in, so a stroke over
+    unpainted ground built chunks full of zeros. Erasing looks the chunk up
+    instead.
+  - **Coverage** (`tests/test_paint_chunk_reclaim.gd`): chunks returned and paint
+    memory back to zero after an erase, a chunk with one cell left kept, a
+    dropped chunk repainted, erasing unpainted ground, an erased layer
+    serializing nothing, a painted one still serializing, paint surviving a
+    capture and restore, and the live count after a wholesale write.
 - **A prefab could wire its copy's outputs to the entities it was built from.**
   `HFPrefab.instantiate()` remapped I/O by turning each old node name into the new
   one and then looking that name back up. The lookup resolves an authored

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,427 tests across 178 test scripts (3,420 passing plus seven intentional no-assert safety tests; 17,433 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,437 tests across 179 test scripts (3,430 passing plus seven intentional no-assert safety tests; 17,451 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,427 tests** across **178 scripts** (**3,420 passing** plus seven intentional no-assert safety tests; **17,433 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,437 tests** across **179 scripts** (**3,430 passing** plus seven intentional no-assert safety tests; **17,451 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3420%20passing-brightgreen" alt="3420 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3430%20passing-brightgreen" alt="3430 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,427 tests across 178 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,437 tests across 179 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/paint/hf_paint_layer.gd
+++ b/addons/hammerforge/paint/hf_paint_layer.gd
@@ -57,13 +57,29 @@ func get_height_at_uv(u: float, v: float) -> float:
 
 func set_cell(cell: Vector2i, filled: bool) -> void:
 	var cid := _cell_to_chunk(cell)
-	var chunk: HFChunkData = _get_or_create_chunk(cid)
+	# Erasing does not need a chunk. Going through _get_or_create_chunk() on the
+	# way out allocated one full of zeros for every stroke over unpainted ground,
+	# which is the same leak from the other direction.
+	var chunk: HFChunkData = (
+		_get_or_create_chunk(cid) if filled else _chunks.get(cid) as HFChunkData
+	)
 	var local := _cell_to_local(cell)
-	var changed := chunk.set_bit(local, filled)
+	var changed: bool = chunk.set_bit(local, filled) if chunk != null else false
 	var removed_height := false
 	if not filled:
 		removed_height = _wall_heights.erase(cell)
 	if changed or removed_height:
+		# A chunk whose last bit just cleared holds nothing but zeros, and holding
+		# it costs memory that get_paint_memory_bytes() reports and, worse, weight
+		# in every .hflevel save and every undo snapshot, permanently, for paint
+		# the user removed.
+		#
+		# Dropped before the dirty mark rather than after: remove_chunk() clears
+		# the dirty flag too, and the reconciler needs to see this chunk to take
+		# its geometry away. Region eviction reconciles removed chunk ids the same
+		# way.
+		if not filled and chunk != null and chunk.is_empty():
+			remove_chunk(cid)
 		_mark_dirty(cid)
 		_mark_dirty_neighbours(cid)
 
@@ -197,6 +213,12 @@ func has_chunk(cid: Vector2i) -> bool:
 	return _chunks.has(cid)
 
 
+## True when the chunk holds no filled cells, or is not there at all.
+func is_chunk_empty(cid: Vector2i) -> bool:
+	var chunk: HFChunkData = _chunks.get(cid) as HFChunkData
+	return chunk == null or chunk.is_empty()
+
+
 func get_chunk_bits(cid: Vector2i) -> PackedByteArray:
 	var chunk: HFChunkData = _chunks.get(cid) as HFChunkData
 	if chunk == null:
@@ -207,6 +229,7 @@ func get_chunk_bits(cid: Vector2i) -> PackedByteArray:
 func set_chunk_bits(cid: Vector2i, bits: PackedByteArray) -> void:
 	var chunk: HFChunkData = _get_or_create_chunk(cid)
 	chunk.bits = bits.duplicate()
+	chunk.recount_live_bits()
 	_mark_dirty(cid)
 	_mark_dirty_neighbours(cid)
 
@@ -364,6 +387,9 @@ func _mark_dirty_neighbours(cid: Vector2i) -> void:
 class HFChunkData:
 	var size: int
 	var bits: PackedByteArray  # bitset, size*size bits
+	## How many cells are filled. Kept as a counter so "is this chunk empty" is a
+	## comparison rather than a scan of every byte on each erase.
+	var live_bits: int = 0
 	var material_ids: PackedByteArray  # 1 byte per cell (0-255 material index)
 	var blend_weights: PackedByteArray  # 1 byte per cell (0-255, normalized to 0.0-1.0)
 	var blend_weights_2: PackedByteArray  # slot 2
@@ -413,9 +439,25 @@ class HFChunkData:
 			return false
 		if v:
 			bits[byte_i] |= mask
+			live_bits += 1
 		else:
 			bits[byte_i] &= ~mask
+			live_bits -= 1
 		return true
+
+	func is_empty() -> bool:
+		return live_bits <= 0
+
+	## Recount from the bytes. Needed whenever the bitset is written whole rather
+	## than a cell at a time, which is what a load does.
+	func recount_live_bits() -> void:
+		var count := 0
+		for byte in bits:
+			var b: int = byte
+			while b != 0:
+				count += b & 1
+				b >>= 1
+		live_bits = count
 
 	func get_material(local: Vector2i) -> int:
 		return material_ids[_idx(local)]

--- a/addons/hammerforge/systems/hf_state_system.gd
+++ b/addons/hammerforge/systems/hf_state_system.gd
@@ -585,6 +585,13 @@ func capture_paint_layers(include_chunks: bool = true) -> Array:
 			entry["height_scale"] = layer.height_scale
 		if include_chunks:
 			for cid in layer.get_chunk_ids():
+				# An all-zero chunk describes nothing. Serializing one writes its
+				# bits, material ids and three blend weight arrays into every save
+				# and every undo snapshot for paint that is not there. set_cell()
+				# drops a chunk when its last bit clears, so this is the guard for
+				# a chunk that was created and never filled.
+				if layer.is_chunk_empty(cid):
+					continue
 				var bits = layer.get_chunk_bits(cid)
 				var bytes: Array = []
 				for b in bits:

--- a/docs/HammerForge_FloorPaint_Greyboxing.md
+++ b/docs/HammerForge_FloorPaint_Greyboxing.md
@@ -24,7 +24,7 @@ HFPaintGrid
 - Converts between world and grid coordinates.
 
 HFPaintLayer
-- Chunked grid storage using a bitset per chunk.
+- Chunked grid storage using a bitset per chunk. A chunk is allocated on the first cell painted in it and dropped when its last cell is erased, so erasing paint gives the memory back and an all-zero chunk is never saved. Erasing over unpainted ground allocates nothing.
 - Per-chunk `material_ids` (PackedByteArray, 1 byte/cell) and blend weights (`blend_weights`, `blend_weights_2`, `blend_weights_3`).
 - Optional per-cell wall height overrides used by the paint-then-raise workflow.
 - Optional `heightmap: Image` (FORMAT_RF) and `height_scale: float` for vertex displacement.

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,427 tests across 178 scripts**: **3,420 passing tests**, seven intentional no-assert safety tests, and **17,433 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,437 tests across 179 scripts**: **3,430 passing tests**, seven intentional no-assert safety tests, and **17,451 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_paint_chunk_reclaim.gd
+++ b/tests/test_paint_chunk_reclaim.gd
@@ -1,0 +1,138 @@
+extends GutTest
+
+## Erasing paint should give the memory back. A chunk whose last bit clears holds
+## nothing but zeros, and holding it costs memory the Test tab reports and weight
+## in every .hflevel save and every undo snapshot, permanently, for paint the
+## user removed.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+
+var root: LevelRoot
+var layer: HFPaintLayer
+
+
+func before_each():
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	layer = root.paint_layers.get_active_layer()
+
+
+func _fill(size: int, filled: bool) -> void:
+	for x in range(size):
+		for z in range(size):
+			layer.set_cell(Vector2i(x, z), filled)
+
+
+# -- Reclamation --------------------------------------------------------------
+
+
+func test_erasing_every_cell_gives_the_chunks_back():
+	_fill(40, true)
+	var chunks_when_painted := layer.get_chunk_ids().size()
+	assert_gt(chunks_when_painted, 1, "40 by 40 cells should span more than one chunk")
+
+	_fill(40, false)
+
+	assert_eq(layer.get_chunk_ids().size(), 0, "Every chunk should be gone")
+
+
+func test_paint_memory_goes_back_down():
+	_fill(40, true)
+	var painted_bytes := root.get_paint_memory_bytes()
+	assert_gt(painted_bytes, 0, "Painting should cost something")
+
+	_fill(40, false)
+
+	assert_eq(root.get_paint_memory_bytes(), 0, "Erasing should give it back")
+
+
+func test_a_chunk_with_one_cell_left_is_kept():
+	_fill(8, true)
+	assert_eq(layer.get_chunk_ids().size(), 1, "8 by 8 cells fit in one chunk")
+
+	for x in range(8):
+		for z in range(8):
+			if x == 0 and z == 0:
+				continue
+			layer.set_cell(Vector2i(x, z), false)
+
+	assert_eq(layer.get_chunk_ids().size(), 1, "One filled cell still needs its chunk")
+	assert_true(layer.get_cell(Vector2i(0, 0)), "and that cell should still be painted")
+
+
+func test_a_chunk_can_be_repainted_after_it_was_dropped():
+	_fill(8, true)
+	_fill(8, false)
+	assert_eq(layer.get_chunk_ids().size(), 0, "The chunk should have gone")
+
+	layer.set_cell(Vector2i(2, 3), true)
+
+	assert_eq(layer.get_chunk_ids().size(), 1, "and come back when painted again")
+	assert_true(layer.get_cell(Vector2i(2, 3)), "with the cell set")
+
+
+func test_erasing_a_cell_that_was_not_painted_changes_nothing():
+	layer.set_cell(Vector2i(5, 5), false)
+
+	assert_eq(layer.get_chunk_ids().size(), 0, "Erasing nothing should not leave a chunk behind")
+
+
+# -- Nothing empty reaches a save or a snapshot -------------------------------
+
+
+func test_an_erased_area_is_not_serialized():
+	_fill(40, true)
+	_fill(40, false)
+
+	var captured: Array = root.state_system.capture_paint_layers(true)
+
+	for entry in captured:
+		assert_eq(entry["chunks"], [], "An erased layer should serialize no chunks")
+
+
+func test_a_painted_area_is_still_serialized():
+	_fill(8, true)
+
+	var captured: Array = root.state_system.capture_paint_layers(true)
+
+	assert_eq(captured[0]["chunks"].size(), 1, "A painted chunk should still be written")
+
+
+func test_paint_survives_a_capture_and_restore():
+	_fill(8, true)
+	var snapshot = root.capture_state(true)
+	_fill(8, false)
+
+	root.restore_state(snapshot)
+
+	var restored = root.paint_layers.get_active_layer()
+	assert_true(restored.get_cell(Vector2i(3, 3)), "The painted cell should come back")
+	assert_eq(restored.get_chunk_ids().size(), 1, "with its chunk")
+
+
+# -- The live bit count is right after a wholesale write ----------------------
+
+
+func test_setting_a_chunk_s_bits_wholesale_recounts_them():
+	_fill(8, true)
+	var cid: Vector2i = layer.get_chunk_ids()[0]
+	var bits := layer.get_chunk_bits(cid)
+
+	layer.set_chunk_bits(cid, bits)
+
+	assert_false(layer.is_chunk_empty(cid), "A chunk loaded with set bits is not empty")
+	layer.set_cell(Vector2i(0, 0), false)
+	assert_eq(layer.get_chunk_ids().size(), 1, "and clearing one cell does not drop it")
+
+
+func test_a_chunk_loaded_with_no_bits_reads_as_empty():
+	_fill(8, true)
+	var cid: Vector2i = layer.get_chunk_ids()[0]
+	var blank := PackedByteArray()
+	blank.resize(layer.get_chunk_bits(cid).size())
+
+	layer.set_chunk_bits(cid, blank)
+
+	assert_true(layer.is_chunk_empty(cid), "No bits set means empty")


### PR DESCRIPTION
Fixes #301

`set_cell()` allocated a chunk on demand and never released one, so clearing the last cell went down the same path as setting one. `remove_chunk()` sat below it with no callers, and the only reclamation in the file was region streaming eviction, which is unloading rather than erasing.

- `HFChunkData` keeps a live-cell counter, so the emptiness check is a comparison rather than a scan on every erase. It is recounted whenever the bitset is written whole, which is what a load does.
- The chunk is dropped **before** the dirty mark. `remove_chunk()` clears the dirty flag too, and the reconciler needs to see the chunk to take its geometry away. Region eviction reconciles removed chunk ids the same way, so that path was the proof it works.
- `capture_paint_layers()` skips an empty chunk as well, so one created and never filled cannot reach a save or an undo snapshot.

One thing the issue did not name that I hit writing the tests: erasing went through `_get_or_create_chunk()` too, so a stroke over unpainted ground allocated chunks full of zeros. Same leak from the other direction, fixed on the same diff.

New `tests/test_paint_chunk_reclaim.gd`, 10 tests. Seven fail on main. Full suite 3302 passing, 0 failing.