### PR TITLE
Eight more vibe scenarios: transforms, structures, cutting, entities, appearance, state, housekeeping, terrain

### DIFF
--- a/tools/vibe/README.md
+++ b/tools/vibe/README.md
@@ -64,6 +64,14 @@ it from here.
 | `limits` | arrays, generators, prefabs, visgroups and paint layers at zero, negative, absurd, empty and duplicate |
 | `chaos` | 300 randomised operations with structural invariants checked after each one |
 | `cost` | faces, build time and `.hflevel` size for one brush of each shape |
+| `transform` | rotate/flip/reset round trips, mirror winding, pivots, and where texture lock puts a texture |
+| `structures` | the four generators: winding at their defaults, schema ranges, regenerate as a no-op |
+| `cutting` | clip, carve, hollow, inset and arrays, measured by volume rather than by what they report |
+| `entities` | naming, duplication, deletion, and what the I/O wired to an entity does when its name moves |
+| `appearance` | material slots, UV params, projections and paint layers at their edges |
+| `persistence` | `capture_state`/`restore_state` round trips, repeated restores, and malformed state |
+| `housekeeping` | visgroup and group names, the cordon, and the paint layer list |
+| `terrain` | heightmap scale and region settings at their edges, and the playtest/glTF exports |
 
 ## Adding a scenario
 

--- a/tools/vibe/hf_vibe_runner.gd
+++ b/tools/vibe/hf_vibe_runner.gd
@@ -22,6 +22,14 @@ const SCENARIOS: Array[String] = [
 	"res://tools/vibe/scenarios/limits.gd",
 	"res://tools/vibe/scenarios/chaos.gd",
 	"res://tools/vibe/scenarios/cost.gd",
+	"res://tools/vibe/scenarios/transform.gd",
+	"res://tools/vibe/scenarios/structures.gd",
+	"res://tools/vibe/scenarios/cutting.gd",
+	"res://tools/vibe/scenarios/entities.gd",
+	"res://tools/vibe/scenarios/appearance.gd",
+	"res://tools/vibe/scenarios/persistence.gd",
+	"res://tools/vibe/scenarios/housekeeping.gd",
+	"res://tools/vibe/scenarios/terrain.gd",
 ]
 
 

--- a/tools/vibe/run_vibe.py
+++ b/tools/vibe/run_vibe.py
@@ -37,6 +37,14 @@ SCENARIOS = [
     "limits",
     "chaos",
     "cost",
+    "transform",
+    "structures",
+    "cutting",
+    "entities",
+    "appearance",
+    "persistence",
+    "housekeeping",
+    "terrain",
 ]
 
 # Generous: chaos runs 300 operations and cost saves eight levels. A scenario

--- a/tools/vibe/scenarios/appearance.gd
+++ b/tools/vibe/scenarios/appearance.gd
@@ -1,0 +1,184 @@
+@tool
+extends HFVibeScenario
+
+## What a face looks like: its material slot, its UV transform, its projection
+## and the surface paint layers stacked on it.
+##
+## Everything here is written straight into the bake and into the exported
+## `.map`, and none of it is re-checked on the way out. So the question each
+## time is whether a value that cannot mean anything -- a slot no material sits
+## in, a UV scale of zero, a NaN rotation -- is refused at the door or carried
+## all the way to the file.
+
+
+func id() -> String:
+	return "appearance"
+
+
+func summary() -> String:
+	return "material slots, UV params, projections and paint layers at their edges"
+
+
+func run() -> void:
+	await _material_slot_range()
+	await _uv_params_at_their_edges()
+	await _projection_range()
+	await _paint_layer_stack()
+
+
+func _bid(node: Node) -> String:
+	return str(node.get_meta("brush_id", ""))
+
+
+## A palette of `count` distinct materials, so slot arithmetic has something to
+## be wrong about.
+func _palette(root: Node3D, count: int) -> void:
+	var mats: Array = []
+	for i in range(count):
+		var m := StandardMaterial3D.new()
+		m.resource_name = "mat_%d" % i
+		mats.append(m)
+	root.set_materials(mats)
+
+
+## Assigning a slot the palette does not have.
+func _material_slot_range() -> void:
+	var root: Node3D = await fresh_root()
+	_palette(root, 4)
+	var b = box(root, Vector3(64, 64, 64))
+	var id := _bid(b)
+	note("palette", "%d materials" % root.get_materials().size())
+	for slot in [-2, 4, 999999]:
+		root.assign_material_to_whole_brushes(slot, [id])
+		await frame()
+		var stored: int = b.faces[0].material_idx
+		note("assign slot %d" % slot, "face 0 now reads material_idx %d" % stored)
+		if stored == slot and (slot < 0 or slot >= root.get_materials().size()):
+			known(
+				343,
+				(
+					"a face can be assigned material slot %d against a palette of %d"
+					% [slot, root.get_materials().size()]
+				),
+				"nothing rejects it, and the bake and the .map export both read that slot back"
+			)
+	# What the exporter does with a face pointing at nothing.
+	var path := "user://vibe_appearance.map"
+	root.export_map(path, "valve220")
+	var text := FileAccess.get_file_as_string(path)
+	var first_brush_line := ""
+	for line in text.split("\n"):
+		if line.find("(") == 0:
+			first_brush_line = line.strip_edges()
+			break
+	note("exported face line", first_brush_line)
+	var reader: Node3D = await fresh_root("SlotReimport")
+	reader.import_map(path)
+	await frame()
+	for problem in HFVibe.check_invariants(reader):
+		flag("re-importing a map whose faces point at a missing slot broke an invariant", problem)
+
+
+## UV scale, offset and rotation, at the values that make the projection
+## meaningless.
+func _uv_params_at_their_edges() -> void:
+	var root: Node3D = await fresh_root()
+	var b = box(root, Vector3(64, 64, 64))
+	var id := _bid(b)
+	var cases := {
+		"zero scale": [Vector2.ZERO, Vector2.ZERO, 0.0],
+		"negative scale": [Vector2(-1, -1), Vector2.ZERO, 0.0],
+		"NAN scale": [Vector2(NAN, NAN), Vector2.ZERO, 0.0],
+		"INF offset": [Vector2.ONE, Vector2(INF, 0), 0.0],
+		"NAN rotation": [Vector2.ONE, Vector2.ZERO, NAN],
+		"enormous scale": [Vector2(1e12, 1e12), Vector2.ZERO, 0.0],
+	}
+	for label in cases:
+		var c: Array = cases[label]
+		root.set_face_uv_params(id, 0, c[0], c[1], c[2])
+		await frame()
+		var tri: Dictionary = b.faces[0].triangulate()
+		var uvs: PackedVector2Array = tri["uvs"]
+		var finite := true
+		var spread := 0.0
+		for uv in uvs:
+			if not uv.is_finite():
+				finite = false
+			else:
+				spread = maxf(spread, uv.length())
+		note(label, "%d uvs, finite %s, largest %f" % [uvs.size(), finite, spread])
+		if not finite:
+			known(
+				344,
+				"UV params with a %s produce non-finite UVs" % label,
+				"the bake writes those straight into the mesh, where they render as nothing"
+			)
+		if label == "zero scale" and spread == 0.0 and uvs.size() > 0:
+			known(
+				344,
+				"a UV scale of zero is accepted and collapses the face's UVs to a point",
+				"every vertex maps to the same texel, so the face samples one pixel"
+			)
+		# Put it back before the next case, so failures do not compound.
+		root.reset_uv_on_face(id, 0)
+		await frame()
+
+
+## `reproject_face_uvs` takes a projection as a bare int.
+func _projection_range() -> void:
+	var root: Node3D = await fresh_root()
+	var b = box(root, Vector3(64, 64, 64))
+	var id := _bid(b)
+	for projection in [-1, 99]:
+		root.reproject_face_uvs(id, 0, projection)
+		await frame()
+		var stored: int = b.faces[0].uv_projection
+		var tri: Dictionary = b.faces[0].triangulate()
+		note(
+			"reproject to %d" % projection,
+			"face stores %d, %d uvs" % [stored, (tri["uvs"] as PackedVector2Array).size()]
+		)
+		if stored == projection:
+			known(
+				345,
+				"a face accepts UV projection %d, which is not a projection" % projection,
+				"it is stored, saved and re-loaded, and the projector falls through to its default"
+			)
+	# Face indices outside the brush.
+	for face_idx in [-1, 999]:
+		root.reset_uv_on_face(id, face_idx)
+		root.reproject_face_uvs(id, face_idx, 0)
+		root.set_face_uv_params(id, face_idx, Vector2.ONE, Vector2.ZERO, 0.0)
+		await frame()
+	note("UV calls against face indices -1 and 999", "survived, %d faces intact" % b.faces.size())
+	for problem in HFVibe.check_invariants(root):
+		flag("out-of-range UV calls broke an invariant", problem)
+
+
+## Surface paint layers stack on a face. Nothing says how many.
+func _paint_layer_stack() -> void:
+	var root: Node3D = await fresh_root()
+	var b = box(root, Vector3(64, 64, 64))
+	var id := _bid(b)
+	for _i in range(64):
+		root.add_surface_paint_layer(id, 0)
+	await frame()
+	var layers: int = b.faces[0].paint_layers.size()
+	note("added 64 surface paint layers to one face", "%d on the face" % layers)
+	if layers >= 64:
+		known(
+			351,
+			"a face accepts an unbounded stack of surface paint layers",
+			"%d layers on one face, each one saved and rebuilt on every preview" % layers
+		)
+	for bad in [-1, 9999]:
+		root.remove_surface_paint_layer(id, 0, bad)
+		await frame()
+	note("removing paint layer -1 and 9999", "%d layers left" % b.faces[0].paint_layers.size())
+	# And through a save, to see what the stack costs on disk.
+	var path := "user://vibe_appearance.hflevel"
+	root.save_hflevel(path, true)
+	await HFVibe.settle_save(_tree, root)
+	note("level with a 64-layer face", "%d bytes" % HFVibe.file_size(path))
+	for problem in HFVibe.check_invariants(root):
+		flag("the paint layer stack broke an invariant", problem)

