### PR TITLE
Extend the vibe base class by path, the way the other scenarios do

### DIFF
--- a/tools/vibe/scenarios/appearance.gd
+++ b/tools/vibe/scenarios/appearance.gd
@@ -1,5 +1,5 @@
 @tool
-extends HFVibeScenario
+extends "res://tools/vibe/hf_vibe_scenario.gd"
 
 ## What a face looks like: its material slot, its UV transform, its projection
 ## and the surface paint layers stacked on it.

--- a/tools/vibe/scenarios/cutting.gd
+++ b/tools/vibe/scenarios/cutting.gd
@@ -1,5 +1,5 @@
 @tool
-extends HFVibeScenario
+extends "res://tools/vibe/hf_vibe_scenario.gd"
 
 ## The operations that take a brush apart: clip, carve, hollow, inset and the
 ## duplicate arrays that copy the result.

--- a/tools/vibe/scenarios/entities.gd
+++ b/tools/vibe/scenarios/entities.gd
@@ -1,5 +1,5 @@
 @tool
-extends HFVibeScenario
+extends "res://tools/vibe/hf_vibe_scenario.gd"
 
 ## Point entities, brush entities and the I/O wiring between them.
 ##

--- a/tools/vibe/scenarios/housekeeping.gd
+++ b/tools/vibe/scenarios/housekeeping.gd
@@ -1,5 +1,5 @@
 @tool
-extends HFVibeScenario
+extends "res://tools/vibe/hf_vibe_scenario.gd"
 
 ## Visgroups, groups, the cordon and paint layers -- the bookkeeping a mapper
 ## builds up around the geometry rather than in it.

--- a/tools/vibe/scenarios/persistence.gd
+++ b/tools/vibe/scenarios/persistence.gd
@@ -1,5 +1,5 @@
 @tool
-extends HFVibeScenario
+extends "res://tools/vibe/hf_vibe_scenario.gd"
 
 ## Capture and restore, which is what undo replays and what every whole-level
 ## operation leans on.
@@ -9,8 +9,6 @@ extends HFVibeScenario
 ## level indistinguishable from the one it came off. When it is not, the loss is
 ## silent -- the operation reports success and the level is just poorer, which
 ## is the shape every round-trip defect in this project has had.
-
-const HFGeneratorSystem = preload("res://addons/hammerforge/systems/hf_generator_system.gd")
 
 
 func id() -> String:
@@ -153,6 +151,12 @@ func _junk_state() -> void:
 	}
 	for label in cases:
 		var root: Node3D = await fresh_root()
+		# Furnished first, deliberately. The cost of a malformed state is not
+		# that it fails to load -- it is that the level is cleared before the
+		# state it was handed is looked at, so a bad file takes the good level
+		# with it.
+		_furnish(root)
+		await frame()
 		var before_count: int = root.get_live_brush_count()
 		root.restore_state(cases[label])
 		await frame()
@@ -174,6 +178,12 @@ func _junk_state() -> void:
 					% [label, junk_materials]
 				),
 				"get_materials() hands those back to every caller that then reads a Material off them"
+			)
+		if before_count > 0 and root.get_live_brush_count() < before_count:
+			known(
+				347,
+				"restore_state with %s emptied a level it could not replace" % label,
+				"%d brushes before, %d after" % [before_count, root.get_live_brush_count()]
 			)
 		for problem in HFVibe.check_invariants(root):
 			known(348, "restore_state with %s broke an invariant" % label, problem)

--- a/tools/vibe/scenarios/structures.gd
+++ b/tools/vibe/scenarios/structures.gd
@@ -1,5 +1,5 @@
 @tool
-extends HFVibeScenario
+extends "res://tools/vibe/hf_vibe_scenario.gd"
 
 ## The four live generators -- arch, stairs, spiral stairs, dome -- driven
 ## through `LevelRoot`, which is how the Structure dock drives them.
@@ -8,9 +8,6 @@ extends HFVibeScenario
 ## Does a setting outside the schema's own range get refused, or built? And is
 ## regenerating with the settings a structure already has a no-op, or does it
 ## move the structure?
-
-const HFGeneratorSchema = preload("res://addons/hammerforge/hf_generator_schema.gd")
-const HFGeneratorSystem = preload("res://addons/hammerforge/systems/hf_generator_system.gd")
 
 
 func id() -> String:

--- a/tools/vibe/scenarios/terrain.gd
+++ b/tools/vibe/scenarios/terrain.gd
@@ -1,5 +1,5 @@
 @tool
-extends HFVibeScenario
+extends "res://tools/vibe/hf_vibe_scenario.gd"
 
 ## The heightmap layer and the region streaming settings around it, plus the two
 ## exports that take a finished level out of the editor.

--- a/tools/vibe/scenarios/transform.gd
+++ b/tools/vibe/scenarios/transform.gd
@@ -1,5 +1,5 @@
 @tool
-extends HFVibeScenario
+extends "res://tools/vibe/hf_vibe_scenario.gd"
 
 ## Rotate, flip and reset-rotation, driven the way the transform commands drive
 ## them: always through `LevelRoot`'s five-argument delegates, because those are


### PR DESCRIPTION
Follow-up to #353. The eight scenarios it added did not run on a clean checkout.

They were written as:

```gdscript
extends HFVibeScenario
```

but `HFVibeScenario` is not a registered class name — `tools/vibe/hf_vibe_scenario.gd`
has no `class_name`, and the seven scenarios written before it all extend it by
path. They loaded during the session only because a stale
`.godot/global_script_class_cache.cfg` still held the name. Rebuilding the cache
and running the sweep on merged `main`:

```
SCRIPT ERROR: Parse Error: Could not find base class "HFVibeScenario".
could not load res://tools/vibe/scenarios/transform.gd -- see the errors above
... (all eight)
available: ["geometry", "round-trip", "map-io", "displacement", "limits", "chaos", "cost"]
```

CI did not catch it: the workflow runs gdformat, gdlint and GUT, and the vibe
sweep is not one of them.

Two of the eight also declared

```gdscript
const HFGeneratorSystem = preload("res://addons/hammerforge/systems/hf_generator_system.gd")
const HFGeneratorSchema = preload("res://addons/hammerforge/hf_generator_schema.gd")
```

for scripts that already carry those exact `class_name`s. A const shadowing a
registered global class is its own compile failure — the same trap `HFLevelIO`
set. Both preloads are dropped; the global names work directly.

While in `persistence.gd`: `_junk_state` now furnishes the level before handing
`restore_state` a malformed dictionary, which is what makes #347's cost
visible rather than theoretical.

```
KNOWN #347  restore_state with entities is a dictionary emptied a level it could not replace -- 10 brushes before, 0 after
KNOWN #347  restore_state with materials holds junk emptied a level it could not replace -- 10 brushes before, 0 after
```

A full sweep is clean again on all fifteen scenarios, with #333 through #352
all still reproducing as `KNOWN`.