### PR TITLE
Hold every generator caller to the schema's own ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Fixed
+- **A generator built a structure out of NaN brushes** (#336). Every builder
+  checks its settings with comparisons like `radius <= 0.0`, and a NaN fails all
+  of them, so it passed every check and the arithmetic ran on it. 27 field and
+  value combinations across the four types produced structures where every piece
+  had a non-finite position or extent, and `create_generator()` reported success
+  over them. The dock's spinners cannot produce one, but a regenerate from a
+  `.hflevel`, an undo replay and a script all can.
+- **Generator dimensions and counts had no ceiling** (#337, #338). The schema's
+  `max` was the dock's SpinBox and nothing else, so an arch could be asked for
+  129,000 segments — 129,000 brushes in one call that reported success — and a
+  stairs could be built 8,200,000 units tall, far past where a float32 position
+  holds a 1-unit grid. `HFGeneratorSchema.check_ranges()` now holds every caller
+  to the schema's own maximums, so the schema is one description of what a field
+  may be rather than a description for the dock and nothing for anyone else, and
+  a new builder gets the rule for free.
+  - Both checks run in `HFGeneratorSystem.validate()`, before the builder sees
+    the settings. A level saved with an out of range structure still loads — the
+    pieces are saved as brushes and only re-linked — and a regenerate refuses
+    before anything is deleted, so the structure stays as it was.
 - **Texture lock tipped the texture on every wall of a rotated brush** (#333).
   The counter-rotation was applied to every face at the same angle whatever axis
   the brush turned about, so a yaw — the most common thing a mapper does — left

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,450 tests across 179 test scripts (3,443 passing plus seven intentional no-assert safety tests; 17,495 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,462 tests across 179 test scripts (3,455 passing plus seven intentional no-assert safety tests; 17,619 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,450 tests** across **179 scripts** (**3,443 passing** plus seven intentional no-assert safety tests; **17,495 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,462 tests** across **179 scripts** (**3,455 passing** plus seven intentional no-assert safety tests; **17,619 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3443%20passing-brightgreen" alt="3443 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3455%20passing-brightgreen" alt="3455 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,450 tests across 179 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,462 tests across 179 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/hf_generator_schema.gd
+++ b/addons/hammerforge/hf_generator_schema.gd
@@ -18,11 +18,13 @@ class_name HFGeneratorSchema
 ## with `type` one of `float`, `int`, `bool` or `enum`, and `enum` carrying an
 ## `options` array of labels.
 ##
-## The schema is a description, not a validator. Its ranges keep a SpinBox
-## sensible; `validate()` on the builder stays the authority on whether settings
-## can be built, because the refusals that matter are relationships between fields
-## — a wall thicker than its own radius, an arc too coarse to stay convex — and no
-## per-field range says that.
+## The schema says what a field may be, for everyone. The dock builds a SpinBox
+## from its range; `check_ranges()` holds a caller that never saw the dock to the
+## same range, which is what a regenerate from a `.hflevel`, an undo replay and a
+## script all are. `validate()` on the builder stays the authority on the
+## refusals that are relationships between fields — a wall thicker than its own
+## radius, an arc too coarse to stay convex — because no per-field range says
+## that.
 
 const TYPE_FLOAT := "float"
 const TYPE_INT := "int"
@@ -65,6 +67,48 @@ static func keys(schema: Array) -> PackedStringArray:
 		if entry is Dictionary and (entry as Dictionary).has("key"):
 			out.append(str((entry as Dictionary)["key"]))
 	return out
+
+
+## What is wrong with these settings against the schema, or an empty array.
+##
+## Two rules, both of which every builder's own `validate()` misses by
+## construction: a NaN fails `radius <= 0.0` the way it fails every comparison,
+## and an upper bound was only ever the dock's SpinBox. A caller that did not
+## come through the dock — a regenerate from a file, an undo replay, a script —
+## reached the arithmetic with either.
+##
+## Returns `[message, hint]` for the first field that is out of range.
+static func check_ranges(schema: Array, settings: Dictionary) -> Array:
+	var merged := merge(schema, settings)
+	for entry in schema:
+		if not (entry is Dictionary) or not (entry as Dictionary).has("key"):
+			continue
+		var field_def: Dictionary = entry
+		var type_name := str(field_def.get("type", TYPE_FLOAT))
+		if type_name == TYPE_BOOL or type_name == TYPE_ENUM:
+			continue
+		var key := str(field_def["key"])
+		var label := str(field_def.get("label", key))
+		# Read finiteness off the value as it arrived. An int field coerces a NaN
+		# to some integer on the way through `merge()`, so by then it is gone.
+		var raw = settings.get(key, 0.0)
+		if (raw is float or raw is int) and not is_finite(float(raw)):
+			return ["'%s' is not a number" % label, "Set %s to a number" % label]
+		var value := float(merged.get(key, 0.0))
+		if field_def.has("max") and value > float(field_def["max"]):
+			var ceiling := _number_text(float(field_def["max"]))
+			return [
+				"'%s' cannot be more than %s" % [label, ceiling],
+				"Use %s or less" % ceiling,
+			]
+	return []
+
+
+## A number written the way a settings field reads it: whole where it is whole.
+static func _number_text(value: float) -> String:
+	if is_equal_approx(value, roundf(value)):
+		return "%d" % int(roundf(value))
+	return "%.3f" % value
 
 
 static func field(schema: Array, key: String) -> Dictionary:

--- a/addons/hammerforge/systems/hf_generator_system.gd
+++ b/addons/hammerforge/systems/hf_generator_system.gd
@@ -97,6 +97,14 @@ static func validate(type: String, settings: Dictionary) -> HFOpResult:
 			"Generator: '%s' is not a generator type" % type,
 			"Known types: %s" % ", ".join(known_types())
 		)
+	# Before the builder, because the builder cannot catch either of these: a
+	# non-finite number passes every comparison it makes, and the upper bounds
+	# live in the schema rather than in the builder at all.
+	var range_problem := HFGeneratorSchema.check_ranges(builder.settings_schema(), settings)
+	if not range_problem.is_empty():
+		return HFOpResult.fail(
+			"%s: %s" % [display_name(type), range_problem[0]], str(range_problem[1])
+		)
 	var result = builder.validate(settings)
 	# A builder that returns nothing is a bug in the builder, but it must not
 	# become a null out of create_generator(), which is declared to hand back a

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,450 tests across 179 scripts**: **3,443 passing tests**, seven intentional no-assert safety tests, and **17,495 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,462 tests across 179 scripts**: **3,455 passing tests**, seven intentional no-assert safety tests, and **17,619 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/superpowers/specs/2026-09-08-structure-library-design.md
+++ b/docs/superpowers/specs/2026-09-08-structure-library-design.md
@@ -82,6 +82,12 @@ because the interesting refusals are relationships between fields — a wall
 thicker than its radius, an arc too coarse to stay convex — and no per-field range
 expresses those.
 
+> Amended 2026-09-11 (#336, #338): the ranges are enforced.
+> `HFGeneratorSchema.check_ranges()` holds a caller that never saw the dock to
+> the schema's own maximums, and refuses a non-finite number, because a NaN
+> passes every comparison a builder makes. `validate()` is still the authority
+> on the relationships between fields.
+
 ### The dock's Structure section
 
 The Arch section becomes the **Structure** section: a type dropdown, controls

--- a/tests/test_generator_schema.gd
+++ b/tests/test_generator_schema.gd
@@ -77,3 +77,66 @@ func test_a_malformed_field_is_skipped_rather_than_crashing():
 func test_an_empty_schema_describes_nothing():
 	assert_eq(HFGeneratorSchemaScript.defaults([]), {})
 	assert_eq(HFGeneratorSchemaScript.merge([], {"radius": 5.0}), {})
+
+
+# ===========================================================================
+# check_ranges — the schema holds a caller that never saw the dock (#336, #338)
+# ===========================================================================
+
+const RANGED := [
+	{
+		"key": "radius",
+		"label": "Radius",
+		"type": "float",
+		"min": 1.0,
+		"max": 4096.0,
+		"default": 128.0
+	},
+	{"key": "segments", "label": "Segments", "type": "int", "min": 1, "max": 128, "default": 8},
+	{"key": "post", "label": "Post", "type": "bool", "default": true},
+	{"key": "fill", "label": "Fill", "type": "enum", "options": ["Solid", "Open"], "default": 0},
+]
+
+
+func test_settings_inside_the_schema_are_accepted():
+	var problem = HFGeneratorSchemaScript.check_ranges(RANGED, {"radius": 256.0, "segments": 16})
+	assert_eq(problem, [], "nothing wrong with these")
+
+
+func test_defaults_are_inside_their_own_schema():
+	assert_eq(HFGeneratorSchemaScript.check_ranges(RANGED, {}), [])
+
+
+func test_a_non_finite_float_is_refused():
+	for value in [NAN, INF, -INF]:
+		var problem = HFGeneratorSchemaScript.check_ranges(RANGED, {"radius": value})
+		assert_false(problem.is_empty(), "radius %s should be refused" % value)
+		assert_string_contains(str(problem[0]), "Radius")
+
+
+func test_a_non_finite_int_field_is_refused_before_it_is_coerced():
+	# int(NAN) is some integer, so by the time merge() has run the NaN is gone.
+	var problem = HFGeneratorSchemaScript.check_ranges(RANGED, {"segments": NAN})
+	assert_false(problem.is_empty())
+	assert_string_contains(str(problem[0]), "Segments")
+
+
+func test_a_value_past_the_schema_maximum_is_refused():
+	var problem = HFGeneratorSchemaScript.check_ranges(RANGED, {"segments": 129000})
+	assert_false(problem.is_empty())
+	assert_string_contains(str(problem[0]), "128")
+	assert_string_contains(str(problem[1]), "128")
+
+
+func test_the_maximum_itself_is_allowed():
+	assert_eq(HFGeneratorSchemaScript.check_ranges(RANGED, {"segments": 128}), [])
+	assert_eq(HFGeneratorSchemaScript.check_ranges(RANGED, {"radius": 4096.0}), [])
+
+
+func test_a_bool_or_enum_field_is_not_range_checked():
+	assert_eq(HFGeneratorSchemaScript.check_ranges(RANGED, {"post": false, "fill": 1}), [])
+
+
+func test_a_field_with_no_maximum_has_no_ceiling():
+	var open_schema := [{"key": "n", "label": "N", "type": "float", "default": 1.0}]
+	assert_eq(HFGeneratorSchemaScript.check_ranges(open_schema, {"n": 1.0e9}), [])

--- a/tests/test_generator_system.gd
+++ b/tests/test_generator_system.gd
@@ -1004,3 +1004,50 @@ func _structure_centre(record) -> Vector3:
 			total += brush.global_position
 			count += 1
 	return total / float(count) if count > 0 else Vector3.ZERO
+
+
+# ===========================================================================
+# Every generator refuses a setting it cannot build (#336, #337, #338)
+# ===========================================================================
+
+
+func test_every_generator_refuses_a_non_finite_setting():
+	# A NaN fails `radius <= 0.0` the way it fails every comparison, so it used
+	# to pass every check a builder made and build a structure of NaN brushes.
+	var checked := 0
+	for type in HFGeneratorSystemScript.known_types():
+		for field in HFGeneratorSystemScript.settings_schema(type):
+			if field["type"] == "bool" or field["type"] == "enum":
+				continue
+			for value in [NAN, INF, -INF]:
+				var settings := {}
+				settings[str(field["key"])] = value
+				var result = HFGeneratorSystemScript.validate(type, settings)
+				assert_false(result.ok, "%s should refuse %s = %s" % [type, field["key"], value])
+				checked += 1
+	assert_gt(checked, 0, "there are generator settings to check")
+
+
+func test_every_generator_refuses_a_setting_past_its_schema_maximum():
+	# The schema's max was the dock's SpinBox and nothing else, so a regenerate
+	# from a file, an undo replay or a script walked straight past it.
+	for type in HFGeneratorSystemScript.known_types():
+		for field in HFGeneratorSystemScript.settings_schema(type):
+			if not field.has("max") or field["type"] == "bool" or field["type"] == "enum":
+				continue
+			var settings := {}
+			settings[str(field["key"])] = float(field["max"]) * 1000.0
+			var result = HFGeneratorSystemScript.validate(type, settings)
+			assert_false(result.ok, "%s should refuse a huge %s" % [type, field["key"]])
+
+
+func test_an_arch_of_129000_segments_is_refused():
+	var result = HFGeneratorSystemScript.validate("arch", {"segments": 129000})
+	assert_false(result.ok, "129000 segments is 129000 brushes")
+	assert_false(HFGeneratorSystemScript.can_build("arch", {"segments": 129000}).ok)
+
+
+func test_every_generator_still_builds_at_its_defaults():
+	for type in HFGeneratorSystemScript.known_types():
+		var defaults = HFGeneratorSystemScript.default_settings(type)
+		assert_true(HFGeneratorSystemScript.validate(type, defaults).ok, "%s defaults" % type)


### PR DESCRIPTION
Fixes #336, fixes #337, fixes #338. One root cause: a generator's settings were only ever checked by the builder, and the builder cannot catch either of these.

A NaN fails every comparison a builder makes, so it passed every check and the arithmetic ran on it — 27 field and value combinations across the four types built structures of NaN pieces and reported success.

The schema's upper bounds were only ever the dock's SpinBox, so a regenerate from a .hflevel, an undo replay or a script walked past them: 129,000 arch segments, an 8,200,000 unit stairs.

Both checks live in `HFGeneratorSchema.check_ranges()`, called from `HFGeneratorSystem.validate()` before the builder sees the settings, so the schema is one description of what a field may be rather than a description for the dock and nothing for anyone else.

Tests sweep every field of every known type, so a new builder is covered without a new test. A level saved with an out of range structure still loads, and a regenerate refuses before anything is deleted.

Docs: CHANGELOG, the schema's own header, and an amendment on the structure library design spec that stated the old rule.