--- a/tools/vibe/scenarios/appearance.gd.uid
+++ b/tools/vibe/scenarios/appearance.gd.uid
@@ -1,0 +1,1 @@
+uid://di1tudjw2wox7

--- a/tools/vibe/scenarios/cutting.gd
+++ b/tools/vibe/scenarios/cutting.gd
@@ -1,0 +1,326 @@
+@tool
+extends HFVibeScenario
+
+## The operations that take a brush apart: clip, carve, hollow, inset and the
+## duplicate arrays that copy the result.
+##
+## What these have in common is that they replace geometry. A brush goes in and
+## different brushes come out, and nothing downstream re-checks the result --
+## the bake takes the faces it is given. So the questions are the same each
+## time: is what comes out still a closed convex solid wound the right way, does
+## it still occupy the space the input did, and does an operation that refuses
+## leave the level exactly as it found it.
+
+
+func id() -> String:
+	return "cutting"
+
+
+func summary() -> String:
+	return "clip, carve, hollow, inset and arrays: winding, volume and refusals"
+
+
+func run() -> void:
+	await _clip_halves_a_brush()
+	await _clip_by_a_plane_that_misses()
+	await _carve_leaves_a_shell()
+	await _hollow_thickness_edges()
+	await _inset_edges()
+	await _array_counts()
+
+
+func _bid(node: Node) -> String:
+	return str(node.get_meta("brush_id", ""))
+
+
+func _brush_ids(root: Node3D) -> PackedStringArray:
+	var out := PackedStringArray()
+	for b in root.draft_brushes_node.get_children():
+		out.append(_bid(b))
+	return out
+
+
+## The volume of a brush's own face geometry, by the divergence theorem over its
+## triangles. Independent of anything the brush says about itself.
+func _volume(brush: Node3D) -> float:
+	var total := 0.0
+	for face in brush.faces:
+		var tri: Dictionary = face.triangulate()
+		var verts: PackedVector3Array = tri["verts"]
+		var i := 0
+		while i + 2 < verts.size():
+			var a: Vector3 = brush.global_transform * verts[i]
+			var b: Vector3 = brush.global_transform * verts[i + 1]
+			var c: Vector3 = brush.global_transform * verts[i + 2]
+			total += a.dot(b.cross(c)) / 6.0
+			i += 3
+	return absf(total)
+
+
+func _level_volume(root: Node3D) -> float:
+	var total := 0.0
+	for b in root.draft_brushes_node.get_children():
+		total += _volume(b)
+	return total
+
+
+## A plane through the middle splits the brush in two. The two halves together
+## are the brush that went in -- no volume created, none lost.
+func _clip_halves_a_brush() -> void:
+	var root: Node3D = await fresh_root()
+	var b = box(root, Vector3(128, 64, 64))
+	var before := _volume(b)
+	var id := _bid(b)
+	var result = root.clip_brush_by_plane(id, Plane(Vector3.RIGHT, 0.0))
+	await frame()
+	if result == null or not result.ok:
+		flag("clipping a box down the middle failed", result.message if result else "null")
+		return
+	var survivors: Array = root.draft_brushes_node.get_children()
+	var after := _level_volume(root)
+	note(
+		"clip a 128x64x64 box at x = 0",
+		"%d brushes, volume %.0f -> %.0f" % [survivors.size(), before, after]
+	)
+	if survivors.size() != 2:
+		flag(
+			"clipping a box down its middle does not leave two halves",
+			"%d brushes on the level afterwards" % survivors.size()
+		)
+	if absf(after - before) > before * 0.02:
+		flag(
+			"clipping a box changes how much material is on the level",
+			"volume %.0f before, %.0f after" % [before, after]
+		)
+	for s in survivors:
+		var half: float = _volume(s)
+		if absf(half - before * 0.5) > before * 0.02:
+			flag(
+				"a half of a centre-clipped box is not half its volume",
+				"%.0f against %.0f" % [half, before * 0.5]
+			)
+	for s in survivors:
+		var inward: int = HFVibe.inward_face_count(s)
+		if inward > 0:
+			flag("a clipped brush has %d inward faces" % inward, "clip at x = 0 on a box")
+	for problem in HFVibe.check_invariants(root):
+		flag("clip broke an invariant", problem)
+
+
+## A plane that misses the brush entirely should either refuse or leave it
+## whole. What it must not do is delete it.
+func _clip_by_a_plane_that_misses() -> void:
+	var root: Node3D = await fresh_root()
+	var b = box(root, Vector3(64, 64, 64))
+	var id := _bid(b)
+	var cases := {
+		"plane 10000 units away": Plane(Vector3.RIGHT, 10000.0),
+		"plane tangent to one face": Plane(Vector3.RIGHT, 32.0),
+		"zero normal": Plane(Vector3.ZERO, 0.0),
+		"non-finite distance": Plane(Vector3.UP, NAN),
+	}
+	for label in cases:
+		var plane: Plane = cases[label]
+		var splits: bool = root.plane_splits_brush(id, plane)
+		var result = root.clip_brush_by_plane(id, plane)
+		await frame()
+		var live: int = root.draft_brushes_node.get_child_count()
+		note(
+			label,
+			(
+				"plane_splits_brush %s, clip %s, %d brushes left"
+				% [splits, "ok" if result and result.ok else "refused", live]
+			)
+		)
+		if live == 0:
+			flag("clipping by a %s deletes the brush" % label, "nothing is left on the level")
+			return
+		for problem in HFVibe.check_invariants(root):
+			flag("clip by a %s broke an invariant" % label, problem)
+
+
+## Carving one brush out of another leaves the shell around the hole.
+func _carve_leaves_a_shell() -> void:
+	var root: Node3D = await fresh_root()
+	var target = box(root, Vector3(256, 128, 256))
+	var target_volume := _volume(target)
+	var cutter = box(root, Vector3(64, 64, 64))
+	var cutter_volume := _volume(cutter)
+	var result = root.carve_with_brush(_bid(cutter))
+	await frame()
+	if result == null or not result.ok:
+		note(
+			"carve a 64 cube out of a 256x128x256 box",
+			"refused: %s" % (result.message if result else "null")
+		)
+		return
+	var after := _level_volume(root)
+	var pieces: int = root.draft_brushes_node.get_child_count()
+	note(
+		"carve a 64 cube out of a 256x128x256 box",
+		(
+			"%d pieces, total volume %.0f (was %.0f, cutter %.0f)"
+			% [pieces, after, target_volume, cutter_volume]
+		)
+	)
+	# The carve should remove the cutter's volume from the target, no more.
+	var expected := target_volume - cutter_volume
+	if absf(after - expected) > target_volume * 0.02:
+		flag(
+			"carving does not remove the cutter's volume",
+			(
+				"%.0f left, expected about %.0f (%.0f minus the %.0f cutter)"
+				% [after, expected, target_volume, cutter_volume]
+			)
+		)
+	var inward := 0
+	for p in root.draft_brushes_node.get_children():
+		inward += HFVibe.inward_face_count(p)
+	if inward > 0:
+		flag("carving leaves %d inward-facing faces" % inward, "across %d pieces" % pieces)
+	for problem in HFVibe.check_invariants(root):
+		flag("carve broke an invariant", problem)
+
+
+## Hollow thickness at its edges: zero, negative, thicker than the brush, and
+## non-finite. A refusal is a fine answer. A wall of nothing is not.
+func _hollow_thickness_edges() -> void:
+	for thickness in [16.0, 0.0, -16.0, 512.0, NAN, INF]:
+		var root: Node3D = await fresh_root()
+		var b = box(root, Vector3(256, 256, 256))
+		var before := _volume(b)
+		var result = root.hollow_brush_by_id(_bid(b), thickness)
+		await frame()
+		var ok: bool = result != null and result.ok
+		var walls: int = root.draft_brushes_node.get_child_count()
+		var after := _level_volume(root)
+		note(
+			"hollow a 256 cube with thickness %s" % thickness,
+			(
+				"%s, %d brushes, volume %.0f (solid was %.0f)"
+				% ["ok" if ok else "refused", walls, after, before]
+			)
+		)
+		if not ok:
+			continue
+		if after <= 0.0 or not is_finite(after):
+			flag(
+				"hollow with thickness %s reports success and leaves no volume" % thickness,
+				"%d brushes totalling %.0f" % [walls, after]
+			)
+		if after > before * 1.01:
+			flag(
+				(
+					"hollow with thickness %s leaves more material than the solid brush had"
+					% thickness
+				),
+				"%.0f against %.0f" % [after, before]
+			)
+		for problem in HFVibe.check_invariants(root):
+			flag("hollow with thickness %s broke an invariant" % thickness, problem)
+
+
+## Inset distance and height at their edges. An inset deeper than the face is
+## wide has nowhere to go.
+func _inset_edges() -> void:
+	for pair in [[8.0, 16.0], [0.0, 0.0], [-8.0, -16.0], [1000.0, 1000.0], [NAN, 8.0], [8.0, INF]]:
+		var root: Node3D = await fresh_root()
+		var b = box(root, Vector3(64, 64, 64))
+		var ok: bool = root.inset_face(_bid(b), 0, pair[0], pair[1])
+		await frame()
+		var inward: int = HFVibe.inward_face_count(b)
+		var extent := HFVibe.local_extent(b)
+		note(
+			"inset face 0 by %s, height %s" % [pair[0], pair[1]],
+			(
+				"%s, %d faces, %d inward, extent %s"
+				% ["ok" if ok else "refused", b.faces.size(), inward, extent]
+			)
+		)
+		if not ok:
+			continue
+		if not extent.is_finite():
+			known(
+				340,
+				"inset with distance %s height %s leaves non-finite geometry" % [pair[0], pair[1]],
+				"local extent %s" % extent
+			)
+		if inward > 0:
+			known(
+				339,
+				(
+					"inset with distance %s height %s leaves %d inward faces"
+					% [pair[0], pair[1], inward]
+				)
+			)
+		for problem in HFVibe.check_invariants(root):
+			known(340, "inset %s/%s broke an invariant" % [pair[0], pair[1]], problem)
+
+
+## Array counts at their edges. #300 put a 256 cap on the dock's linear path;
+## these are the other two paths and the numbers either side of the cap.
+func _array_counts() -> void:
+	var root: Node3D = await fresh_root()
+	var b = box(root, Vector3(32, 32, 32))
+	var ids := PackedStringArray([_bid(b)])
+	for count in [0, 1, -4, 257, 100000]:
+		var before: int = root.draft_brushes_node.get_child_count()
+		var linear = root.create_duplicate_array(ids, count, Vector3(64, 0, 0))
+		await frame()
+		var made: int = root.draft_brushes_node.get_child_count() - before
+		note(
+			"linear array of %d" % count,
+			"%s, %d brushes added" % ["ok" if linear else "refused", made]
+		)
+		if made > 1000:
+			flag(
+				"a linear array of %d copies is built without a cap" % count,
+				"%d brushes added in one call" % made
+			)
+		if linear and made < 0:
+			flag("a linear array of %d removed brushes" % count, "%d fewer than before" % -made)
+		if made > 0 and typeof(linear) == TYPE_STRING:
+			root.remove_duplicate_array(str(linear))
+			await frame()
+	for counts in [Vector3i(0, 0, 0), Vector3i(-2, 2, 2), Vector3i(50, 50, 50)]:
+		var before: int = root.draft_brushes_node.get_child_count()
+		var grid = root.create_grid_array(ids, counts, Vector3(64, 64, 64))
+		await frame()
+		var made: int = root.draft_brushes_node.get_child_count() - before
+		note("grid array %s" % counts, "%s, %d brushes added" % ["ok" if grid else "refused", made])
+		if grid and (counts.x < 1 or counts.y < 1 or counts.z < 1):
+			known(
+				346,
+				"a grid array with a negative count is built rather than refused",
+				(
+					"counts %s made %d copies; the linear path refuses a negative count outright"
+					% [counts, made]
+				)
+			)
+		if made > 1000:
+			flag(
+				"a grid array of %s is built without a cap" % counts,
+				"%d brushes added in one call" % made
+			)
+		if made > 0 and typeof(grid) == TYPE_STRING:
+			root.remove_duplicate_array(str(grid))
+			await frame()
+	for count in [0, -4, 5000]:
+		var before: int = root.draft_brushes_node.get_child_count()
+		var radial = root.create_radial_array(ids, count, 1, 15.0, Vector3.ZERO, 0.0)
+		await frame()
+		var made: int = root.draft_brushes_node.get_child_count() - before
+		note(
+			"radial array of %d" % count,
+			"%s, %d brushes added" % ["ok" if radial else "refused", made]
+		)
+		if made > 1000:
+			flag(
+				"a radial array of %d copies is built without a cap" % count,
+				"%d brushes added in one call" % made
+			)
+		if made > 0 and typeof(radial) == TYPE_STRING:
+			root.remove_duplicate_array(str(radial))
+			await frame()
+	for problem in HFVibe.check_invariants(root):
+		flag("arrays broke an invariant", problem)

