### PR TITLE
Refuse a bevel or inset that is not one, and stop sizing a face normal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Fixed
+- **A bevel radius of zero built a bevel nobody asked for** (#330). `0` is how a
+  user says "actually, no bevel", and `bevel_edge()` coerced it — and a negative
+  radius — to 0.01, returned true, and left an inverted cap triangle. Both are
+  refused now, the way `can_hollow_brush()` refuses a wall thickness of zero.
+  - **The inverted cap was not a winding problem.** `FaceData._compute_normal()`
+    called a face degenerate when the raw cross product of its first two edges
+    came out under `0.0001`, and that quantity grows with the *square* of the
+    face, so a 0.01-unit cap on a 64-unit brush measured `4e-5` and was handed
+    `Vector3.UP` regardless of how it had been wound. Both caps of a small bevel
+    came out facing the same way, one of them into the solid. The edges are
+    normalised before the cross now, so what is measured is the angle between
+    them and the answer does not depend on how big the face is. Three points in
+    a line are still degenerate, which is the thing the check was for.
+- **Inset accepted numbers it could not use** (#339, #340). `maxf()` does not
+  clean a NaN and the height was never looked at, so both went into the vertex
+  arithmetic and a brush came back with a non-finite extent while the call
+  reported success. Both are now refused, along with an inset distance of zero
+  or less — the same coercion #330 removes from the bevel.
+  - **A recessed inset no longer turns its walls inside out.** The side faces
+    were wound on the assumption that the inset boundary is in front of the
+    original one. A negative height puts it behind, which inverted every wall.
+    Which way a wall faces is now taken from the height: a raised inset is a
+    boss and its walls face away from the middle of the face, a recess is a pit
+    and its walls are seen from inside it, and at zero height the ring is flat
+    and is part of the original surface.
 - **A generator built a structure out of NaN brushes** (#336). Every builder
   checks its settings with comparisons like `radius <= 0.0`, and a NaN fails all
   of them, so it passed every check and the arithmetic ran on it. 27 field and

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,462 tests across 179 test scripts (3,455 passing plus seven intentional no-assert safety tests; 17,619 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,473 tests across 179 test scripts (3,466 passing plus seven intentional no-assert safety tests; 17,735 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,462 tests** across **179 scripts** (**3,455 passing** plus seven intentional no-assert safety tests; **17,619 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,473 tests** across **179 scripts** (**3,466 passing** plus seven intentional no-assert safety tests; **17,735 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3455%20passing-brightgreen" alt="3455 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3466%20passing-brightgreen" alt="3466 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,462 tests across 179 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,473 tests across 179 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/face_data.gd
+++ b/addons/hammerforge/face_data.gd
@@ -568,7 +568,13 @@ func _compute_normal() -> void:
 	var a = local_verts[0]
 	var b = local_verts[1]
 	var c = local_verts[2]
-	var n = (c - a).cross(b - a)
+	# The edges are normalised before the cross, so what is measured is the angle
+	# between them rather than the area of the triangle. The raw cross product
+	# grows with the square of the face, so an absolute floor on it meant any
+	# small face was called degenerate and given `Vector3.UP` — a 0.01-unit bevel
+	# cap came out facing into the solid whatever winding it was built with, and
+	# the same is true of every tessellation sliver.
+	var n = (c - a).normalized().cross((b - a).normalized())
 	if n.length() > 0.0001:
 		normal = n.normalized()
 	else:

--- a/addons/hammerforge/systems/hf_bevel_system.gd
+++ b/addons/hammerforge/systems/hf_bevel_system.gd
@@ -34,7 +34,11 @@ func bevel_edge(brush_id: String, edge: Array, segments: int = 2, radius: float 
 	if not is_finite(radius):
 		HFLog.warn("HFBevelSystem: bevel radius must be finite")
 		return false
-	radius = maxf(radius, 0.01)
+	if radius <= 0.0:
+		# Typing 0 is how a user says "actually, no bevel". Coercing it to 0.01
+		# gave them a bevel they did not ask for and reported success over it.
+		HFLog.warn("HFBevelSystem: bevel radius must be greater than zero")
+		return false
 	var brush: Node3D = root.find_brush_by_id(brush_id)
 	if not brush:
 		return false
@@ -171,7 +175,14 @@ func bevel_edge(brush_id: String, edge: Array, segments: int = 2, radius: float 
 func inset_face(
 	brush_id: String, face_index: int, inset_distance: float = 2.0, height: float = 0.0
 ) -> bool:
-	inset_distance = maxf(inset_distance, 0.01)
+	if not is_finite(inset_distance) or not is_finite(height):
+		# maxf() does not clean a NaN, and height was never looked at, so both
+		# went into the vertex arithmetic and stayed on the face.
+		HFLog.warn("HFBevelSystem: inset needs finite numbers")
+		return false
+	if inset_distance <= 0.0:
+		HFLog.warn("HFBevelSystem: inset distance must be greater than zero")
+		return false
 	var brush: Node3D = root.find_brush_by_id(brush_id)
 	if not brush:
 		return false
@@ -200,6 +211,9 @@ func inset_face(
 		if height != 0.0:
 			inset_v += face.normal * height
 		inset_verts.append(inset_v)
+	# Read before the face is overwritten: the side walls at zero height are part
+	# of the original surface and have to face the way it did.
+	var face_normal: Vector3 = face.normal
 	# Replace original face with the inset face.
 	face.local_verts = inset_verts
 	face.ensure_geometry()
@@ -208,10 +222,20 @@ func inset_face(
 	for i in range(count):
 		var next: int = (i + 1) % count
 		var side_face = FaceData.new()
-		# CW winding from outside: orig[i] → orig[next] → inset[next] → inset[i]
-		side_face.local_verts = PackedVector3Array(
-			[verts[i], verts[next], inset_verts[next], inset_verts[i]]
-		)
+		var quad := PackedVector3Array([verts[i], verts[next], inset_verts[next], inset_verts[i]])
+		# Which way a side wall faces is decided by the height, not by assuming
+		# the inset boundary is in front of the original one. A raised inset is a
+		# boss and its walls face away from the middle of the face; a negative
+		# height is a recess and its walls look into it, the far side of the same
+		# material; at zero height the ring is flat and is part of the original
+		# surface. Assuming the first of those wound the other two inside out.
+		var in_plane: Vector3 = (verts[i] + verts[next]) * 0.5 - centroid
+		var reference: Vector3 = face_normal
+		if not is_zero_approx(height):
+			reference = in_plane * signf(height)
+		if (quad[2] - quad[0]).cross(quad[1] - quad[0]).dot(reference) < 0.0:
+			quad.reverse()
+		side_face.local_verts = quad
 		side_face.material_idx = face.material_idx
 		side_face.uv_projection = face.uv_projection
 		side_face.uv_scale = face.uv_scale
@@ -293,6 +317,7 @@ func _compute_centroid(verts: PackedVector3Array) -> Vector3:
 
 
 ## Fan the arc at one edge endpoint into triangles that face `outward`.
+##
 ## All arc points lie in a plane perpendicular to the edge, so the fan normal is
 ## parallel to the edge axis and a single dot product settles the winding.
 func _append_endpoint_caps(

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -1621,7 +1621,7 @@ Replace a sharp edge with a rounded profile:
 1. Enter **Vertex mode** (V key) and switch to **Edge sub-mode** (E key).
 2. Select one or more edges.
 3. Open the **Brush** tab → **Bevel** section.
-4. Set **Segments** (1-16) and **Radius** (distance the bevel cuts into the brush).
+4. Set **Segments** (1-16) and **Radius** (distance the bevel cuts into the brush). The radius has to be greater than zero; `0` or below is refused rather than treated as a very small bevel.
 5. Click **Bevel Edge**.
 
 The selected edges are replaced with bevel strip faces. Higher segment counts produce smoother curves.
@@ -1630,11 +1630,11 @@ The selected edges are replaced with bevel strip faces. Higher segment counts pr
 Shrink a face inward and create connecting side faces:
 1. Select a face in **Face Select Mode**.
 2. Open the **Brush** tab → **Bevel** section.
-3. Set **Inset** (distance to shrink inward) and optional **Height** (extrude along normal).
+3. Set **Inset** (distance to shrink inward) and optional **Height** (extrude along normal). A positive height raises the face into a boss; a negative one pushes it in to make a recessed panel.
 4. Click **Inset Face**.
 
 Notes:
-- Inset distance cannot exceed the face's corner-to-centroid distance (the operation is rejected with a toast if too large).
+- Inset distance has to be greater than zero and cannot exceed the face's corner-to-centroid distance (the operation is rejected with a toast if too large).
 - Both bevel and inset operations are fully undoable.
 
 ## Entities (early)

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,462 tests across 179 scripts**: **3,455 passing tests**, seven intentional no-assert safety tests, and **17,619 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,473 tests across 179 scripts**: **3,466 passing tests**, seven intentional no-assert safety tests, and **17,735 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_bevel.gd
+++ b/tests/test_bevel.gd
@@ -493,3 +493,134 @@ func test_bevel_on_a_larger_radius_is_still_convex():
 	var brush = _make_box_brush()
 	assert_true(sys.bevel_edge("box_brush", [0, 1], 4, 7.0), "Bevel should succeed")
 	assert_lt(_worst_plane_violation(brush), 0.02, "A wider bevel should stay convex")
+
+
+# ---------------------------------------------------------------------------
+# Refusing what is not a bevel or an inset (#330, #339, #340)
+# ---------------------------------------------------------------------------
+
+
+## How many faces point back at the brush's own centre. A back-facing polygon
+## bakes inside out and fails every convexity check from then on.
+func _inward_face_count(brush: Node3D) -> int:
+	var centre := _brush_centre(brush)
+	var inward := 0
+	for face in brush.faces:
+		if face.local_verts.size() < 3:
+			continue
+		var out_dir: Vector3 = _face_centre(face) - centre
+		if out_dir.length() < 0.0001:
+			continue
+		if face.normal.dot(out_dir.normalized()) < 0.0:
+			inward += 1
+	return inward
+
+
+func test_bevel_refuses_a_radius_of_zero():
+	var brush = _make_box_brush()
+	var before: int = brush.faces.size()
+	_capture_warning("greater than zero")
+	assert_false(sys.bevel_edge("box_brush", [0, 3], 2, 0.0), "0 is not a bevel")
+	_assert_captured_warning("greater than zero")
+	assert_eq(brush.faces.size(), before, "nothing added")
+
+
+func test_bevel_refuses_a_negative_radius():
+	var brush = _make_box_brush()
+	var before: int = brush.faces.size()
+	_capture_warning("greater than zero")
+	assert_false(sys.bevel_edge("box_brush", [0, 3], 2, -8.0))
+	_assert_captured_warning("greater than zero")
+	assert_eq(brush.faces.size(), before)
+
+
+## A real 64 unit box, built the way the brush system builds one, because the
+## cap winding was read off arc points that are `radius` apart at coordinates of
+## 32 — and how much of a float32 that leaves is what decided the sign.
+func _make_real_box(brush_id: String) -> Node3D:
+	var brush = DraftBrush.new()
+	brush.brush_id = brush_id
+	brush.shape = 0
+	brush.size = Vector3(64, 64, 64)
+	root.draft_brushes_node.add_child(brush)
+	brush.rebuild_preview()
+	return brush
+
+
+func test_a_small_bevel_winds_its_caps_outward_on_every_edge():
+	var beveled := 0
+	for radius in [0.01, 0.05, 0.5, 4.0]:
+		for a in range(8):
+			for b in range(a + 1, 8):
+				var id := "edge_%s_%d_%d" % [radius, a, b]
+				var brush = _make_real_box(id)
+				if not sys.bevel_edge(id, [a, b], 2, radius):
+					continue
+				beveled += 1
+				assert_eq(
+					_inward_face_count(brush),
+					0,
+					"radius %s on edge %d-%d left an inverted face" % [radius, a, b]
+				)
+	assert_gt(beveled, 0, "there are edges to bevel")
+
+
+func test_inset_refuses_numbers_that_are_not_numbers():
+	var brush = _make_box_brush()
+	var before: int = brush.faces.size()
+	for args in [[NAN, 8.0], [8.0, INF], [INF, 0.0], [8.0, NAN]]:
+		assert_false(
+			sys.inset_face("box_brush", 0, args[0], args[1]),
+			"inset %s should be refused" % str(args)
+		)
+	assert_eq(brush.faces.size(), before, "nothing added")
+	for face in brush.faces:
+		for v in face.local_verts:
+			assert_true(v.is_finite(), "no non-finite vertex reached the brush")
+
+
+func test_inset_refuses_a_distance_that_is_not_an_inset():
+	var brush = _make_box_brush()
+	var before: int = brush.faces.size()
+	assert_false(sys.inset_face("box_brush", 0, 0.0, 0.0))
+	assert_false(sys.inset_face("box_brush", 0, -4.0, 0.0))
+	assert_eq(brush.faces.size(), before)
+
+
+## Which way the walls of an inset look, measured against the inset face itself
+## rather than against the brush centre — a recess makes the brush concave, so
+## the centre says nothing useful about it.
+func _wall_dots_towards_the_inset(brush: Node3D) -> Array:
+	var pit_centre := _face_centre(brush.faces[0])
+	var out: Array = []
+	for i in range(6, brush.faces.size()):
+		var face: FaceData = brush.faces[i]
+		out.append(face.normal.dot((pit_centre - _face_centre(face)).normalized()))
+	return out
+
+
+func test_a_recessed_inset_walls_look_into_the_recess():
+	# A negative height pushes the inset face into the solid, which put the inset
+	# boundary behind the original one and wound every side face inside out.
+	var brush = _make_box_brush()
+	assert_true(sys.inset_face("box_brush", 0, 4.0, -8.0))
+	var dots: Array = _wall_dots_towards_the_inset(brush)
+	assert_eq(dots.size(), 4, "one wall per edge of the face")
+	for d in dots:
+		assert_gt(d, 0.0, "a pit wall is seen from inside the pit")
+
+
+func test_a_raised_inset_walls_look_away_from_the_boss():
+	var brush = _make_box_brush()
+	assert_true(sys.inset_face("box_brush", 0, 4.0, 8.0))
+	assert_eq(_inward_face_count(brush), 0, "a boss stays convex")
+	for d in _wall_dots_towards_the_inset(brush):
+		assert_lt(d, 0.0, "a boss wall is seen from outside it")
+
+
+func test_a_flat_inset_ring_faces_the_way_the_original_face_did():
+	var brush = _make_box_brush()
+	var was: Vector3 = brush.faces[0].normal
+	assert_true(sys.inset_face("box_brush", 0, 4.0, 0.0))
+	for i in range(6, brush.faces.size()):
+		assert_gt(brush.faces[i].normal.dot(was), 0.9, "the ring is the old surface")

--- a/tests/test_face_data.gd
+++ b/tests/test_face_data.gd
@@ -172,3 +172,43 @@ func test_box_projection_z():
 	var face = FaceData.new()
 	face.normal = Vector3(0, 0, 1)
 	assert_eq(face._box_projection_axis(), FaceData.UVProjection.PLANAR_Z)
+
+
+# ===========================================================================
+# A face normal must not depend on how big the face is (#330)
+# ===========================================================================
+
+
+func test_a_small_face_gets_its_real_normal_not_the_fallback():
+	# The degenerate test used to be an absolute floor on the raw cross product,
+	# which grows with the square of the face. A 0.01-unit triangle fell under it
+	# and was given Vector3.UP, so a small bevel cap faced into the solid
+	# whatever winding it had been built with.
+	for scale in [1.0, 0.1, 0.01, 0.001]:
+		var face = FaceData.new()
+		face.local_verts = PackedVector3Array(
+			[
+				Vector3(32.0, -32.0, 32.0),
+				Vector3(32.0 - scale, -32.0, 32.0),
+				Vector3(32.0, -32.0, 32.0 - scale),
+			]
+		)
+		face.ensure_geometry()
+		assert_almost_eq(
+			absf(face.normal.dot(Vector3.UP)), 1.0, 0.0001, "scale %s is flat in Y" % scale
+		)
+		assert_almost_eq(face.normal.y, 1.0, 0.0001, "scale %s should keep its winding" % scale)
+
+
+func test_a_face_with_three_points_in_a_line_is_still_called_degenerate():
+	var face = FaceData.new()
+	face.local_verts = PackedVector3Array([Vector3.ZERO, Vector3(1, 0, 0), Vector3(2, 0, 0)])
+	face.ensure_geometry()
+	assert_eq(face.normal, Vector3.UP, "collinear points have no plane")
+
+
+func test_a_face_with_two_points_in_the_same_place_is_degenerate():
+	var face = FaceData.new()
+	face.local_verts = PackedVector3Array([Vector3.ZERO, Vector3.ZERO, Vector3(1, 0, 0)])
+	face.ensure_geometry()
+	assert_eq(face.normal, Vector3.UP)


### PR DESCRIPTION
Fixes #330, fixes #339, fixes #340.

`bevel_edge()` coerced a radius of 0 or below to 0.01 and `inset_face()` took a NaN through `maxf()` and never looked at its height at all. Both reported success over the result. Both refuse now.

#330's inverted cap turned out not to be a winding problem. `FaceData._compute_normal()` called a face degenerate when the raw cross product of its first two edges came under `0.0001`, and that quantity grows with the square of the face — a 0.01-unit cap on a 64-unit brush measures `4e-5`, so both caps of a small bevel were handed `Vector3.UP` and one of them faced into the solid whatever winding it had been built with. The edges are normalised before the cross now, so the test is the angle between them and the answer no longer depends on how big the face is. Three points in a line are still degenerate.

#339's recessed inset wound its side walls inside out. Which way a wall faces is taken from the height rather than from the assumption that the inset boundary is in front of the original one.

The bevel test sweeps every edge of a real 64 unit box at four radii, because the 16 unit box the older tests build does not reach the threshold. Confirmed each new test fails against the old code before keeping it.

Docs: CHANGELOG and the user guide's bevel and inset sections.