### PR TITLE
Point the bevel KNOWN at #330 instead of the closed #314

### DIFF
--- a/tools/vibe/scenarios/geometry.gd
+++ b/tools/vibe/scenarios/geometry.gd
@@ -120,7 +120,10 @@ func run() -> void:
 			)
 		)
 		if ok and inward > 0:
-			known(314, "%s leaves inverted faces" % entry[2], "%d faces wound inward" % inward)
+			# #314 fixed the strip winding. The endpoint caps still lose their sign
+			# once the arc collapses, which a radius of 0 or below reaches because
+			# bevel_edge() coerces it to 0.01 rather than refusing it.
+			known(330, "%s leaves inverted faces" % entry[2], "%d faces wound inward" % inward)
 		if ok and extent.length() > Vector3(64, 64, 64).length() * 2.0:
 			known(
 				315,


### PR DESCRIPTION
Follow-up to #329.

Running the harness against merged `main` showed the `geometry` scenario still
citing #314, which is closed. It is not a regression of #314 — the strip winding
that fixed is clean, and the ordinary bevels come back with no inverted faces:

```
ordinary bevel                   returned=true  inward=0
wider bevel                      returned=true  inward=0
zero radius                      returned=true  inward=1
negative radius                  returned=true  inward=1
radius far larger than the brush  returned=true  inward=0
```

What survives is the endpoint cap triangle losing its sign once the arc
collapses, which a radius of 0 or below reaches because `bevel_edge()` coerces
it to 0.01 rather than refusing it. Filed as #330 with the measurements. This
just repoints the `KNOWN` so the baseline cites a live issue.

Doing it now rather than leaving it is the workflow `tools/vibe/README.md`
describes: when an issue closes, check whether the `KNOWN` still reproduces, and
either retire it or re-aim it at what is actually still broken.