--- a/tools/vibe/scenarios/cutting.gd.uid
+++ b/tools/vibe/scenarios/cutting.gd.uid
@@ -1,0 +1,1 @@
+uid://ch3ecfebe6lvx

--- a/tools/vibe/scenarios/entities.gd
+++ b/tools/vibe/scenarios/entities.gd
@@ -1,0 +1,248 @@
+@tool
+extends HFVibeScenario
+
+## Point entities, brush entities and the I/O wiring between them.
+##
+## Wiring is held by *name*, so every question here is really the same one: when
+## a name changes -- because an entity was renamed, duplicated, deleted or
+## restored -- does the wiring that referred to it follow, break loudly, or
+## quietly point at nothing.
+
+
+func id() -> String:
+	return "entities"
+
+
+func summary() -> String:
+	return "entity naming, duplication, deletion and what happens to the I/O wired to them"
+
+
+func run() -> void:
+	await _duplicate_keeps_the_wiring_straight()
+	await _delete_leaves_no_dangling_output()
+	await _rename_by_hand()
+	await _output_input_validation()
+	await _brush_entity_tie()
+
+
+## An entity of `type` at `where`, with an authored name.
+func _spawn(root: Node3D, type: String, where: Vector3, authored: String) -> Node3D:
+	var info := {
+		"entity_type": type,
+		"entity_class": type,
+		"transform": Transform3D(Basis.IDENTITY, where),
+		"properties": {},
+		"name": authored,
+		"entity_name": authored,
+	}
+	var entity = root._restore_entity_from_info(info)
+	return entity
+
+
+func _paths(nodes: Array) -> Array:
+	var out: Array = []
+	for n in nodes:
+		out.append(n.get_path())
+	return out
+
+
+## Duplicating a wired entity: the copy cannot keep the original's authored name,
+## or every output aimed at that name now fires at two entities.
+func _duplicate_keeps_the_wiring_straight() -> void:
+	var root: Node3D = await fresh_root()
+	var button := _spawn(root, "func_button", Vector3.ZERO, "button_1")
+	var door := _spawn(root, "func_door", Vector3(128, 0, 0), "door_1")
+	if button == null or door == null:
+		note("entity creation", "could not create func_button/func_door, skipping")
+		return
+	root.add_entity_output(button, "OnPressed", "door_1", "Open")
+	await frame()
+	note("wired", "%d output(s) on the button" % root.get_entity_outputs(button).size())
+
+	var copy_info: Dictionary = root.build_duplicate_entity_info(door, Vector3(0, 0, 128))
+	root.create_entities_from_infos([copy_info])
+	await frame()
+	var matches: Array = root.find_entities_by_name("door_1")
+	note("after duplicating the door", "%d entities answer to 'door_1'" % matches.size())
+	if matches.size() > 1:
+		known(
+			341,
+			"duplicating a wired entity leaves two entities with the same authored name",
+			(
+				"%d entities answer to 'door_1', so every output aimed at it now fires at all of them"
+				% matches.size()
+			)
+		)
+	var summary: Dictionary = root.get_connection_summary("door_1")
+	note("connection summary for 'door_1'", summary)
+
+
+## Deleting the target of an output leaves the output pointing at a name nothing
+## answers to. `cleanup_dangling_connections` exists for exactly this.
+func _delete_leaves_no_dangling_output() -> void:
+	var root: Node3D = await fresh_root()
+	var button := _spawn(root, "func_button", Vector3.ZERO, "button_1")
+	var door := _spawn(root, "func_door", Vector3(128, 0, 0), "door_1")
+	if button == null or door == null:
+		return
+	root.add_entity_output(button, "OnPressed", "door_1", "Open")
+	await frame()
+	root.delete_entities_by_paths(_paths([door]))
+	await frame()
+	var outputs: Array = root.get_entity_outputs(button)
+	var dangling := 0
+	for o in outputs:
+		if root.find_entities_by_name(str((o as Dictionary).get("target_name", ""))).is_empty():
+			dangling += 1
+	note(
+		"after deleting the door", "%d of %d outputs point at nothing" % [dangling, outputs.size()]
+	)
+	if dangling > 0:
+		flag(
+			"deleting an entity leaves the outputs aimed at it dangling",
+			(
+				"%d of %d outputs on the button still target 'door_1'; the level reports no error"
+				% [dangling, outputs.size()]
+			)
+		)
+	var all: Array = root.get_all_entity_connections()
+	var health: Dictionary = root.validate_level()
+	note("validate_level after the delete", health)
+	note("get_all_entity_connections", "%d connection(s)" % all.size())
+
+
+## Renaming an entity by hand -- which is what the Inspector does -- and whether
+## the wiring follows.
+func _rename_by_hand() -> void:
+	var root: Node3D = await fresh_root()
+	var button := _spawn(root, "func_button", Vector3.ZERO, "button_1")
+	var door := _spawn(root, "func_door", Vector3(128, 0, 0), "door_1")
+	if button == null or door == null:
+		return
+	root.add_entity_output(button, "OnPressed", "door_1", "Open")
+	await frame()
+	door.set_meta("entity_name", "door_renamed")
+	await frame()
+	var found: Array = root.find_entities_by_name("door_1")
+	var summary: Dictionary = root.get_connection_summary("door_renamed")
+	note("after renaming door_1 to door_renamed", "%d answer to the old name" % found.size())
+	note("connection summary for the new name", summary)
+	if found.is_empty() and int(summary.get("triggers", 0)) == 0:
+		note(
+			"the wiring did not follow the rename",
+			"the button still fires at 'door_1', which nothing answers to"
+		)
+
+
+## What an output accepts. Every field here is written verbatim into the exported
+## `.map`, so anything a mapper can type is something the engine reads back.
+func _output_input_validation() -> void:
+	var root: Node3D = await fresh_root()
+	var button := _spawn(root, "func_button", Vector3.ZERO, "button_1")
+	if button == null:
+		return
+	var cases := [
+		["empty output name", "", "door_1", "Open", "", 0.0],
+		["empty target", "OnPressed", "", "Open", "", 0.0],
+		["empty input", "OnPressed", "door_1", "", "", 0.0],
+		["negative delay", "OnPressed", "door_1", "Open", "", -5.0],
+		["non-finite delay", "OnPressed", "door_1", "Open", "", NAN],
+		["target with a comma", "OnPressed", "door,1", "Open", "", 0.0],
+		["parameter with a quote", "OnPressed", "door_1", "Open", 'say "hi"', 0.0],
+	]
+	for case in cases:
+		var before: int = root.get_entity_outputs(button).size()
+		root.add_entity_output(button, case[1], case[2], case[3], case[4], case[5], false)
+		await frame()
+		var after: int = root.get_entity_outputs(button).size()
+		note(case[0], "accepted" if after > before else "refused")
+		if after > before and case[0] in ["empty output name", "empty target", "empty input"]:
+			known(
+				342,
+				"an entity output with an %s is accepted" % case[0],
+				"it writes a line into the exported .map that names nothing"
+			)
+		if after > before and case[0] == "non-finite delay":
+			known(
+				342,
+				"an entity output accepts a non-finite delay",
+				"NAN is written straight into the exported .map"
+			)
+	# One final export, to see what the accepted junk does downstream, and then
+	# back in through the importer -- a format this exporter writes and its own
+	# importer cannot read is not a format.
+	var path := "user://vibe_entities.map"
+	root.export_map(path, "valve220")
+	var text := FileAccess.get_file_as_string(path)
+	note("exported .map", "%d bytes, %d output lines" % [text.length(), text.count("OnPressed")])
+	if text.find("nan") >= 0 or text.find("NAN") >= 0:
+		known(
+			342,
+			"the exported .map carries a NAN through an entity output",
+			"a map compiler reading that line has no defined behaviour"
+		)
+	for line in text.split("\n"):
+		if line.find("door 1") >= 0:
+			# Deliberate: `MapIO._no_commas()` strips rather than escapes, because
+			# the format defines no escape for a comma and a reader splitting on
+			# it would get a field too many. Recorded so the behaviour stays
+			# visible, not reported.
+			note("a comma in a target name is rewritten on export", line.strip_edges())
+		if line.find('\\"') >= 0:
+			# Deliberate: `escape_property()` and the reader agree on `\"` and
+			# `\`. Classic .map parsers do not define an escape, so this is
+			# recorded as a compatibility note rather than reported as a defect.
+			note("the exporter escapes a quote inside a value", line.strip_edges())
+	var validation: Dictionary = root.validate_map(path)
+	note("the exporter's own validator on that file", validation)
+	var reader: Node3D = await fresh_root("Reimport")
+	var imported: int = reader.import_map(path)
+	var back: Array = HFVibe.describe_entities(reader)
+	note("re-imported", "%d brushes, %d entities" % [imported, back.size()])
+	if back.is_empty():
+		flag(
+			"the importer reads back no entities from a file this exporter wrote",
+			"%d bytes of .map with a func_button in it" % text.length()
+		)
+	var restored_outputs := 0
+	for e in back:
+		restored_outputs += (e.get("io", []) as Array).size()
+		note("re-imported entity", "%s io %s" % [e.get("type"), e.get("io")])
+	if restored_outputs == 0 and text.count("OnPressed") > 0:
+		flag(
+			"the importer drops every entity output the exporter wrote",
+			(
+				"%d OnPressed lines went out and %d came back, so a .map round trip unwires the level"
+				% [text.count("OnPressed"), restored_outputs]
+			)
+		)
+
+
+## Tying brushes to an entity class makes them a brush entity. Untying puts them
+## back. The round trip should be exact.
+func _brush_entity_tie() -> void:
+	var root: Node3D = await fresh_root()
+	var b = box(root, Vector3(64, 64, 64))
+	var id := str(b.get_meta("brush_id", ""))
+	var before := HFVibe.describe_brushes(root)
+	root.tie_brushes_to_entity([id], "func_door")
+	await frame()
+	note("after tie", "entity class %s" % str(b.get_meta("brush_entity_class", "")))
+	root.untie_brushes_from_entity([id])
+	await frame()
+	var after := HFVibe.describe_brushes(root)
+	diff_levels({"b": before}, {"b": after}, "tie to func_door and untie")
+	for bad_class in ["", "   ", "worldspawn"]:
+		root.tie_brushes_to_entity([id], bad_class)
+		await frame()
+		var tied := str(b.get_meta("brush_entity_class", ""))
+		note("tie to '%s'" % bad_class, "brush entity class is now '%s'" % tied)
+		if bad_class.strip_edges() == "" and tied != "":
+			flag(
+				"a brush can be tied to an entity class that is blank",
+				"the class ends up '%s', which exports as an entity with no classname" % tied
+			)
+		root.untie_brushes_from_entity([id])
+		await frame()
+	for problem in HFVibe.check_invariants(root):
+		flag("tying and untying broke an invariant", problem)

