### PR TITLE
Check a face's material slot, UV transform and projection before writing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Fixed
+- **A face's material slot was never checked against the palette** (#343). Any
+  integer could be assigned and was stored, saved and read back, so the bake, the
+  `.map` exporter and the UV editor each fell back to something that is not the
+  material the mapper picked — the face silently becomes `__default` in the
+  export. The three `assign_material_*` paths refuse a slot that is not `-1` and
+  not an index into the palette, and `validate_level()` now also reports a slot
+  *below* the default rather than only one past the end, with the same reset.
+- **`set_face_uv_params()` wrote a UV transform the mesh cannot use** (#344). A
+  non-finite scale, offset or rotation reached the mesh's UV channel, where the
+  vertex is discarded or drawn undefined depending on the driver, and it survived
+  the save — with the geometry still looking right, which is why nobody thinks to
+  look at the UVs. A scale component of zero collapsed the whole face onto one
+  texel. Both are refused. A negative scale is still allowed: it mirrors the
+  texture, which is a thing to want.
+- **`reproject_face_uvs()` stored any integer as a UV projection** (#345). The
+  projector falls through its `match` to the `(x, y)` branch, so the face got a
+  projection nobody chose, no dock control can show, and the `.map` exporter
+  wrote out whatever the fallback produced. The setter and
+  `assign_material_and_reproject()` refuse one, `FaceData.from_dict()` falls back
+  to `PLANAR_Z` so a file cannot smuggle one in, and `validate_level()` reports
+  and resets one that is already there.
 - **A bevel radius of zero built a bevel nobody asked for** (#330). `0` is how a
   user says "actually, no bevel", and `bevel_edge()` coerced it — and a negative
   radius — to 0.01, returned true, and left an inverted cap triangle. Both are

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,473 tests across 179 test scripts (3,466 passing plus seven intentional no-assert safety tests; 17,735 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,483 tests across 179 test scripts (3,476 passing plus seven intentional no-assert safety tests; 17,763 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,473 tests** across **179 scripts** (**3,466 passing** plus seven intentional no-assert safety tests; **17,735 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,483 tests** across **179 scripts** (**3,476 passing** plus seven intentional no-assert safety tests; **17,763 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3466%20passing-brightgreen" alt="3466 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3476%20passing-brightgreen" alt="3476 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,473 tests across 179 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,483 tests across 179 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/face_data.gd
+++ b/addons/hammerforge/face_data.gd
@@ -95,6 +95,16 @@ func adjust_uvs_for_transform(pos_delta: Vector3, size_ratio: Vector3) -> void:
 		uv_scale *= inv_size
 
 
+## Whether an integer names one of this enum's projections.
+##
+## `uv_projection` is a bare `int`, and the projector falls through its `match`
+## to the `(x, y)` branch for anything else — so an out of range value is stored,
+## saved, reloaded and exported as a projection nobody chose and no dock control
+## can show.
+static func is_valid_projection(projection: int) -> bool:
+	return projection >= 0 and projection <= UVProjection.CYLINDRICAL
+
+
 ## The two local directions a planar projection reads, in (u, v) order.
 ##
 ## These are the axes `_project_uvs_for_vertices()` samples, written out so the
@@ -353,7 +363,11 @@ func to_dict() -> Dictionary:
 static func from_dict(data: Dictionary) -> FaceData:
 	var face = FaceData.new()
 	face.material_idx = int(data.get("material_idx", -1))
-	face.uv_projection = int(data.get("uv_projection", UVProjection.PLANAR_Z))
+	var stored_projection := int(data.get("uv_projection", UVProjection.PLANAR_Z))
+	if not is_valid_projection(stored_projection):
+		# An older or newer file, or a hand edit. The enum has to mean something.
+		stored_projection = UVProjection.PLANAR_Z
+	face.uv_projection = stored_projection
 	face.uv_scale = _decode_vec2(data.get("uv_scale", null), Vector2.ONE)
 	face.uv_offset = _decode_vec2(data.get("uv_offset", null), Vector2.ZERO)
 	face.uv_rotation = float(data.get("uv_rotation", 0.0))

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -1636,12 +1636,54 @@ func reset_uv_on_face(brush_id: String, face_idx: int) -> void:
 		tag_brush_dirty(brush_id)
 
 
+## Whether a UV scale, offset and rotation can be written onto a face.
+##
+## A non-finite value here reaches the mesh's UV channel, where the vertex is
+## discarded or drawn undefined depending on the driver, and it survives the save
+## — so reopening the level does not clear it, and the geometry still looks
+## right, which is why nobody thinks to look at the UVs. A scale component of
+## zero collapses every vertex of the face onto one texel and cannot be undone by
+## scaling back up. A negative scale is allowed on purpose: it mirrors the
+## texture, which is a thing to want.
+func is_usable_uv_transform(scale: Vector2, offset: Vector2, rotation: float) -> bool:
+	if not scale.is_finite() or not offset.is_finite() or not is_finite(rotation):
+		HFLog.warn("LevelRoot: a UV transform needs finite numbers")
+		return false
+	if is_zero_approx(scale.x) or is_zero_approx(scale.y):
+		HFLog.warn("LevelRoot: a UV scale of zero is not a scale")
+		return false
+	return true
+
+
+## Whether a material slot names something in the palette.
+##
+## `-1` is the default slot and means no material. Anything else has to be an
+## index into the palette: the bake, the `.map` exporter and the UV editor all
+## resolve the slot, and each of their fallbacks for a slot that is not there
+## gives the face something other than what the mapper picked.
+func is_usable_material_slot(material_index: int) -> bool:
+	if material_index == -1:
+		return true
+	if material_index < 0 or material_index >= get_materials().size():
+		HFLog.warn(
+			(
+				"LevelRoot: material slot %d is not in a palette of %d"
+				% [material_index, get_materials().size()]
+			)
+		)
+		return false
+	return true
+
+
 func reproject_face_uvs(brush_id: String, face_idx: int, projection: int) -> void:
 	var brush = brush_system.find_brush_by_id(brush_id)
 	if not brush or not (brush is DraftBrush):
 		return
 	var draft := brush as DraftBrush
 	if face_idx < 0 or face_idx >= draft.faces.size():
+		return
+	if not FaceData.is_valid_projection(projection):
+		HFLog.warn("LevelRoot: %d is not a UV projection" % projection)
 		return
 	var face: FaceData = draft.faces[face_idx]
 	var before := face.to_dict()
@@ -1665,6 +1707,8 @@ func set_face_uv_params(
 		return
 	var draft := brush as DraftBrush
 	if face_idx < 0 or face_idx >= draft.faces.size():
+		return
+	if not is_usable_uv_transform(scale, offset, rotation):
 		return
 	var face: FaceData = draft.faces[face_idx]
 	var before := face.to_dict()
@@ -1785,6 +1829,8 @@ func get_primary_selected_face() -> Dictionary:
 
 
 func assign_material_to_selected_faces(material_index: int) -> int:
+	if not is_usable_material_slot(material_index):
+		return 0
 	return brush_system.assign_material_to_selected_faces(material_index)
 
 
@@ -1793,6 +1839,8 @@ func assign_material_to_faces_by_id(
 ) -> void:
 	var brush: DraftBrush = brush_system.find_brush_by_id(brush_key)
 	if not brush or not is_instance_valid(brush):
+		return
+	if not is_usable_material_slot(material_index):
 		return
 	var typed_indices: Array[int] = []
 	var changed := false
@@ -1811,6 +1859,8 @@ func assign_material_to_faces_by_id(
 
 
 func assign_material_to_whole_brushes(material_index: int, brush_ids: Array) -> int:
+	if not is_usable_material_slot(material_index):
+		return 0
 	var count := 0
 	for bid in brush_ids:
 		var brush: DraftBrush = brush_system._find_brush_by_key(str(bid))
@@ -1830,6 +1880,11 @@ func assign_material_to_whole_brushes(material_index: int, brush_ids: Array) -> 
 
 
 func assign_material_and_reproject(material_index: int, projection: int) -> int:
+	if not is_usable_material_slot(material_index):
+		return 0
+	if not FaceData.is_valid_projection(projection):
+		HFLog.warn("LevelRoot: %d is not a UV projection" % projection)
+		return 0
 	var sel = get_face_selection()
 	var count := 0
 	for brush_key in sel.keys():

--- a/addons/hammerforge/systems/hf_validation_system.gd
+++ b/addons/hammerforge/systems/hf_validation_system.gd
@@ -130,6 +130,7 @@ func validate(auto_fix: bool = false) -> Dictionary:
 	# Face material indices out of palette bounds
 	var palette_count = root.material_manager.materials.size() if root.material_manager else 0
 	var invalid_face_mats := 0
+	var invalid_projections := 0
 	for node in brush_nodes:
 		if not (node is DraftBrush):
 			continue
@@ -138,14 +139,29 @@ func validate(auto_fix: bool = false) -> Dictionary:
 			if face == null:
 				continue
 			var idx = int(face.material_idx)
-			if idx >= palette_count and idx >= 0:
+			# -1 is the default slot. Anything else has to be in the palette —
+			# below it as well as past the end, which a level can acquire from a
+			# file written against a longer palette or by a call that was never
+			# checked.
+			if idx < -1 or idx >= palette_count:
 				invalid_face_mats += 1
 				if auto_fix:
 					face.material_idx = -1
+			if not FaceData.is_valid_projection(int(face.uv_projection)):
+				invalid_projections += 1
+				if auto_fix:
+					face.uv_projection = FaceData.UVProjection.PLANAR_Z
+					face.custom_uvs = PackedVector2Array()
 	if invalid_face_mats > 0:
 		issues.append("Faces reference missing materials: %d" % invalid_face_mats)
 		if auto_fix:
 			fixed += invalid_face_mats
+			if root.brush_system:
+				root.brush_system._refresh_brush_previews()
+	if invalid_projections > 0:
+		issues.append("Faces carry a UV projection that is not one: %d" % invalid_projections)
+		if auto_fix:
+			fixed += invalid_projections
 			if root.brush_system:
 				root.brush_system._refresh_brush_previews()
 

--- a/docs/HammerForge_Texture_Materials.md
+++ b/docs/HammerForge_Texture_Materials.md
@@ -19,9 +19,9 @@ Surface paint is separate from floor paint. Floor paint is a grid-based system t
 ## Data Model (FaceData)
 Face data lives on each DraftBrush in `faces` and is serialized into `.hflevel`.
 
-- `material_idx`: Index into `MaterialManager.materials`.
-- `uv_projection`: Projection enum (planar X/Y/Z, box, cylindrical).
-- `uv_scale`, `uv_offset`, `uv_rotation`: Projection transform. Transform order: rotate → scale → offset (matches Valve 220 convention).
+- `material_idx`: Index into `MaterialManager.materials`, or `-1` for no material. A slot that is neither is refused on assignment, and `Validate Level` reports and resets one that is already on a face.
+- `uv_projection`: Projection enum (planar X/Y/Z, box, cylindrical). An integer outside the enum is refused on assignment and falls back to planar Z on load, so a file cannot carry a projection no control can show.
+- `uv_scale`, `uv_offset`, `uv_rotation`: Projection transform. Transform order: rotate → scale → offset (matches Valve 220 convention). A non-finite value is refused, as is a scale component of zero, which collapses the face onto one texel. A negative scale is allowed and mirrors the texture. The rotation is stored wrapped into `[-pi, pi)`.
 - `custom_uvs`: Optional explicit UVs (per vertex).
 - `uv_format_version`: Serialization version (1 = current). Old data (version 0) used a different transform order and is auto-migrated on load.
 - `paint_layers`: Array of paint layers.

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,473 tests across 179 scripts**: **3,466 passing tests**, seven intentional no-assert safety tests, and **17,735 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,483 tests across 179 scripts**: **3,476 passing tests**, seven intentional no-assert safety tests, and **17,763 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_dirty_tags.gd
+++ b/tests/test_dirty_tags.gd
@@ -200,6 +200,10 @@ func _make_production_root() -> LevelRoot:
 	var production_root := LevelRootType.new()
 	production_root.auto_spawn_player = false
 	add_child_autoqfree(production_root)
+	# A material slot has to name something in the palette, so the slot numbers
+	# these tests use as markers need a palette deep enough to hold them.
+	while production_root.get_materials().size() < 12:
+		production_root.add_material_to_palette(StandardMaterial3D.new())
 	return production_root
 
 

--- a/tests/test_generator_record_lifecycle.gd
+++ b/tests/test_generator_record_lifecycle.gd
@@ -19,6 +19,10 @@ func before_each() -> void:
 	root.commit_freeze = false
 	root.hflevel_autosave_enabled = false
 	add_child_autoqfree(root)
+	# The slot numbers below stand in for "this face was painted", and a slot has
+	# to name something in the palette, so make one deep enough to hold them.
+	while root.get_materials().size() < 12:
+		root.add_material_to_palette(StandardMaterial3D.new())
 
 
 func after_each() -> void:

--- a/tests/test_material_palette_integrity.gd
+++ b/tests/test_material_palette_integrity.gd
@@ -116,3 +116,118 @@ func test_load_all_into_keeps_materials_that_were_already_there():
 
 	assert_gt(added, 0, "The prototypes should still load alongside a hand made material")
 	assert_eq(root.get_material_names()[0], "hand_made", "and the existing slot 0 should not move")
+
+
+# -- A slot has to name something in the palette (#343) ------------------------
+
+
+func test_a_slot_outside_the_palette_is_refused():
+	root.add_material_to_palette(_make_material("A"))
+	root.add_material_to_palette(_make_material("B"))
+	var brush := _make_brush("b1")
+	root.assign_material_to_faces_by_id("b1", [0], 1)
+	for slot in [-2, 2, 999999]:
+		root.assign_material_to_faces_by_id("b1", [0], slot)
+		assert_eq(brush.faces[0].material_idx, 1, "slot %d must not stick" % slot)
+
+
+func test_the_default_slot_is_still_allowed():
+	root.add_material_to_palette(_make_material("A"))
+	var brush := _make_brush("b1")
+	root.assign_material_to_faces_by_id("b1", [0], 0)
+	root.assign_material_to_faces_by_id("b1", [0], -1)
+	assert_eq(brush.faces[0].material_idx, -1, "-1 means no material")
+
+
+func test_assigning_a_bad_slot_to_whole_brushes_changes_nothing():
+	root.add_material_to_palette(_make_material("A"))
+	var brush := _make_brush("b1")
+	assert_eq(root.assign_material_to_whole_brushes(7, ["b1"]), 0)
+	for face in brush.faces:
+		assert_eq(face.material_idx, -1)
+
+
+func test_validate_reports_and_fixes_a_slot_below_the_default():
+	root.add_material_to_palette(_make_material("A"))
+	var brush := _make_brush("b1")
+	brush.faces[0].material_idx = -5
+	var report: Dictionary = root.validate_level(false)
+	assert_gt(_issues_mentioning(report, "missing materials").size(), 0, "reported")
+	root.validate_level(true)
+	assert_eq(brush.faces[0].material_idx, -1, "reset to the default slot")
+
+
+func _issues_mentioning(report: Dictionary, text: String) -> Array:
+	var out: Array = []
+	for issue in report.get("issues", []):
+		if str(issue).findn(text) >= 0:
+			out.append(issue)
+	return out
+
+
+# -- A UV projection has to be one of the projections (#345) -------------------
+
+
+func test_reprojecting_to_an_integer_that_is_not_a_projection_is_refused():
+	var brush := _make_brush("b1")
+	root.reproject_face_uvs("b1", 0, FaceData.UVProjection.PLANAR_X)
+	for bad in [-1, 99]:
+		root.reproject_face_uvs("b1", 0, bad)
+		assert_eq(
+			brush.faces[0].uv_projection,
+			FaceData.UVProjection.PLANAR_X,
+			"projection %d must not stick" % bad
+		)
+
+
+func test_a_projection_out_of_range_does_not_survive_a_load():
+	var face := FaceData.new()
+	face.local_verts = PackedVector3Array([Vector3.ZERO, Vector3(1, 0, 0), Vector3(1, 1, 0)])
+	face.uv_projection = 99
+	var restored := FaceData.from_dict(face.to_dict())
+	assert_true(
+		FaceData.is_valid_projection(restored.uv_projection), "a file cannot smuggle one in"
+	)
+
+
+func test_validate_reports_and_fixes_a_projection_that_is_not_one():
+	var brush := _make_brush("b1")
+	brush.faces[0].uv_projection = 99
+	var report: Dictionary = root.validate_level(false)
+	assert_gt(_issues_mentioning(report, "UV projection").size(), 0, "reported")
+	root.validate_level(true)
+	assert_true(FaceData.is_valid_projection(brush.faces[0].uv_projection))
+
+
+# -- A UV transform has to be usable (#344) -----------------------------------
+
+
+func test_a_uv_transform_that_is_not_numbers_is_refused():
+	var brush := _make_brush("b1")
+	root.set_face_uv_params("b1", 0, Vector2(2, 2), Vector2(1, 1), 0.5)
+	var kept := brush.faces[0].to_dict()
+	var bad := [
+		[Vector2(NAN, 1), Vector2.ZERO, 0.0],
+		[Vector2.ONE, Vector2(INF, 0), 0.0],
+		[Vector2.ONE, Vector2.ZERO, NAN],
+	]
+	for entry in bad:
+		root.set_face_uv_params("b1", 0, entry[0], entry[1], entry[2])
+		assert_eq(brush.faces[0].to_dict(), kept, "%s must not stick" % str(entry))
+	for uv in brush.faces[0].custom_uvs:
+		assert_true(uv.is_finite(), "no non-finite UV reached the mesh")
+
+
+func test_a_uv_scale_of_zero_is_refused():
+	var brush := _make_brush("b1")
+	root.set_face_uv_params("b1", 0, Vector2(2, 2), Vector2.ZERO, 0.0)
+	root.set_face_uv_params("b1", 0, Vector2(0, 2), Vector2.ZERO, 0.0)
+	assert_almost_eq(brush.faces[0].uv_scale.x, 2.0, 0.0001, "zero collapses the face")
+	root.set_face_uv_params("b1", 0, Vector2(2, 0), Vector2.ZERO, 0.0)
+	assert_almost_eq(brush.faces[0].uv_scale.y, 2.0, 0.0001)
+
+
+func test_a_negative_uv_scale_is_allowed_because_it_mirrors():
+	var brush := _make_brush("b1")
+	root.set_face_uv_params("b1", 0, Vector2(-1, 1), Vector2.ZERO, 0.0)
+	assert_almost_eq(brush.faces[0].uv_scale.x, -1.0, 0.0001)

--- a/tests/test_structure_dock_commands.gd
+++ b/tests/test_structure_dock_commands.gd
@@ -22,6 +22,10 @@ func before_each() -> void:
 	root.commit_freeze = false
 	root.hflevel_autosave_enabled = false
 	add_child_autoqfree(root)
+	# A material slot has to name something in the palette, and slot 7 below is
+	# a marker for "this face was painted".
+	while root.get_materials().size() < 12:
+		root.add_material_to_palette(StandardMaterial3D.new())
 	dock.level_root = root
 	_choose_arch()
 

--- a/tests/test_structure_preview.gd
+++ b/tests/test_structure_preview.gd
@@ -22,6 +22,10 @@ func before_each() -> void:
 	root.commit_freeze = false
 	root.hflevel_autosave_enabled = false
 	add_child_autoqfree(root)
+	# A material slot has to name something in the palette, and slot 7 below is
+	# a marker for "this face was painted".
+	while root.get_materials().size() < 12:
+		root.add_material_to_palette(StandardMaterial3D.new())
 	dock.level_root = root
 	_choose("arch")
 	_open_section()


### PR DESCRIPTION
Fixes #343, fixes #344, fixes #345. One root cause: a face field was written from a caller's integer without being checked against what the field means, and every one of them is persisted.

- A material slot could be any integer. The three assign paths — plus `assign_material_to_selected_faces()`, which the issue did not name but had the same hole — refuse a slot that is not `-1` and not an index into the palette. `validate_level()` already reported a slot past the end of the palette; it now reports one below the default too, which is the half that was missing.
- `set_face_uv_params()` refuses a non-finite scale, offset or rotation, and a scale component of zero. A negative scale still goes through deliberately: it mirrors the texture.
- `reproject_face_uvs()` and `assign_material_and_reproject()` refuse a projection outside the enum, `FaceData.from_dict()` falls back to planar Z so a file cannot smuggle one in, and `validate_level()` reports and resets one already on a face.

Four existing fixtures used slot numbers as markers for "this face was painted" with no palette behind them. They seed one now — they were relying on the missing check.

Docs: CHANGELOG and the FaceData data model section of the texture and materials guide.