### PR TITLE
Derive texture lock from the face, and refuse a transform that is not a number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Fixed
+- **Texture lock tipped the texture on every wall of a rotated brush** (#333).
+  The counter-rotation was applied to every face at the same angle whatever axis
+  the brush turned about, so a yaw — the most common thing a mapper does — left
+  four faces of a box a quarter turn out and the mapper fixing UVs by hand
+  afterwards. It is now derived from the face's own projection: a turn that keeps
+  the projection plane where it is folds into `uv_rotation`, with the sign taken
+  from the projection rather than assumed (PLANAR_Z reads `(x, y)` and PLANAR_Y
+  reads `(x, z)`, so the two go opposite ways round), and a half turn that puts
+  the plane the other way up folds into the V scale. A turn that swings a face
+  out from under its own projection cannot be written as a UV rotation at all, so
+  that face is left alone and its texture travels with the brush upright, instead
+  of being tipped.
+- **A UV rotation was never wrapped, so a round trip was not a round trip**
+  (#334). Four 90-degree turns left every face at `-2 pi` rather than `0`, so a
+  level saved afterwards differed from the same level saved before, the exported
+  `.map` said `-360` where it meant `0`, and a long session walked the angle off
+  to where a float32 has no fraction left. `adjust_uvs_for_rotation()` and
+  `set_face_uv_params()` both wrap into `[-pi, pi)` now.
+- **Rotate and flip wrote a NaN transform onto a brush** (#335). Neither checked
+  the angle or the pivot it was handed, so a non-finite value from an undo
+  replay, a numeric field or a script went into the basis and the origin and
+  stayed there — poisoning the brush AABB, the level AABB, the bake and the
+  saved file, with no editor action able to recover it. Both refuse a non-finite
+  argument and log, the way `can_hollow_brush()` already does. An axis index
+  outside 0-2 is refused too rather than falling through to Z, which used to
+  turn the selection about an axis the caller never asked for.
 - **Five brush primitives were built inside out** (#313). `PRISM_TRI`,
   `PRISM_PENT`, `OCTAHEDRON`, `DODECAHEDRON` and `ICOSAHEDRON` came out of
   `create_brush_from_info()` with every face normal pointing at the brush

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,437 tests across 179 test scripts (3,430 passing plus seven intentional no-assert safety tests; 17,451 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,450 tests across 179 test scripts (3,443 passing plus seven intentional no-assert safety tests; 17,495 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,437 tests** across **179 scripts** (**3,430 passing** plus seven intentional no-assert safety tests; **17,451 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,450 tests** across **179 scripts** (**3,443 passing** plus seven intentional no-assert safety tests; **17,495 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3430%20passing-brightgreen" alt="3430 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3443%20passing-brightgreen" alt="3443 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,437 tests across 179 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,450 tests across 179 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/face_data.gd
+++ b/addons/hammerforge/face_data.gd
@@ -3,6 +3,11 @@ extends Resource
 class_name FaceData
 
 enum UVProjection { PLANAR_X, PLANAR_Y, PLANAR_Z, BOX_UV, CYLINDRICAL }
+
+## How far a rotated projection plane may lean off a local axis and still be
+## treated as that axis. Rotations arrive as exact quarter turns or as a turn
+## about the projection axis itself, so anything past this is a genuine tilt.
+const UV_AXIS_EPSILON := 0.0001
 enum PaintBlend { OVERLAY, MULTIPLY, ADD }
 
 
@@ -90,11 +95,70 @@ func adjust_uvs_for_transform(pos_delta: Vector3, size_ratio: Vector3) -> void:
 		uv_scale *= inv_size
 
 
-func adjust_uvs_for_rotation(angle_rad: float) -> void:
+## The two local directions a planar projection reads, in (u, v) order.
+##
+## These are the axes `_project_uvs_for_vertices()` samples, written out so the
+## texture-lock maths can work with the projection rather than guess at it.
+## Note the handedness is not the same for all three: PLANAR_Z reads (x, y) and
+## PLANAR_Y reads (x, z), so a turn about Y moves U the opposite way round to a
+## turn about Z. That is the sign that used to be assumed.
+static func projection_axes(projection: int) -> Array:
+	match projection:
+		UVProjection.PLANAR_X:
+			return [Vector3.BACK, Vector3.UP]
+		UVProjection.PLANAR_Y:
+			return [Vector3.RIGHT, Vector3.BACK]
+		_:
+			return [Vector3.RIGHT, Vector3.UP]
+
+
+## Keep this face's texture where it is in the world while the brush turns.
+##
+## `local_rot` is the brush's rotation expressed in the brush's own space: a
+## local point `v` ends up where `local_rot * v` used to be, so reading the old
+## projection at `local_rot * v` is exactly "the texture did not move".
+##
+## That only stays a projection of the same kind when the turn keeps the
+## projection plane where it is — a turn about the projection axis, at any angle.
+## Then the whole difference is a turn inside the UV plane, which `uv_rotation`
+## can hold. A turn about any other axis swings the face out from under its own
+## projection, and nothing the stored fields can say expresses that, so the face
+## is left alone and its texture travels with the brush rather than being tipped
+## on its side.
+##
+## Returns true if the UVs were adjusted.
+func adjust_uvs_for_rotation(local_rot: Basis) -> bool:
 	if uv_projection == UVProjection.CYLINDRICAL:
-		return
-	uv_rotation -= angle_rad
+		return false
+	var effective := uv_projection
+	if effective == UVProjection.BOX_UV:
+		effective = _box_projection_axis()
+	var axes: Array = projection_axes(effective)
+	# The composed map reads the old projection axes pulled back through the
+	# turn, so these two vectors span the plane the projection would have to be.
+	var inv := local_rot.inverse()
+	var f_u: Vector3 = inv * (axes[0] as Vector3)
+	var f_v: Vector3 = inv * (axes[1] as Vector3)
+	var kept: Vector3 = (axes[0] as Vector3).cross(axes[1] as Vector3)
+	if absf(f_u.cross(f_v).dot(kept)) < 1.0 - UV_AXIS_EPSILON:
+		return false
+	# The change of basis from the projection's own axes to the pulled-back ones.
+	# It is orthogonal, so it is a turn in the UV plane, possibly mirrored.
+	var a00 := f_u.dot(axes[0])
+	var a01 := f_u.dot(axes[1])
+	var a10 := f_v.dot(axes[0])
+	var a11 := f_v.dot(axes[1])
+	var turn := atan2(a10, a00)
+	if a00 * a11 - a01 * a10 >= 0.0:
+		uv_rotation = wrapf(uv_rotation + turn, -PI, PI)
+	else:
+		# The turn put the plane back the other way up. `diag(sx, sy) * rot(r) *
+		# diag(1, -1)` is the same map as `diag(sx, -sy) * rot(-r)`, which the
+		# stored fields can hold, so the flip folds into the V scale.
+		uv_rotation = wrapf(-(uv_rotation + turn), -PI, PI)
+		uv_scale.y = -uv_scale.y
 	custom_uvs = PackedVector2Array()
+	return true
 
 
 func triangulate() -> Dictionary:

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -1670,7 +1670,9 @@ func set_face_uv_params(
 	var before := face.to_dict()
 	face.uv_scale = scale
 	face.uv_offset = offset
-	face.uv_rotation = rotation
+	# Stored wrapped so two faces that look the same compare the same, and so a
+	# run of turns cannot walk the angle off to where a float has no fraction left.
+	face.uv_rotation = wrapf(rotation, -PI, PI)
 	face.custom_uvs = PackedVector2Array()
 	face.ensure_custom_uvs()
 	draft.rebuild_preview()

--- a/addons/hammerforge/systems/hf_transform_system.gd
+++ b/addons/hammerforge/systems/hf_transform_system.gd
@@ -60,6 +60,24 @@ static func rotation_basis(axis_index: int, angle_rad: float) -> Basis:
 	return Basis(axis_vector(axis_index), angle_rad)
 
 
+## Whether an axis index names a world axis. `axis_vector()` falls through to Z,
+## so a caller that got its index wrong would otherwise turn the selection about
+## an axis it did not ask for.
+static func is_valid_axis(axis_index: int) -> bool:
+	return axis_index >= 0 and axis_index <= 2
+
+
+## A world rotation written in the object's own space.
+##
+## Texture lock works on local face data, so it needs the turn as the object sees
+## it: after the move, the local point `v` sits where `local_rotation * v` used
+## to sit. The basis is orthonormalised first because only its rotation part
+## takes part in that; any scale on the node is a separate thing.
+static func local_rotation(basis: Basis, rot: Basis) -> Basis:
+	var orientation := basis.orthonormalized()
+	return orientation.inverse() * rot * orientation
+
+
 ## Linear reflection through the plane whose normal is the given axis.
 static func reflection_basis(axis_index: int) -> Basis:
 	var scale := Vector3.ONE
@@ -266,6 +284,12 @@ func can_flip_brushes(brush_ids: Array) -> HFOpResult:
 func rotate(
 	brush_ids: Array, entity_paths: Array, axis_index: int, angle_rad: float, pivot: Vector3
 ) -> int:
+	if not is_valid_axis(axis_index):
+		HFLog.warn("HFTransformSystem: rotate needs an axis of 0, 1 or 2")
+		return 0
+	if not is_finite(angle_rad) or not pivot.is_finite():
+		HFLog.warn("HFTransformSystem: rotate needs a finite angle and pivot")
+		return 0
 	if is_zero_approx(angle_rad):
 		return 0
 	var rot := rotation_basis(axis_index, angle_rad)
@@ -276,9 +300,10 @@ func rotate(
 		var draft := _brush_at_id(str(brush_id))
 		if draft == null:
 			continue
+		var local_rot := local_rotation(draft.global_transform.basis, rot)
 		draft.global_transform = rotated_transform(draft.global_transform, rot, pivot)
 		if lock_textures:
-			adjust_face_uvs_for_rotation(draft, angle_rad)
+			adjust_face_uvs_for_rotation(draft, local_rot)
 			draft.rebuild_preview()
 		_tag_dirty(draft)
 		changed += 1
@@ -298,6 +323,12 @@ func rotate(
 ## `can_flip_brushes()` first to report that to the user. Returns the number
 ## changed.
 func flip(brush_ids: Array, entity_paths: Array, axis_index: int, pivot: Vector3) -> int:
+	if not is_valid_axis(axis_index):
+		HFLog.warn("HFTransformSystem: flip needs an axis of 0, 1 or 2")
+		return 0
+	if not pivot.is_finite():
+		HFLog.warn("HFTransformSystem: flip needs a finite pivot")
+		return 0
 	var changed := 0
 	for brush_id in brush_ids:
 		var draft := _brush_at_id(str(brush_id))
@@ -506,11 +537,11 @@ func selection_bounds(brush_ids: Array, entity_paths: Array) -> AABB:
 
 ## Compensate every face's UV rotation so the texture stays put in world space,
 ## matching what `texture_lock` already means for moving and resizing a brush.
-static func adjust_face_uvs_for_rotation(draft: DraftBrush, angle_rad: float) -> void:
+static func adjust_face_uvs_for_rotation(draft: DraftBrush, local_rot: Basis) -> void:
 	for face in draft.faces:
 		if face == null:
 			continue
-		face.adjust_uvs_for_rotation(angle_rad)
+		face.adjust_uvs_for_rotation(local_rot)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/HammerForge_Editor_Smoke_Checklist.md
+++ b/docs/HammerForge_Editor_Smoke_Checklist.md
@@ -250,7 +250,7 @@ It writes one PNG per tab under `user://console_preview/`.
 - Press **Shift+R** the same number of times. Confirm it returns to where it started.
 - Set the axis lock to **X**, then press **R**. Confirm it now pitches instead of yawing. Clear the lock.
 - Change **Pivot** to **World Origin** and press **R**. Confirm the brush orbits the origin rather than turning in place.
-- With **Texture Lock** on, rotate a textured brush and confirm the texture stays put in world space. Turn Texture Lock off, rotate again, and confirm the texture now turns with the brush.
+- With **Texture Lock** on, yaw a textured box 90 degrees. Confirm the top and bottom keep their texture where it was in the world, and that the four walls carry theirs around upright rather than tipped on their side. Yaw four times and confirm the textures are back exactly as they started.
 - Bake the rotated brush. Confirm the geometry is solid and textured from outside, not inside-out.
 - Press **Shift+M** to flip. Confirm the brush mirrors across X and still renders from outside. Press **Shift+M** again and confirm it returns exactly.
 - Repeat the flip on a **wedge**. Confirm the mirrored wedge slopes the other way, still renders correctly, and its shape reads as Custom in the dock.

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -489,8 +489,13 @@ it started, however lopsided the selection is.
 **The step.** Set it in Selection Tools. 15° by default; 45° and 90° are the
 other two you will reach for.
 
-**Texture Lock applies.** With it on, textures stay put in world space as the
-brush turns underneath them. Turn it off if you want the texture to ride along.
+**Texture Lock applies.** With it on, a face that turns in its own plane keeps
+its texture where it is in the world — the top and bottom of a box under a yaw,
+for instance. A face that swings around instead, like a wall under that same
+yaw, carries its texture with it upright; a face projection cannot express a
+world-locked texture on a face that has moved out from under it, and tipping the
+texture on its side is worse than carrying it. Turn Texture Lock off and every
+face carries its texture along.
 
 ### After you rotate
 
@@ -1455,7 +1460,8 @@ When Texture Lock is enabled, moving or resizing a brush automatically adjusts i
 Notes:
 - Works with PLANAR_X, PLANAR_Y, PLANAR_Z, and BOX_UV projections.
 - CYLINDRICAL projection is not compensated (complex; future enhancement).
-- Applies to HammerForge move, nudge, floor/ceiling, and resize actions. Godot's native Node3D transform widget leaves the brush's face UV resources unchanged so native undo/redo remains truthful.
+- Applies to HammerForge move, nudge, floor/ceiling, resize and rotate actions. Godot's native Node3D transform widget leaves the brush's face UV resources unchanged so native undo/redo remains truthful.
+- On a rotation, a face is compensated when the turn keeps its projection plane where it is. A face that turns out from under its own projection is left alone, so its texture travels with the brush rather than tipping.
 - Persists in `.hflevel` settings.
 
 ## Cordon (Partial Bake)

--- a/docs/features.md
+++ b/docs/features.md
@@ -30,7 +30,7 @@ Two-stage CAD drawing: drag base, click height. Brushes support **Add** and **Su
 - **Clip to Face Plane** (Shift+Alt+X) -- cut along the plane of a selected face, which is the cheapest route to an angled wall or a chamfered corner
 - **Carve** (Ctrl+Shift+R) -- boolean-subtract one brush from all intersecting brushes, using the carver's real face planes, so the carver can be rotated or a cylinder
 - **Merge** (Ctrl+Shift+M) -- combine 2+ selected brushes into one, preserving per-brush materials and full transforms (rotation/scale)
-- **Rotate** (R / Shift+R) -- turn the selection by a configurable step about the locked axis, or Y. Texture Lock keeps the texture pinned in world space
+- **Rotate** (R / Shift+R) -- turn the selection by a configurable step about the locked axis, or Y. Texture Lock pins the texture in world space on faces that turn in their own plane, and carries it along upright on faces that swing around
 - **Flip** (Shift+M) -- mirror the selection across the locked axis, or X. Winding is preserved, so a mirrored brush never bakes inside out
 - **Reset Rotation** (Alt+R) -- clear a rotation and keep the geometry. A quarter turn folds into the brush size losslessly, and any scale set with Godot's own gizmo is left alone, because that is not rotation
 - **Arrays** -- Linear, Radial (copies around an axis) and Grid (a 3D lattice) layouts in the Duplicate Array section. Select any piece of one to load it back: Create becomes **Update Array**, with **Detach** beside it, and Update says how many copies it would move back before it moves them

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,437 tests across 179 scripts**: **3,430 passing tests**, seven intentional no-assert safety tests, and **17,451 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,450 tests across 179 scripts**: **3,443 passing tests**, seven intentional no-assert safety tests, and **17,495 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_texture_lock.gd
+++ b/tests/test_texture_lock.gd
@@ -226,3 +226,139 @@ func test_rotation_does_not_disturb_size_compensation():
 	face.adjust_uvs_for_transform(Vector3.ZERO, Vector3(2.0, 0.5, 1.0))
 	assert_almost_eq(face.uv_scale.x, 0.5, 0.001)
 	assert_almost_eq(face.uv_scale.y, 2.0, 0.001)
+
+
+# ===========================================================================
+# adjust_uvs_for_rotation — texture lock under a brush turn (#333, #334)
+# ===========================================================================
+
+
+func _rot(axis: Vector3, degrees: float) -> Basis:
+	return Basis(axis, deg_to_rad(degrees))
+
+
+func test_a_turn_across_the_projection_leaves_the_face_alone():
+	# A yaw swings a wall around rather than turning it in its own plane. The
+	# old code subtracted the yaw anyway, which tipped the texture on its side.
+	var face = FaceData.new()
+	face.uv_projection = FaceData.UVProjection.PLANAR_Z
+	face.normal = Vector3.BACK
+	assert_false(face.adjust_uvs_for_rotation(_rot(Vector3.UP, 90.0)))
+	assert_eq(face.uv_projection, FaceData.UVProjection.PLANAR_Z)
+	assert_almost_eq(face.uv_rotation, 0.0, 0.0001)
+
+
+func test_a_half_turn_across_the_plane_mirrors_v_rather_than_tipping():
+	# 180 degrees about X keeps a PLANAR_Z face's plane but puts it the other
+	# way up, which the V scale can hold.
+	var face = FaceData.new()
+	face.uv_projection = FaceData.UVProjection.PLANAR_Z
+	face.normal = Vector3.BACK
+	assert_true(face.adjust_uvs_for_rotation(_rot(Vector3.RIGHT, 180.0)))
+	assert_eq(face.uv_projection, FaceData.UVProjection.PLANAR_Z)
+	assert_almost_eq(face.uv_scale.y, -1.0, 0.0001)
+	assert_almost_eq(face.uv_scale.x, 1.0, 0.0001)
+
+
+func test_turn_about_the_projection_axis_keeps_the_projection():
+	# PLANAR_Y reads (x, z) and PLANAR_Z reads (x, y), so the two counter-turns
+	# go opposite ways. That sign used to be assumed to be the same for both.
+	var y_face = FaceData.new()
+	y_face.uv_projection = FaceData.UVProjection.PLANAR_Y
+	y_face.normal = Vector3.UP
+	assert_true(y_face.adjust_uvs_for_rotation(_rot(Vector3.UP, 30.0)))
+	assert_eq(y_face.uv_projection, FaceData.UVProjection.PLANAR_Y)
+	assert_almost_eq(y_face.uv_rotation, deg_to_rad(-30.0), 0.0001)
+
+	var z_face = FaceData.new()
+	z_face.uv_projection = FaceData.UVProjection.PLANAR_Z
+	z_face.normal = Vector3.BACK
+	assert_true(z_face.adjust_uvs_for_rotation(_rot(Vector3.BACK, 30.0)))
+	assert_eq(z_face.uv_projection, FaceData.UVProjection.PLANAR_Z)
+	assert_almost_eq(z_face.uv_rotation, deg_to_rad(30.0), 0.0001)
+
+
+func test_turn_that_no_projection_can_express_leaves_the_face_alone():
+	var face = FaceData.new()
+	face.uv_projection = FaceData.UVProjection.PLANAR_Z
+	face.normal = Vector3.BACK
+	face.uv_rotation = 0.25
+	face.uv_scale = Vector2(2.0, 3.0)
+	assert_false(face.adjust_uvs_for_rotation(_rot(Vector3.UP, 37.0)), "not expressible")
+	assert_eq(face.uv_projection, FaceData.UVProjection.PLANAR_Z)
+	assert_almost_eq(face.uv_rotation, 0.25, 0.0001)
+	assert_almost_eq(face.uv_scale.y, 3.0, 0.0001)
+
+
+func test_cylindrical_is_still_left_alone():
+	var face = FaceData.new()
+	face.uv_projection = FaceData.UVProjection.CYLINDRICAL
+	face.normal = Vector3.UP
+	assert_false(face.adjust_uvs_for_rotation(_rot(Vector3.UP, 90.0)))
+	assert_eq(face.uv_projection, FaceData.UVProjection.CYLINDRICAL)
+
+
+func test_uv_rotation_is_wrapped_into_a_turn():
+	var face = FaceData.new()
+	face.uv_projection = FaceData.UVProjection.PLANAR_Y
+	face.normal = Vector3.UP
+	for _i in 4:
+		face.adjust_uvs_for_rotation(_rot(Vector3.UP, 90.0))
+	assert_almost_eq(face.uv_rotation, 0.0, 0.0001, "four quarter turns is no turn")
+
+
+## The texture did not move: where U increases in the world is where it did.
+##
+## Solved from the face's own projected UVs rather than from the stored fields,
+## so a change that keeps the fields tidy and the texture wrong still fails.
+func _world_u_direction(face, basis: Basis) -> Vector3:
+	face.custom_uvs = PackedVector2Array()
+	face.ensure_custom_uvs()
+	var verts: PackedVector3Array = face.local_verts
+	var uvs: PackedVector2Array = face.custom_uvs
+	if verts.size() < 3:
+		return Vector3.ZERO
+	var e1: Vector3 = verts[1] - verts[0]
+	var e2: Vector3 = verts[2] - verts[0]
+	var n := e1.cross(e2)
+	if n.length() < 0.000001:
+		return Vector3.ZERO
+	var m := Basis(Vector3(e1.x, e2.x, n.x), Vector3(e1.y, e2.y, n.y), Vector3(e1.z, e2.z, n.z))
+	var rhs := Vector3(uvs[1].x - uvs[0].x, uvs[2].x - uvs[0].x, 0.0)
+	var grad := m.inverse() * rhs
+	if grad.length() < 0.000001:
+		return Vector3.ZERO
+	return (basis * grad).normalized()
+
+
+func test_a_yaw_does_not_tip_any_face_texture():
+	var brush: DraftBrush = load("res://addons/hammerforge/brush_instance.gd").new()
+	brush.shape = 0
+	brush.size = Vector3(128, 64, 32)
+	add_child_autoqfree(brush)
+	brush.rebuild_preview()
+	for face in brush.get_faces():
+		face.uv_projection = FaceData.UVProjection.BOX_UV
+		face.custom_uvs = PackedVector2Array()
+
+	var before: Array = []
+	for face in brush.get_faces():
+		before.append(_world_u_direction(face, Basis.IDENTITY))
+
+	var turn := Basis(Vector3.UP, deg_to_rad(90.0))
+	for face in brush.get_faces():
+		face.adjust_uvs_for_rotation(turn)
+
+	for i in brush.get_faces().size():
+		var face = brush.get_faces()[i]
+		var was: Vector3 = before[i]
+		if was == Vector3.ZERO:
+			continue
+		var now: Vector3 = _world_u_direction(face, turn)
+		if absf(face.normal.dot(Vector3.UP)) > 0.9:
+			# Top and bottom turn in their own plane, so the texture stays put.
+			assert_almost_eq(now.dot(was), 1.0, 0.0001, "face %d should be locked" % i)
+		else:
+			# A wall swings around. Its texture goes with it, upright as it was.
+			var carried := turn * was
+			assert_almost_eq(now.dot(carried), 1.0, 0.0001, "face %d was tipped" % i)

--- a/tests/test_transform_integration.gd
+++ b/tests/test_transform_integration.gd
@@ -523,10 +523,12 @@ func test_mirror_face_tolerates_a_null_entry():
 	pass_test("mirroring a face list with a hole in it must not crash")
 
 
-func test_an_out_of_range_axis_falls_back_to_z():
+func test_an_out_of_range_axis_is_refused():
+	# It used to fall through to Z, so a caller with the wrong index mirrored the
+	# selection about an axis it never asked for.
 	var b := _make_brush(Vector3(40, 0, 10), Vector3(32, 32, 32), "z1")
-	sys.flip(["z1"], [], 99, Vector3.ZERO)
-	assert_almost_eq(b.global_position.z, -10.0, 0.001)
+	assert_eq(sys.flip(["z1"], [], 99, Vector3.ZERO), 0)
+	assert_almost_eq(b.global_position.z, 10.0, 0.001)
 	assert_almost_eq(b.global_position.x, 40.0, 0.001)
 
 

--- a/tests/test_transform_system.gd
+++ b/tests/test_transform_system.gd
@@ -308,7 +308,7 @@ func test_rotate_reports_changed_count():
 
 func test_rotate_by_zero_is_a_no_op():
 	var b := _make_brush(Vector3(10, 0, 0), Vector3(32, 32, 32), "r1")
-	var before := b.global_transform
+	var before: Transform3D = b.global_transform
 	var changed: int = sys.rotate(["r1"], [], 1, 0.0, Vector3.ZERO)
 	assert_eq(changed, 0)
 	assert_true(b.global_transform.is_equal_approx(before))
@@ -346,13 +346,26 @@ func test_rotate_ignores_entities_without_an_angle_key():
 # ===========================================================================
 
 
-func test_texture_lock_on_compensates_uv_rotation():
+func test_texture_lock_on_compensates_a_face_that_turns_in_its_own_plane():
 	root.texture_lock = true
 	var b := _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "t1")
 	var face = b.get_faces()[0]
+	face.uv_projection = FaceDataScript.UVProjection.PLANAR_Y
 	face.uv_rotation = 0.0
 	sys.rotate(["t1"], [], 1, deg_to_rad(90.0), Vector3.ZERO)
 	assert_almost_eq(face.uv_rotation, -deg_to_rad(90.0), 0.001)
+
+
+func test_texture_lock_leaves_a_face_the_turn_swings_around():
+	# A yaw does not turn a PLANAR_Z face in its own plane, so subtracting the
+	# yaw from its UV rotation only tipped the texture on its side.
+	root.texture_lock = true
+	var b := _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "t2")
+	var face = b.get_faces()[0]
+	face.uv_projection = FaceDataScript.UVProjection.PLANAR_Z
+	face.uv_rotation = 0.0
+	sys.rotate(["t2"], [], 1, deg_to_rad(90.0), Vector3.ZERO)
+	assert_almost_eq(face.uv_rotation, 0.0, 0.001)
 
 
 func test_texture_lock_off_leaves_uv_rotation():
@@ -397,7 +410,7 @@ func test_flip_mirrors_every_world_vertex():
 
 func test_flip_twice_restores_a_box_exactly():
 	var b := _make_brush(Vector3(48, 12, -7), Vector3(32, 16, 8), "f1")
-	var before := b.global_transform
+	var before: Transform3D = b.global_transform
 	sys.flip(["f1"], [], 0, Vector3.ZERO)
 	sys.flip(["f1"], [], 0, Vector3.ZERO)
 	assert_true(b.global_transform.is_equal_approx(before))
@@ -406,7 +419,7 @@ func test_flip_twice_restores_a_box_exactly():
 func test_flip_twice_restores_a_rotated_brush_exactly():
 	var b := _make_brush(Vector3(48, 0, 0), Vector3(32, 16, 8), "f1")
 	sys.rotate(["f1"], [], 1, deg_to_rad(30.0), Vector3.ZERO)
-	var before := b.global_transform
+	var before: Transform3D = b.global_transform
 	sys.flip(["f1"], [], 2, Vector3(10, 0, 0))
 	sys.flip(["f1"], [], 2, Vector3(10, 0, 0))
 	assert_true(b.global_transform.is_equal_approx(before))
@@ -622,7 +635,7 @@ func test_can_flip_refuses_a_displaced_brush():
 func test_flip_skips_a_displaced_brush():
 	var b := _make_brush(Vector3(48, 0, 0), Vector3(32, 32, 32), "f1")
 	b.get_faces()[0].displacement = Resource.new()
-	var before := b.global_transform
+	var before: Transform3D = b.global_transform
 	assert_eq(sys.flip(["f1"], [], 0, Vector3.ZERO), 0)
 	assert_true(b.global_transform.is_equal_approx(before))
 
@@ -809,3 +822,50 @@ func test_selection_bounds_grows_when_a_brush_is_turned():
 func test_selection_bounds_on_empty_selection_is_degenerate():
 	var bounds: AABB = sys.selection_bounds([], [])
 	assert_true(bounds.size.is_equal_approx(Vector3.ZERO))
+
+
+# ===========================================================================
+# Nonsense inputs (#335) and rotation round trips (#334)
+# ===========================================================================
+
+
+func test_rotate_refuses_a_non_finite_angle():
+	var b = _make_brush(Vector3.ZERO)
+	assert_eq(sys.rotate([b.brush_id], [], 1, NAN, Vector3.ZERO), 0, "NAN angle")
+	assert_eq(sys.rotate([b.brush_id], [], 1, INF, Vector3.ZERO), 0, "INF angle")
+	assert_true(b.global_transform.is_finite(), "brush transform stays finite")
+
+
+func test_rotate_refuses_a_non_finite_pivot():
+	var b = _make_brush(Vector3.ZERO)
+	var pivot := Vector3(NAN, 0, 0)
+	assert_eq(sys.rotate([b.brush_id], [], 1, deg_to_rad(90.0), pivot), 0)
+	assert_true(b.global_transform.is_finite())
+
+
+func test_flip_refuses_a_non_finite_pivot():
+	var b = _make_brush(Vector3.ZERO)
+	assert_eq(sys.flip([b.brush_id], [], 0, Vector3(INF, 0, 0)), 0)
+	assert_true(b.global_transform.is_finite())
+
+
+func test_rotate_and_flip_refuse_an_axis_that_is_not_an_axis():
+	# `axis_vector()` falls through to Z, so an out of range index used to turn
+	# the selection about an axis nobody asked for.
+	var b = _make_brush(Vector3.ZERO)
+	var before: Transform3D = b.global_transform
+	assert_eq(sys.rotate([b.brush_id], [], 9, deg_to_rad(90.0), Vector3.ZERO), 0)
+	assert_eq(sys.flip([b.brush_id], [], -1, Vector3.ZERO), 0)
+	assert_eq(b.global_transform, before, "brush untouched")
+
+
+func test_four_quarter_turns_leave_the_faces_as_they_were():
+	root.texture_lock = true
+	var b = _make_brush(Vector3.ZERO, Vector3(128, 64, 32))
+	var before: Array = []
+	for face in b.get_faces():
+		before.append(face.to_dict())
+	for _i in 4:
+		sys.rotate([b.brush_id], [], 1, deg_to_rad(90.0), Vector3.ZERO)
+	for i in b.get_faces().size():
+		assert_eq(b.get_faces()[i].to_dict(), before[i], "face %d drifted" % i)


### PR DESCRIPTION
Three defects in the rotate path, one branch.

Fixes #333 — texture lock counter-rotated every face by the brush angle whatever
axis the brush turned about, so a yaw tipped the texture on all four walls of a
box. It is now derived from the face's own projection, with the sign taken from
the projection rather than assumed, and a face the turn swings out from under
its projection is left alone instead of tipped.

Fixes #334 — the UV rotation is wrapped into a turn on write, so four quarter
turns leave a brush exactly as it was rather than at -2 pi.

Fixes #335 — rotate and flip refuse a non-finite angle or pivot, and an axis
index that is not an axis, rather than writing a NaN transform that no editor
action can undo.

Two existing tests pinned behaviour these issues call the bug and were rewritten
to say what the code now does: the texture lock compensation test, and the flip
test that asserted an out of range axis falls through to Z.

Docs: CHANGELOG, user guide, features, smoke checklist.