--- a/tools/vibe/scenarios/entities.gd.uid
+++ b/tools/vibe/scenarios/entities.gd.uid
@@ -1,0 +1,1 @@
+uid://crmf76xfmxml4

--- a/tools/vibe/scenarios/housekeeping.gd
+++ b/tools/vibe/scenarios/housekeeping.gd
@@ -1,0 +1,179 @@
+@tool
+extends HFVibeScenario
+
+## Visgroups, groups, the cordon and paint layers -- the bookkeeping a mapper
+## builds up around the geometry rather than in it.
+##
+## None of it is geometry, so none of it is checked by anything that looks at
+## geometry. A visgroup named by a blank string, a cordon built from nothing, a
+## paint layer renamed to the name of another: each is a small thing that only
+## shows up later, when the level is loaded and something is missing.
+
+
+func id() -> String:
+	return "housekeeping"
+
+
+func summary() -> String:
+	return "visgroup and group names, the cordon, and the paint layer list at their edges"
+
+
+func run() -> void:
+	await _visgroup_names()
+	await _group_names()
+	await _cordon_from_nothing()
+	await _paint_layer_list()
+
+
+func _visgroup_names() -> void:
+	var root: Node3D = await fresh_root()
+	var b = box(root, Vector3(64, 64, 64))
+	for vg_name in ["", "   ", "lights", "lights"]:
+		root.create_visgroup(vg_name, Color.WHITE)
+		await frame()
+	var names: PackedStringArray = root.get_visgroup_names()
+	note("created '', '   ', 'lights' twice", "visgroups now %s" % [names])
+	for n in names:
+		if n != "" and n.strip_edges() == "":
+			known(
+				349,
+				"a visgroup can be named with nothing but whitespace",
+				(
+					"'' is refused but '%s' is not, so the dock shows a blank row that cannot be told from another"
+					% n
+				)
+			)
+	var lights := 0
+	for n in names:
+		if n == "lights":
+			lights += 1
+	if lights > 1:
+		flag("creating a visgroup twice makes two of them", "%d named 'lights'" % lights)
+
+	# Hiding a visgroup, then adding a brush to it.
+	root.set_visgroup_visible("lights", false)
+	await frame()
+	root.add_selection_to_visgroup("lights", [b])
+	await frame()
+	note("brush added to a hidden visgroup", "visible = %s" % b.visible)
+	if b.visible:
+		flag(
+			"a brush added to a hidden visgroup stays visible",
+			"the visgroup is hidden, so its members should not be on screen"
+		)
+	root.set_visgroup_visible("lights", true)
+	await frame()
+	note("after showing the visgroup again", "visible = %s" % b.visible)
+	if not b.visible:
+		flag("showing a visgroup again does not bring its members back", "brush is still hidden")
+
+	# Removing a visgroup a brush is still in.
+	root.remove_visgroup("lights")
+	await frame()
+	var left: PackedStringArray = b.get_meta("visgroups", PackedStringArray())
+	note("after removing the visgroup", "brush still lists %s, visible = %s" % [left, b.visible])
+	if Array(left).has("lights"):
+		flag(
+			"removing a visgroup leaves its name on the brushes that were in it",
+			"the brush still carries 'lights' in its visgroups meta, which is saved and reloaded"
+		)
+	for problem in HFVibe.check_invariants(root):
+		flag("visgroup bookkeeping broke an invariant", problem)
+
+
+func _group_names() -> void:
+	var root: Node3D = await fresh_root()
+	var a = box(root, Vector3(64, 64, 64), Vector3(-64, 0, 0))
+	var b = box(root, Vector3(64, 64, 64), Vector3(64, 0, 0))
+	root.group_selection("", [a, b])
+	await frame()
+	note("group with a blank name", "%d members" % root.get_group_members("").size())
+	root.group_selection("crates", [a, b])
+	await frame()
+	note("group 'crates'", "%d members" % root.get_group_members("crates").size())
+	# Regrouping one member into another group: which group does it end up in?
+	root.group_selection("barrels", [a])
+	await frame()
+	note(
+		"after regrouping one member",
+		(
+			"crates %d, barrels %d"
+			% [root.get_group_members("crates").size(), root.get_group_members("barrels").size()]
+		)
+	)
+	root.ungroup_nodes([a, b])
+	await frame()
+	note(
+		"after ungrouping both",
+		(
+			"crates %d, barrels %d"
+			% [root.get_group_members("crates").size(), root.get_group_members("barrels").size()]
+		)
+	)
+
+
+func _cordon_from_nothing() -> void:
+	var root: Node3D = await fresh_root()
+	root.set_cordon_from_selection([])
+	await frame()
+	note("cordon from an empty selection", "enabled = %s" % root.get("cordon_enabled"))
+	var b = box(root, Vector3(64, 64, 64))
+	root.set_cordon_from_selection([b])
+	await frame()
+	note("cordon from one brush", "enabled = %s" % root.get("cordon_enabled"))
+	var dry: Dictionary = root.bake_dry_run()
+	note("bake dry run inside the cordon", dry)
+	# A cordon that excludes everything: move the brush far outside it.
+	b.global_position = Vector3(100000, 0, 0)
+	await frame()
+	var dry_outside: Dictionary = root.bake_dry_run()
+	note("bake dry run with the only brush outside the cordon", dry_outside)
+	if int(dry_outside.get("brushes", -1)) > 0:
+		flag(
+			"the dry run counts a brush that the cordon excludes",
+			(
+				"the brush sits at %s, far outside the cordon, and the dry run reports %s"
+				% [b.global_position, dry_outside]
+			)
+		)
+
+
+func _paint_layer_list() -> void:
+	var root: Node3D = await fresh_root()
+	for _i in range(4):
+		root.add_paint_layer()
+	await frame()
+	var names: Array = root.get_paint_layer_names()
+	note("four layers added", names)
+	for bad in [-1, 99]:
+		var renamed: bool = root.rename_paint_layer(bad, "nope")
+		note("rename layer %d" % bad, "returned %s" % renamed)
+		if renamed:
+			flag("renaming a paint layer that does not exist reports success", "index %d" % bad)
+		root.set_active_paint_layer(bad)
+		await frame()
+		note("set active layer %d" % bad, "active is now %d" % root.get_active_paint_layer_index())
+		if root.get_active_paint_layer_index() == bad:
+			flag(
+				"the active paint layer can be set to index %d" % bad,
+				"every paint stroke from here writes into a layer that is not there"
+			)
+	var blank: bool = root.rename_paint_layer(0, "")
+	await frame()
+	note(
+		"rename layer 0 to a blank name",
+		"returned %s, names now %s" % [blank, root.get_paint_layer_names()]
+	)
+	# Remove every layer, one at a time, and keep going past the end.
+	for _i in range(8):
+		root.set_active_paint_layer(0)
+		root.remove_active_paint_layer()
+		await frame()
+	note(
+		"removed eight layers from a list of four", "%d left" % root.get_paint_layer_names().size()
+	)
+	if root.get_paint_layer_names().is_empty():
+		flag(
+			"every paint layer can be removed, leaving a level with none",
+			"the paint tool has no layer to write into and the dock has no row to select"
+		)

