### PR TITLE
Load the round-trip palette off disk, and retire the two fixed KNOWNs

### DIFF
--- a/tools/vibe/scenarios/round_trip.gd
+++ b/tools/vibe/scenarios/round_trip.gd
@@ -10,10 +10,17 @@ extends "res://tools/vibe/hf_vibe_scenario.gd"
 ## diffs what comes back. Data loss here is silent by nature: the operation
 ## reports success and the level is simply poorer than it was.
 
-## Keys whose loss is already reported. Both are the same defect: an untyped
-## Array decoded from JSON assigned to a typed property, which Godot refuses at
-## runtime while the caller carries on believing the write landed.
-const KNOWN_LOSSES := {"materials": 283, "paint_layers": 284}
+## Keys whose loss is already reported, mapped to the issue covering them.
+## Empty while the two that were here -- #283 and #284, both the same untyped
+## Array assigned to a typed property -- are fixed and holding.
+const KNOWN_LOSSES := {}
+
+## Real palette materials, loaded from disk. See the note in `_build()`.
+const PALETTE_MATERIALS: Array[String] = [
+	"res://materials/test_mat.tres",
+	"res://addons/hammerforge/textures/prototypes/materials/proto_arrow_down_blue.tres",
+	"res://addons/hammerforge/textures/prototypes/materials/proto_arrow_down_green.tres",
+]
 
 
 func id() -> String:
@@ -63,9 +70,16 @@ func run() -> void:
 
 ## A level with one of everything worth losing.
 func _build(root: Node3D) -> void:
-	for i in range(3):
-		var m := StandardMaterial3D.new()
-		m.resource_name = "vibe_mat_%d" % i
+	# Materials must come off disk. A `.hflevel` stores the resource path of each
+	# palette slot, so a StandardMaterial3D built in memory has nothing to store
+	# and comes back null through no fault of the loader. Using real resources is
+	# what a user's palette actually holds, and is the only way this round trip
+	# says anything.
+	for path in PALETTE_MATERIALS:
+		var m = load(path)
+		if m == null:
+			flag("fixture material missing", path)
+			continue
 		root.material_manager.add_material(m)
 
 	for i in range(4):


### PR DESCRIPTION
Follow-up to #329, found by running the harness against main after #302-#312 landed.

The `round-trip` scenario kept reporting `materials` as lost across a `.hflevel`
save and citing #283, which is merged. It was the fixture, not the loader.

The scenario built its palette from `StandardMaterial3D.new()`. A `.hflevel`
stores the *resource path* of each palette slot, so a material that was never
saved to disk has nothing to store and comes back null. The palette came back
with the right three slots, all of them empty, and the diff called that data
loss.

```
before: [vibe_mat_0, vibe_mat_1, vibe_mat_2]
after:  [<null>, <null>, <null>]
```

It now loads three real resources — `materials/test_mat.tres` and two prototype
materials — which is what a user's palette actually holds and the only way this
round trip says anything.

**#283 and #284 are fixed and holding**, which this confirms rather than
contradicts: the palette count survives, the `Invalid assignment` error is gone
from the log, and the terrain slot paths come back. `KNOWN_LOSSES` is now empty.

Full sweep against `main` after this: all seven scenarios clean, with the only
remaining `KNOWN` entries being #330 (bevel cap at a zero radius) and #322
(sphere and torus still heavy, the curved-shape half the issue called out as a
separate decision). #283, #284 and #300 no longer reproduce.