--- a/tools/vibe/scenarios/housekeeping.gd.uid
+++ b/tools/vibe/scenarios/housekeeping.gd.uid
@@ -1,0 +1,1 @@
+uid://blftejqqxq5w4

--- a/tools/vibe/scenarios/persistence.gd
+++ b/tools/vibe/scenarios/persistence.gd
@@ -1,0 +1,179 @@
+@tool
+extends HFVibeScenario
+
+## Capture and restore, which is what undo replays and what every whole-level
+## operation leans on.
+##
+## The round trip here is `capture_state()` -> `restore_state()`. It is supposed
+## to be exact: the state a capture wrote back onto a level should leave that
+## level indistinguishable from the one it came off. When it is not, the loss is
+## silent -- the operation reports success and the level is just poorer, which
+## is the shape every round-trip defect in this project has had.
+
+const HFGeneratorSystem = preload("res://addons/hammerforge/systems/hf_generator_system.gd")
+
+
+func id() -> String:
+	return "persistence"
+
+
+func summary() -> String:
+	return "capture/restore round trips, repeated restores, and level health after them"
+
+
+func run() -> void:
+	await _capture_restore_round_trip()
+	await _restore_is_idempotent()
+	await _restore_across_levels()
+	await _junk_state()
+
+
+## A level with something of everything on it.
+func _furnish(root: Node3D) -> void:
+	var mats: Array = []
+	for i in range(3):
+		var m := StandardMaterial3D.new()
+		m.resource_name = "mat_%d" % i
+		mats.append(m)
+	root.set_materials(mats)
+
+	var a = box(root, Vector3(128, 64, 64), Vector3(-128, 0, 0))
+	var b = box(root, Vector3(64, 64, 64), Vector3(128, 0, 0))
+	a.faces[0].material_idx = 2
+	a.faces[1].uv_scale = Vector2(2, 4)
+	a.faces[1].uv_offset = Vector2(0.25, 0.5)
+	b.faces[3].uv_rotation = 0.75
+	root.create_visgroup("lights", Color.YELLOW)
+	root.add_selection_to_visgroup("lights", [b])
+	root.tie_brushes_to_entity([str(b.get_meta("brush_id", ""))], "func_door")
+	var entity = (
+		root
+		. _restore_entity_from_info(
+			{
+				"entity_type": "light",
+				"entity_class": "light",
+				"transform": Transform3D(Basis.IDENTITY, Vector3(0, 64, 0)),
+				"properties": {"brightness": 2.5},
+				"name": "light_1",
+				"entity_name": "light_1",
+			}
+		)
+	)
+	if entity:
+		root.add_entity_output(entity, "OnStart", "door_1", "Open")
+	root.create_generator(
+		"stairs", HFGeneratorSystem.default_settings("stairs"), Transform3D.IDENTITY
+	)
+	root.create_displacement(str(a.get_meta("brush_id", "")), 2, 2)
+	root.add_paint_layer()
+
+
+## Capture a furnished level, change it, put the capture back.
+func _capture_restore_round_trip() -> void:
+	var root: Node3D = await fresh_root()
+	_furnish(root)
+	await frame()
+	var before := HFVibe.describe_level(root)
+	var state: Dictionary = root.capture_state()
+	note("captured", "%d top-level keys" % state.size())
+
+	# Wreck the level, so a restore that quietly does nothing is visible.
+	root.clear_brushes()
+	root._clear_entities()
+	await frame()
+	note("after clearing", "%d brushes" % root.get_live_brush_count())
+
+	root.restore_state(state)
+	await frame()
+	var after := HFVibe.describe_level(root)
+	diff_levels(before, after, "capture_state and restore_state")
+	for problem in HFVibe.check_invariants(root):
+		flag("restore_state broke an invariant", problem)
+
+
+## Restoring the same capture twice must land in the same place as once.
+## Undo replays a capture every time it is stepped over.
+func _restore_is_idempotent() -> void:
+	var root: Node3D = await fresh_root()
+	_furnish(root)
+	await frame()
+	var state: Dictionary = root.capture_state()
+	root.restore_state(state)
+	await frame()
+	var once := HFVibe.describe_level(root)
+	for _i in range(3):
+		root.restore_state(state)
+		await frame()
+	var four_times := HFVibe.describe_level(root)
+	note("restored the same capture four times", "%d brushes" % root.get_live_brush_count())
+	diff_levels(once, four_times, "restoring the same capture four times rather than once")
+	for problem in HFVibe.check_invariants(root):
+		flag("repeated restore broke an invariant", problem)
+
+
+## A capture taken off one level, restored onto another. This is what a prefab
+## drop, a paste and a whole-level replace all do.
+func _restore_across_levels() -> void:
+	var source: Node3D = await fresh_root("Source")
+	_furnish(source)
+	await frame()
+	var before := HFVibe.describe_level(source)
+	var state: Dictionary = source.capture_state()
+
+	var target: Node3D = await fresh_root("Target")
+	target.restore_state(state)
+	await frame()
+	var after := HFVibe.describe_level(target)
+	diff_levels(before, after, "a capture restored onto a different level")
+	for problem in HFVibe.check_invariants(target):
+		flag("restoring onto another level broke an invariant", problem)
+
+	# And the source must not have been emptied out from under the caller by the
+	# restore reparenting its nodes. #282 was exactly this shape.
+	var source_after := HFVibe.describe_level(source)
+	diff_levels(before, source_after, "the source level after its capture was restored elsewhere")
+
+
+## A state dictionary that did not come from `capture_state`: truncated, wrong
+## types, absurd counts. A hand-edited `.hflevel` produces all three.
+func _junk_state() -> void:
+	var cases := {
+		"empty": {},
+		"brushes is a string": {"brushes": "nope", "entities": [], "materials": []},
+		"a brush entry is a number": {"brushes": [42], "entities": [], "materials": []},
+		"a brush with no size": {"brushes": [{"shape": 0}], "entities": [], "materials": []},
+		"a brush with a NAN size":
+		{
+			"brushes": [{"shape": 0, "size": Vector3(NAN, NAN, NAN)}],
+			"entities": [],
+			"materials": []
+		},
+		"entities is a dictionary": {"brushes": [], "entities": {}, "materials": []},
+		"materials holds junk": {"brushes": [], "entities": [], "materials": [1, "two", null]},
+	}
+	for label in cases:
+		var root: Node3D = await fresh_root()
+		var before_count: int = root.get_live_brush_count()
+		root.restore_state(cases[label])
+		await frame()
+		note(
+			"restore_state with %s" % label,
+			(
+				"%d brushes (was %d), %d materials"
+				% [root.get_live_brush_count(), before_count, root.get_materials().size()]
+			)
+		)
+		var junk_materials := 0
+		for m in root.get_materials():
+			if m != null and not (m is Material):
+				junk_materials += 1
+		if junk_materials > 0:
+			flag(
+				(
+					"restore_state with %s puts %d non-materials in the palette"
+					% [label, junk_materials]
+				),
+				"get_materials() hands those back to every caller that then reads a Material off them"
+			)
+		for problem in HFVibe.check_invariants(root):
+			known(348, "restore_state with %s broke an invariant" % label, problem)

--- a/tools/vibe/scenarios/persistence.gd.uid
+++ b/tools/vibe/scenarios/persistence.gd.uid
@@ -1,0 +1,1 @@
+uid://cpwd7ubg3qjil

--- a/tools/vibe/scenarios/structures.gd
+++ b/tools/vibe/scenarios/structures.gd
@@ -1,0 +1,272 @@
+@tool
+extends HFVibeScenario
+
+## The four live generators -- arch, stairs, spiral stairs, dome -- driven
+## through `LevelRoot`, which is how the Structure dock drives them.
+##
+## Three shapes of question. Does the geometry come out wound the right way?
+## Does a setting outside the schema's own range get refused, or built? And is
+## regenerating with the settings a structure already has a no-op, or does it
+## move the structure?
+
+const HFGeneratorSchema = preload("res://addons/hammerforge/hf_generator_schema.gd")
+const HFGeneratorSystem = preload("res://addons/hammerforge/systems/hf_generator_system.gd")
+
+
+func id() -> String:
+	return "structures"
+
+
+func summary() -> String:
+	return "arch/stairs/spiral/dome winding, schema range enforcement, regenerate round trip"
+
+
+func run() -> void:
+	await _defaults_build_clean()
+	await _regenerate_is_a_no_op()
+	await _placement_is_honoured()
+	await _out_of_range_settings()
+	await _nonsense_settings()
+
+
+func _types() -> PackedStringArray:
+	return HFGeneratorSystem.known_types()
+
+
+## Every structure id currently on the level.
+##
+## `create_generator` reports success but not which structure it made, so the
+## only way back to the record it just wrote is to diff the system's capture
+## across the call. Ids sort as strings, not as the microsecond counts they are
+## built from, so "newest" cannot be read off an ordering.
+func _generator_ids(root: Node3D) -> Dictionary:
+	var out: Dictionary = {}
+	for r in root.generator_system.capture():
+		out[str((r as Dictionary).get("generator_id", ""))] = true
+	return out
+
+
+func _added_generator(root: Node3D, before: Dictionary) -> String:
+	for gid in _generator_ids(root):
+		if not before.has(gid):
+			return str(gid)
+	return ""
+
+
+func _pieces(root: Node3D, generator_id: String) -> Array:
+	var out: Array = []
+	for b in root.draft_brushes_node.get_children():
+		if str(b.get_meta("hf_generator_id", "")) == generator_id:
+			out.append(b)
+	return out
+
+
+## Every type at its own defaults. A structure a mapper places from the dock
+## without touching a setting is the most-travelled path there is.
+func _defaults_build_clean() -> void:
+	var root: Node3D = await fresh_root()
+	for type in _types():
+		var settings: Dictionary = HFGeneratorSystem.default_settings(type)
+		var seen := _generator_ids(root)
+		var result = root.create_generator(type, settings, Transform3D.IDENTITY)
+		if result == null or not result.ok:
+			flag("%s at its defaults will not build" % type, result.message if result else "null")
+			continue
+		var gid := _added_generator(root, seen)
+		var pieces := _pieces(root, gid)
+		var inward := 0
+		var degenerate := 0
+		for p in pieces:
+			inward += HFVibe.inward_face_count(p)
+			if HFVibe.local_extent(p).length() < 0.001:
+				degenerate += 1
+		note("%s defaults" % type, "%d pieces, %d inward faces" % [pieces.size(), inward])
+		if inward > 0:
+			flag(
+				"%s builds %d inward-facing faces at its defaults" % [type, inward],
+				"across %d pieces -- these bake inside out" % pieces.size()
+			)
+		if degenerate > 0:
+			flag("%s builds %d zero-extent pieces at its defaults" % [type, degenerate])
+		for problem in HFVibe.check_invariants(root):
+			flag("%s at defaults broke an invariant" % type, problem)
+
+
+## Regenerating with the settings a structure already has should change nothing.
+## It is what the dock does every time a spinner is touched and put back.
+func _regenerate_is_a_no_op() -> void:
+	for type in _types():
+		var root: Node3D = await fresh_root()
+		var settings: Dictionary = HFGeneratorSystem.default_settings(type)
+		var placement := Transform3D(Basis.IDENTITY, Vector3(128, 64, -32))
+		var seen := _generator_ids(root)
+		var result = root.create_generator(type, settings, placement)
+		if result == null or not result.ok:
+			continue
+		var gid := _added_generator(root, seen)
+		var before := HFVibe.describe_brushes(root)
+		var again = root.regenerate_generator(gid, settings.duplicate())
+		await frame()
+		if again == null or not again.ok:
+			flag(
+				"%s will not regenerate with the settings it was built from" % type,
+				again.message if again else "null"
+			)
+			continue
+		var after := HFVibe.describe_brushes(root)
+		diff_levels({"b": before}, {"b": after}, "%s regenerated with identical settings" % type)
+
+
+## A structure placed away from the origin belongs where it was placed.
+func _placement_is_honoured() -> void:
+	for type in _types():
+		var root: Node3D = await fresh_root()
+		var origin := Vector3(512, 128, -256)
+		var placement := Transform3D(Basis.from_euler(Vector3(0, deg_to_rad(45), 0)), origin)
+		var seen := _generator_ids(root)
+		var result = root.create_generator(
+			type, HFGeneratorSystem.default_settings(type), placement
+		)
+		if result == null or not result.ok:
+			continue
+		var gid := _added_generator(root, seen)
+		var pieces := _pieces(root, gid)
+		if pieces.is_empty():
+			continue
+		var bounds := AABB(pieces[0].global_position, Vector3.ZERO)
+		for p in pieces:
+			bounds = bounds.expand(p.global_position)
+		var nearest := INF
+		for p in pieces:
+			nearest = minf(nearest, p.global_position.distance_to(origin))
+		note(
+			"%s placed at %s" % [type, origin],
+			(
+				"centre %s, nearest piece %.1f away"
+				% [bounds.get_center().snapped(Vector3.ONE), nearest]
+			)
+		)
+		# The placement is a point on the structure, not necessarily its centre,
+		# so the test is that *something* is near it -- not that everything is.
+		var span: float = maxf(bounds.size.length(), 1.0)
+		if nearest > span:
+			flag(
+				"%s lands nowhere near its placement" % type,
+				(
+					"nearest of %d pieces is %.1f from %s, and the structure spans %.1f"
+					% [pieces.size(), nearest, origin, span]
+				)
+			)
+		var rebuilt: Transform3D = root.generator_rebuild_placement(gid)
+		if not rebuilt.origin.is_equal_approx(origin):
+			flag(
+				"%s does not remember where it was placed" % type,
+				"placed at %s, rebuild placement reports %s" % [origin, rebuilt.origin]
+			)
+
+
+## The schema carries a min and a max per field. Feeding a value outside that
+## range is what a hand-edited `.hflevel`, an undo replay and a script all do.
+func _out_of_range_settings() -> void:
+	for type in _types():
+		var root: Node3D = await fresh_root()
+		var schema: Array = HFGeneratorSystem.settings_schema(type)
+		for entry in schema:
+			if not (entry is Dictionary):
+				continue
+			var field: Dictionary = entry
+			var key := str(field.get("key", ""))
+			var ftype := str(field.get("type", ""))
+			if key == "" or ftype == HFGeneratorSchema.TYPE_BOOL:
+				continue
+			if not field.has("max"):
+				continue
+			var over: float = float(field["max"]) * 1000.0 + 1000.0
+			var settings: Dictionary = HFGeneratorSystem.default_settings(type)
+			settings[key] = over
+			var check = root.can_build_generator(type, settings)
+			var seen := _generator_ids(root)
+			var built = root.create_generator(type, settings, Transform3D.IDENTITY)
+			var ok: bool = built != null and built.ok
+			if not ok:
+				continue
+			var gid := _added_generator(root, seen)
+			var pieces := _pieces(root, gid)
+			var inward := 0
+			var biggest := 0.0
+			for p in pieces:
+				inward += HFVibe.inward_face_count(p)
+				biggest = maxf(biggest, HFVibe.local_extent(p).length())
+			note(
+				"%s %s = %s (schema max %s)" % [type, key, over, field["max"]],
+				(
+					"can_build %s, %d pieces, %d inward, largest piece %.0f units"
+					% [check.ok if check else "null", pieces.size(), inward, biggest]
+				)
+			)
+			if inward > 0:
+				flag(
+					(
+						"%s with %s far above its schema max builds %d inward faces"
+						% [type, key, inward]
+					)
+				)
+			if pieces.size() > 1000:
+				known(
+					337,
+					"%s builds %d pieces from %s = %s" % [type, pieces.size(), key, over],
+					"the schema caps that field at %s and nothing else does" % field["max"]
+				)
+			if biggest > 1000000.0:
+				known(
+					338,
+					(
+						"%s accepts %s = %s and builds a piece %.0f units across"
+						% [type, key, over, biggest]
+					),
+					"the schema caps that field at %s" % field["max"]
+				)
+			for problem in HFVibe.check_invariants(root):
+				known(338, "%s with %s out of range broke an invariant" % [type, key], problem)
+
+
+## Non-finite numbers, which is what a corrupt record hands the builder.
+func _nonsense_settings() -> void:
+	var root: Node3D = await fresh_root()
+	for type in _types():
+		var schema: Array = HFGeneratorSystem.settings_schema(type)
+		for entry in schema:
+			if not (entry is Dictionary):
+				continue
+			var key := str((entry as Dictionary).get("key", ""))
+			if key == "":
+				continue
+			for bad in [NAN, INF, -INF]:
+				var settings: Dictionary = HFGeneratorSystem.default_settings(type)
+				settings[key] = bad
+				var seen := _generator_ids(root)
+				var built = root.create_generator(type, settings, Transform3D.IDENTITY)
+				if built == null:
+					flag("%s with %s = %s returned null, not a result" % [type, key, bad])
+					continue
+				if not built.ok:
+					continue
+				var gid := _added_generator(root, seen)
+				var pieces := _pieces(root, gid)
+				var bad_geometry := 0
+				for p in pieces:
+					if not p.global_position.is_finite() or not HFVibe.local_extent(p).is_finite():
+						bad_geometry += 1
+				if bad_geometry > 0:
+					known(
+						336,
+						"%s accepts %s = %s and builds non-finite geometry" % [type, key, bad],
+						(
+							"%d of %d pieces have a non-finite position or extent"
+							% [bad_geometry, pieces.size()]
+						)
+					)
+				else:
+					note("%s %s = %s" % [type, key, bad], "built %d finite pieces" % pieces.size())
+				for problem in HFVibe.check_invariants(root):
+					known(336, "%s with %s = %s broke an invariant" % [type, key, bad], problem)

--- a/tools/vibe/scenarios/structures.gd.uid
+++ b/tools/vibe/scenarios/structures.gd.uid
@@ -1,0 +1,1 @@
+uid://c30lapmycfiba

--- a/tools/vibe/scenarios/terrain.gd
+++ b/tools/vibe/scenarios/terrain.gd
@@ -1,0 +1,138 @@
+@tool
+extends HFVibeScenario
+
+## The heightmap layer and the region streaming settings around it, plus the two
+## exports that take a finished level out of the editor.
+##
+## Terrain settings are numbers a mapper types into a dock: a scale, a layer
+## height, a region size in cells, a memory budget in megabytes. Each one is
+## arithmetic on the grid, so a zero or a negative is not a preference -- it is a
+## division or an allocation that has to mean something.
+
+
+func id() -> String:
+	return "terrain"
+
+
+func summary() -> String:
+	return "heightmap scale and region settings at their edges, and the playtest/glTF exports"
+
+
+func run() -> void:
+	await _heightmap_settings()
+	await _region_settings()
+	await _missing_heightmap_file()
+	await _exports()
+
+
+func _heightmap_settings() -> void:
+	var root: Node3D = await fresh_root()
+	root.generate_heightmap_noise({})
+	await frame()
+	note("noise heightmap generated", "%d paint bytes" % root.get_paint_memory_bytes())
+	for value in [0.0, -8.0, NAN, INF]:
+		root.set_heightmap_scale(value)
+		await frame()
+		var layer = root.paint_layers.get_active_layer() if root.paint_layers else null
+		var stored = layer.height_scale if layer else null
+		note("heightmap scale %s" % value, "stored as %s" % stored)
+		if typeof(stored) == TYPE_FLOAT and not is_finite(stored):
+			known(
+				350,
+				"the heightmap scale accepts %s" % value,
+				"every height on the layer is multiplied by it, so the whole layer becomes non-finite"
+			)
+		if typeof(stored) == TYPE_FLOAT and stored == 0.0 and value == 0.0:
+			known(
+				350,
+				"the heightmap scale accepts zero",
+				"the layer flattens to nothing and the sculpt on it cannot be recovered by putting the scale back"
+			)
+	for value in [NAN, INF, -INF]:
+		root.set_layer_y(value)
+		await frame()
+		var layer = root.paint_layers.get_active_layer() if root.paint_layers else null
+		var stored = layer.grid.layer_y if layer and layer.grid else null
+		note("layer Y %s" % value, "stored as %s" % stored)
+		if typeof(stored) == TYPE_FLOAT and not is_finite(stored):
+			known(
+				350,
+				"the paint layer height accepts %s" % value,
+				"the layer's geometry is built at that Y, so it lands nowhere"
+			)
+
+
+func _region_settings() -> void:
+	var root: Node3D = await fresh_root()
+	root.set_region_streaming_enabled(true)
+	await frame()
+	for value in [0, -16, 1000000]:
+		root.set_region_size_cells(value)
+		await frame()
+		var settings: Dictionary = root.get_region_settings()
+		note("region size %d cells" % value, settings)
+		var stored := int(settings.get("region_size_cells", -1))
+		if stored <= 0 or stored > 65536:
+			known(
+				352,
+				"the region size can be set to %d cells" % stored,
+				"one region is that many cells square, so the streaming budget covers a single region"
+			)
+	for value in [0, -4, 100000]:
+		root.set_region_streaming_radius(value)
+		root.set_region_memory_budget_mb(value)
+		await frame()
+		var settings: Dictionary = root.get_region_settings()
+		note("radius and budget %d" % value, settings)
+		if int(settings.get("memory_budget_mb", 1)) <= 0:
+			flag(
+				(
+					"the region memory budget can be set to %d MB"
+					% int(settings.get("memory_budget_mb", 0))
+				),
+				"nothing can be held inside that budget, so streaming evicts whatever it loads"
+			)
+
+
+## Pointing the importer at files that are not a heightmap.
+func _missing_heightmap_file() -> void:
+	var root: Node3D = await fresh_root()
+	HFVibe.write_text("user://vibe_not_an_image.png", "this is not a png")
+	for path in ["user://vibe_missing.png", "user://vibe_not_an_image.png", ""]:
+		root.import_heightmap(path)
+		await frame()
+		note("import_heightmap('%s')" % path, "%d paint bytes" % root.get_paint_memory_bytes())
+	for problem in HFVibe.check_invariants(root):
+		flag("a failed heightmap import broke an invariant", problem)
+
+
+## The two ways a level leaves the editor.
+func _exports() -> void:
+	var root: Node3D = await fresh_root()
+	var b = box(root, Vector3(128, 32, 128))
+	b.faces[0].material_idx = 7
+	await frame()
+	note("level health", root.get_level_health())
+	note("missing dependencies", root.check_missing_dependencies())
+
+	var gltf := "user://vibe_export.gltf"
+	var gltf_err: int = root.export_baked_gltf(gltf)
+	note(
+		"export_baked_gltf with nothing baked",
+		"returned error %d, wrote %d bytes" % [gltf_err, HFVibe.file_size(gltf)]
+	)
+	if gltf_err == OK and HFVibe.file_size(gltf) == 0:
+		flag(
+			"export_baked_gltf reports OK and writes no file",
+			"nothing is baked, so there is nothing to export, but the caller is told it worked"
+		)
+
+	var scene := "user://vibe_playtest.tscn"
+	var play_ok: bool = root.export_playtest_scene(scene)
+	note(
+		"export_playtest_scene", "returned %s, wrote %d bytes" % [play_ok, HFVibe.file_size(scene)]
+	)
+	if play_ok and HFVibe.file_size(scene) == 0:
+		flag("export_playtest_scene reports success and writes no file", scene)
+	for problem in HFVibe.check_invariants(root):
+		flag("exporting broke an invariant", problem)

--- a/tools/vibe/scenarios/terrain.gd.uid
+++ b/tools/vibe/scenarios/terrain.gd.uid
@@ -1,0 +1,1 @@
+uid://bpj2g5pifjiic

--- a/tools/vibe/scenarios/transform.gd
+++ b/tools/vibe/scenarios/transform.gd
@@ -1,0 +1,263 @@
+@tool
+extends HFVibeScenario
+
+## Rotate, flip and reset-rotation, driven the way the transform commands drive
+## them: always through `LevelRoot`'s five-argument delegates, because those are
+## the signatures undo replays.
+##
+## The shapes this looks for are round trips (four 90-degree rotations, or two
+## flips across the same plane, must land exactly where they started) and
+## winding after a mirror (a negative-determinant basis inverts face winding
+## invisibly until the bake).
+
+const AXIS_X := 0
+const AXIS_Y := 1
+const AXIS_Z := 2
+
+
+func id() -> String:
+	return "transform"
+
+
+func summary() -> String:
+	return "rotate/flip/reset round trips, mirror winding, pivots and nonsense angles"
+
+
+func run() -> void:
+	await _rotation_round_trip()
+	await _flip_round_trip()
+	await _mirror_winding()
+	await _pivot_arithmetic()
+	await _reset_rotation_keeps_scale()
+	await _texture_lock_world_direction()
+	await _nonsense_inputs()
+
+
+func _ids(nodes: Array) -> Array:
+	var out: Array = []
+	for n in nodes:
+		out.append(str(n.get_meta("brush_id", "")))
+	return out
+
+
+## Four quarter turns is the identity. Anything else is drift a mapper pays for
+## by nudging the brush back by hand every time they rotate it.
+func _rotation_round_trip() -> void:
+	var root: Node3D = await fresh_root()
+	var b = box(root, Vector3(64, 32, 16), Vector3(100, 0, -40))
+	var ids := _ids([b])
+	var before := HFVibe.describe_brushes(root)
+	for _i in range(4):
+		root.rotate_managed_nodes(ids, [], AXIS_Y, 90.0, Vector3.ZERO)
+	await frame()
+	var after := HFVibe.describe_brushes(root)
+	note("four 90 deg yaw about origin", "%s -> %s" % [b.global_position, b.global_position])
+	diff_levels(
+		{"brushes": before}, {"brushes": after}, "four 90 deg yaw rotations", {"brushes": 334}
+	)
+
+	# And the same about the brush's own centre, which is the pivot the dock
+	# uses by default.
+	var c = box(root, Vector3(48, 48, 48), Vector3(-200, 16, 0))
+	var cid := _ids([c])
+	var pivot: Vector3 = root.resolve_transform_pivot(cid, [])
+	var start: Vector3 = c.global_position
+	for _i in range(4):
+		root.rotate_managed_nodes(cid, [], AXIS_X, 90.0, pivot)
+	await frame()
+	if not c.global_position.is_equal_approx(start):
+		flag(
+			"four pitch rotations about the selection pivot move the brush",
+			"%s -> %s" % [start, c.global_position]
+		)
+	else:
+		note("four 90 deg pitch about selection pivot", "position held at %s" % start)
+
+
+## Mirroring twice across the same plane is the identity too.
+func _flip_round_trip() -> void:
+	var root: Node3D = await fresh_root()
+	var b = box(root, Vector3(96, 24, 48), Vector3(64, 0, 0))
+	var ids := _ids([b])
+	b.faces[0].material_idx = 3
+	b.faces[1].material_idx = 7
+	var before := HFVibe.describe_brushes(root)
+	root.flip_managed_nodes(ids, [], AXIS_X, Vector3.ZERO)
+	await frame()
+	root.flip_managed_nodes(ids, [], AXIS_X, Vector3.ZERO)
+	await frame()
+	var after := HFVibe.describe_brushes(root)
+	diff_levels({"brushes": before}, {"brushes": after}, "two flips across the same plane")
+
+
+## A mirror has a negative determinant, and every face that survives it comes
+## back wound the other way unless something re-winds them.
+func _mirror_winding() -> void:
+	var root: Node3D = await fresh_root()
+	for shape in range(0, 6):
+		var info := {"shape": shape, "size": Vector3(64, 64, 64), "center": Vector3.ZERO}
+		if shape != 0:
+			info["sides"] = 8
+		var b = root.create_brush_from_info(info)
+		if b == null:
+			note("shape %d" % shape, "create_brush_from_info returned null")
+			continue
+		var before_inward := HFVibe.inward_face_count(b)
+		root.flip_managed_nodes(_ids([b]), [], AXIS_Z, Vector3.ZERO)
+		await frame()
+		var after_inward := HFVibe.inward_face_count(b)
+		var det: float = b.global_transform.basis.determinant()
+		note(
+			"shape %d flipped" % shape,
+			"inward %d -> %d, basis determinant %.3f" % [before_inward, after_inward, det]
+		)
+		if after_inward > before_inward:
+			flag(
+				"flipping shape %d leaves %d inward faces" % [shape, after_inward],
+				"was %d before the flip; determinant %.3f" % [before_inward, det]
+			)
+		if det < 0.0:
+			flag(
+				"flipping shape %d leaves a negative-determinant basis" % shape,
+				"determinant %.3f -- every face renders and bakes inside out from here" % det
+			)
+		root.delete_brush(b)
+		await frame()
+
+
+## Rotating about a distant pivot is an orbit: the distance to the pivot is what
+## must not move.
+func _pivot_arithmetic() -> void:
+	var root: Node3D = await fresh_root()
+	var b = box(root, Vector3(32, 32, 32), Vector3(256, 0, 0))
+	var ids := _ids([b])
+	var pivot := Vector3.ZERO
+	var r0: float = b.global_position.distance_to(pivot)
+	root.rotate_managed_nodes(ids, [], AXIS_Y, 37.5, pivot)
+	await frame()
+	var r1: float = b.global_position.distance_to(pivot)
+	note("orbit radius about origin", "%.4f -> %.4f" % [r0, r1])
+	if absf(r1 - r0) > 0.001:
+		flag("rotating about a pivot changes the orbit radius", "%.4f -> %.4f" % [r0, r1])
+	if HFVibe.inward_face_count(b) > 0:
+		flag(
+			"a 37.5 degree rotation leaves inward faces",
+			"%d faces wound inward" % HFVibe.inward_face_count(b)
+		)
+
+
+## `reset_rotation` documents that it keeps the scale Godot's gizmo wrote, so
+## drive it the way the gizmo does -- set `rotation` and `scale` on the node.
+func _reset_rotation_keeps_scale() -> void:
+	var root: Node3D = await fresh_root()
+	var b = box(root, Vector3(64, 64, 64))
+	var ids := _ids([b])
+	b.position = Vector3(10, 0, 0)
+	b.rotation = Vector3(0.3, 0.6, 0.1)
+	b.scale = Vector3(2.0, 0.5, 1.5)
+	await frame()
+	root.reset_managed_rotation(ids)
+	await frame()
+	var scale: Vector3 = b.global_transform.basis.get_scale()
+	var euler: Vector3 = b.global_transform.basis.get_euler()
+	note("after reset_rotation", "scale %s euler %s pos %s" % [scale, euler, b.global_position])
+	if not scale.is_equal_approx(Vector3(2.0, 0.5, 1.5)):
+		flag("reset_rotation changed the scale", "expected (2, 0.5, 1.5), got %s" % scale)
+	if euler.length() > 0.001:
+		flag("reset_rotation left a rotation behind", "euler %s" % euler)
+
+
+## Texture lock claims the texture stays where it was in the world while the
+## brush turns under it. Verified independently: the world direction along which
+## U increases on a given face must not move.
+func _texture_lock_world_direction() -> void:
+	var root: Node3D = await fresh_root()
+	var b = box(root, Vector3(128, 64, 32))
+	var ids := _ids([b])
+	note("texture lock enabled", root.transform_system._texture_lock_enabled())
+	var before: Array = []
+	for i in range(b.faces.size()):
+		before.append(_u_direction(b, i))
+	root.rotate_managed_nodes(ids, [], AXIS_Y, 90.0, Vector3.ZERO)
+	await frame()
+	for i in range(b.faces.size()):
+		var n0: Vector3 = before[i]
+		var n1: Vector3 = _u_direction(b, i)
+		if n0 == Vector3.ZERO or n1 == Vector3.ZERO:
+			note("face %d" % i, "no measurable U direction (before %s after %s)" % [n0, n1])
+			continue
+		var moved := rad_to_deg(n0.angle_to(n1))
+		var normal: Vector3 = (b.global_transform.basis * b.faces[i].normal).normalized()
+		note(
+			"face %d (world normal %s)" % [i, normal.snapped(Vector3.ONE * 0.01)],
+			"U direction moved %.1f deg" % moved
+		)
+		if moved > 1.0:
+			known(
+				333,
+				"texture lock moves the U direction on face %d by %.1f deg" % [i, moved],
+				(
+					"world normal %s: a 90 deg yaw should leave the texture on a vertical wall alone"
+					% normal.snapped(Vector3.ONE * 0.01)
+				)
+			)
+
+
+## World-space direction of increasing U across one face, or zero when the face
+## is degenerate. Read off the face's own triangulated UVs, not from anything
+## the UV code claims about itself.
+func _u_direction(brush: Node3D, face_idx: int) -> Vector3:
+	var tri: Dictionary = brush.faces[face_idx].triangulate()
+	var verts: PackedVector3Array = tri["verts"]
+	var uvs: PackedVector2Array = tri["uvs"]
+	if verts.size() < 3 or uvs.size() != verts.size():
+		return Vector3.ZERO
+	var basis: Basis = brush.global_transform.basis
+	var v0: Vector3 = basis * verts[0]
+	var e1: Vector3 = basis * verts[1] - v0
+	var e2: Vector3 = basis * verts[2] - v0
+	var n: Vector3 = e1.cross(e2)
+	if n.length() < 0.0001:
+		return Vector3.ZERO
+	# g . e1 = du1, g . e2 = du2, g . n = 0.
+	var m := Basis(Vector3(e1.x, e2.x, n.x), Vector3(e1.y, e2.y, n.y), Vector3(e1.z, e2.z, n.z))
+	if absf(m.determinant()) < 0.000001:
+		return Vector3.ZERO
+	var g: Vector3 = m.inverse() * Vector3(uvs[1].x - uvs[0].x, uvs[2].x - uvs[0].x, 0.0)
+	return g.normalized() if g.length() > 0.0 else Vector3.ZERO
+
+
+## Numbers no dock would send, which undo replay and a script can both send.
+func _nonsense_inputs() -> void:
+	var root: Node3D = await fresh_root()
+	var b = box(root, Vector3(64, 64, 64))
+	var ids := _ids([b])
+	var cases := [
+		["NAN angle", func(): root.rotate_managed_nodes(ids, [], AXIS_Y, NAN, Vector3.ZERO)],
+		["INF angle", func(): root.rotate_managed_nodes(ids, [], AXIS_Y, INF, Vector3.ZERO)],
+		["NAN pivot", func(): root.rotate_managed_nodes(ids, [], AXIS_Y, 45.0, Vector3(NAN, 0, 0))],
+		["INF flip pivot", func(): root.flip_managed_nodes(ids, [], AXIS_X, Vector3(INF, 0, 0))],
+		["axis index 9", func(): root.rotate_managed_nodes(ids, [], 9, 45.0, Vector3.ZERO)],
+		["axis index -1", func(): root.flip_managed_nodes(ids, [], -1, Vector3.ZERO)],
+	]
+	for case in cases:
+		var label: String = case[0]
+		var before: Transform3D = b.global_transform
+		(case[1] as Callable).call()
+		await frame()
+		var xf: Transform3D = b.global_transform
+		var finite: bool = (
+			xf.origin.is_finite() and xf.basis.determinant() == xf.basis.determinant()
+		)
+		note(label, "pos %s det %s" % [xf.origin, xf.basis.determinant()])
+		if not finite:
+			known(
+				335,
+				"%s leaves the brush with a non-finite transform" % label,
+				"origin %s, determinant %s" % [xf.origin, xf.basis.determinant()]
+			)
+			# Put it back so the next case starts from something sane.
+			b.global_transform = before
+			await frame()
+		for problem in HFVibe.check_invariants(root):
+			known(335, "%s broke an invariant" % label, problem)

--- a/tools/vibe/scenarios/transform.gd.uid
+++ b/tools/vibe/scenarios/transform.gd.uid
@@ -1,0 +1,1 @@
+uid://tb8v2cytqvim


### PR DESCRIPTION
The scaffolding from this session's vibe sweep, extending `tools/vibe/` rather
than starting somewhere new.

Eight scenarios, covering the areas the existing seven did not reach:

| id | covers |
|---|---|
| `transform` | rotate/flip/reset round trips, mirror winding, pivots, and where texture lock puts a texture |
| `structures` | the four generators: winding at their defaults, schema ranges, regenerate as a no-op |
| `cutting` | clip, carve, hollow, inset and arrays, measured by volume rather than by what they report |
| `entities` | naming, duplication, deletion, and what the I/O wired to an entity does when its name moves |
| `appearance` | material slots, UV params, projections and paint layers at their edges |
| `persistence` | `capture_state`/`restore_state` round trips, repeated restores, and malformed state |
| `housekeeping` | visgroup and group names, the cordon, and the paint layer list |
| `terrain` | heightmap scale and region settings at their edges, and the playtest/glTF exports |

Two of them verify independently rather than taking a subsystem's word for it,
which is where the findings that held up came from:

- `transform` reads each face's own triangulated UVs and solves for the world
  direction along which U increases, so "the texture stayed put" is measured
  rather than assumed. That is what caught #333.
- `cutting` computes brush volume by the divergence theorem over the triangles,
  so a clip, a carve and a hollow are checked against the material they should
  have left behind rather than against the count of brushes they report.

Everything the sweep found is filed as #333 through #352 and recorded in the
scenarios as `known(<issue>, ...)`, so a full run is green today and goes red
again if any of them comes back after a fix. A clean run now looks like:

```
  geometry       clean      transform      clean
  round-trip     clean      structures     clean
  map-io         clean      cutting        clean
  displacement   clean      entities       clean
  limits         clean      appearance     clean
  chaos          clean      persistence    clean
  cost           clean      housekeeping   clean
                            terrain        clean
```

Two things the scenarios record as notes rather than report: `MapIO` strips
commas from I/O fields and escapes quotes inside values. Both are deliberate and
documented in `map_io.gd`, so they are kept visible without going red.

No production code is touched.