### PR TITLE
Give a duplicated entity its own address, and make an output be wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Fixed
+- **Duplicating a wired entity left two entities on one address** (#341). I/O is
+  addressed by the authored name, and `build_duplicate_entity_info()` copied it
+  along with everything else — so `find_entities_by_name("door_1")` returned both,
+  every output aimed at `door_1` fired at both, and there was no way to aim at
+  one of them. It survived a save and a `.map` export, where the ambiguity became
+  the compiler's problem. The copy takes the next free name now: `door_1` becomes
+  `door_2`, and a name with no number on the end gets one. Its own outputs are
+  left alone on purpose — a copy of a button should go on firing at the door the
+  original fired at. `validate_level()` reports two entities sharing an address,
+  which a paste, an import or a hand edit can also produce.
+- **Entity outputs accepted blank names and a NaN delay** (#342). All of them
+  reached the exported `.map` as lines that read like wiring and do nothing, and
+  this project's own importer drops three of six such lines on the way back in —
+  so the dock showed connections the round trip had already lost.
+  `add_entity_output()` refuses a blank output, target or input name and a delay
+  that is not zero or more seconds. `validate_level()` reports a connection with
+  a field missing, and the `.map` importer now counts the lines it drops and says
+  so in the import result instead of dropping them in silence. A line only counts
+  as a loss when it has the five fields of a connection and fails on one of them;
+  an ordinary entity property is not wiring.
 - **A face's material slot was never checked against the palette** (#343). Any
   integer could be assigned and was stored, saved and read back, so the bake, the
   `.map` exporter and the UV editor each fell back to something that is not the

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,483 tests across 179 test scripts (3,476 passing plus seven intentional no-assert safety tests; 17,763 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,492 tests across 179 test scripts (3,485 passing plus seven intentional no-assert safety tests; 17,783 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,483 tests** across **179 scripts** (**3,476 passing** plus seven intentional no-assert safety tests; **17,763 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,492 tests** across **179 scripts** (**3,485 passing** plus seven intentional no-assert safety tests; **17,783 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3476%20passing-brightgreen" alt="3476 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3485%20passing-brightgreen" alt="3485 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,483 tests across 179 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,492 tests across 179 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/map_io.gd
+++ b/addons/hammerforge/map_io.gd
@@ -111,7 +111,21 @@ static func parse_map_text(text: String) -> Dictionary:
 		var origin = _parse_origin(str(props.get("origin", "")))
 		var has_brushes = entity.get("brushes", []).size() > 0
 		var authored := str(props.get("targetname", ""))
-		var connections := _connections_from_pairs(entity.get("pairs", []))
+		var unusable_connections := [0]
+		var connections := _connections_from_pairs(entity.get("pairs", []), unusable_connections)
+		if unusable_connections[0] > 0:
+			(
+				errors
+				. append(
+					(
+						"%s: dropped %d I/O line(s) with a missing field or a delay that is not a number"
+						% [
+							entity_class if entity_class != "" else "entity",
+							unusable_connections[0]
+						]
+					)
+				)
+			)
 		if not has_brushes and entity_class != "":
 			entity_points.append(
 				{
@@ -146,7 +160,11 @@ static func parse_map_text(text: String) -> Dictionary:
 ## Read from the ordered pairs rather than the properties dictionary, so two
 ## outputs on the same event both survive. A reserved key is never a connection,
 ## and everything else has to look like one to be taken as one.
-static func _connections_from_pairs(pairs: Array) -> Array:
+## `dropped` is a one-element array the count of unusable lines is written into,
+## so the importer can say what it lost rather than losing it in silence. A line
+## only counts as lost when it has the five fields of a connection and fails on
+## one of them; an ordinary entity property is not wiring and is not a loss.
+static func _connections_from_pairs(pairs: Array, dropped: Array) -> Array:
 	var out: Array = []
 	for pair in pairs:
 		if not (pair is Array) or pair.size() != 2:
@@ -154,9 +172,12 @@ static func _connections_from_pairs(pairs: Array) -> Array:
 		var key := str(pair[0])
 		if key in RESERVED_ENTITY_KEYS:
 			continue
-		var connection := parse_connection(key, str(pair[1]))
+		var value := str(pair[1])
+		var connection := parse_connection(key, value)
 		if not connection.is_empty():
 			out.append(connection)
+		elif value.split(",", true).size() == 5:
+			dropped[0] = int(dropped[0]) + 1
 	return out
 
 

--- a/addons/hammerforge/systems/hf_entity_system.gd
+++ b/addons/hammerforge/systems/hf_entity_system.gd
@@ -207,7 +207,36 @@ func build_duplicate_info(entity: DraftEntity, offset: Vector3) -> Dictionary:
 	transform.origin += offset
 	info["transform"] = transform
 	info["name"] = _unique_entity_copy_name(str(entity.name))
+	# The authored name is the address I/O is wired by, so a copy that keeps it
+	# answers to everything aimed at the original and there is no way to aim at
+	# one of them. The copy's own outputs are left as they are on purpose: a copy
+	# of a button should go on firing at the door it fired at.
+	if info.has("entity_name"):
+		info["entity_name"] = unique_authored_name(str(info["entity_name"]))
 	return info
+
+
+## An authored name nothing in the level already answers to.
+##
+## A trailing number is counted on, because that is how a mapper names a run of
+## them — `door_1` becomes `door_2` — and a name without one gets `_2` added.
+## Both node names and authored names are checked, since an output resolves
+## against either.
+func unique_authored_name(source_name: String) -> String:
+	if source_name.strip_edges() == "":
+		return source_name
+	var taken := build_name_index()
+	if not taken.has(source_name):
+		return source_name
+	var stem := source_name
+	var counter := 2
+	var underscore := source_name.rfind("_")
+	if underscore > 0 and source_name.substr(underscore + 1).is_valid_int():
+		stem = source_name.substr(0, underscore)
+		counter = int(source_name.substr(underscore + 1)) + 1
+	while taken.has("%s_%d" % [stem, counter]):
+		counter += 1
+	return "%s_%d" % [stem, counter]
 
 
 func create_entities_from_infos(infos: Array) -> void:
@@ -297,6 +326,22 @@ func add_entity_output(
 	fire_once: bool = false
 ) -> void:
 	if not entity:
+		return
+	# Every one of these reaches the exported `.map` as a line that reads like
+	# wiring and does nothing, and this project's own importer drops it again on
+	# the way back in — so the dock shows a connection that the round trip has
+	# already lost.
+	if output_name.strip_edges() == "":
+		HFLog.warn("HFEntitySystem: an output needs a name")
+		return
+	if target_name.strip_edges() == "":
+		HFLog.warn("HFEntitySystem: an output needs something to fire at")
+		return
+	if input_name.strip_edges() == "":
+		HFLog.warn("HFEntitySystem: an output needs an input to fire")
+		return
+	if not is_finite(delay) or delay < 0.0:
+		HFLog.warn("HFEntitySystem: an output delay must be zero or more seconds")
 		return
 	var outputs: Array = entity.get_meta("entity_io_outputs", [])
 	(

--- a/addons/hammerforge/systems/hf_validation_system.gd
+++ b/addons/hammerforge/systems/hf_validation_system.gd
@@ -165,6 +165,44 @@ func validate(auto_fix: bool = false) -> Dictionary:
 			if root.brush_system:
 				root.brush_system._refresh_brush_previews()
 
+	# Two entities answering to the same authored name, and wiring with a field
+	# missing. A level can get either from a paste, a `.map` import or a hand
+	# edit, so the check at the setter is not enough on its own.
+	var seen_names: Dictionary = {}
+	var duplicate_names: Array = []
+	var broken_connections := 0
+	if root.entities_node:
+		for child in root.entities_node.get_children():
+			var authored := str(child.get_meta("entity_name", "")).strip_edges()
+			if authored != "":
+				if seen_names.has(authored):
+					if not (authored in duplicate_names):
+						duplicate_names.append(authored)
+				seen_names[authored] = true
+			for connection in child.get_meta("entity_io_outputs", []):
+				if not (connection is Dictionary):
+					broken_connections += 1
+					continue
+				var fields: Dictionary = connection
+				var delay = fields.get("delay", 0.0)
+				if (
+					str(fields.get("output_name", "")).strip_edges() == ""
+					or str(fields.get("target_name", "")).strip_edges() == ""
+					or str(fields.get("input_name", "")).strip_edges() == ""
+					or not is_finite(float(delay))
+					or float(delay) < 0.0
+				):
+					broken_connections += 1
+	for authored in duplicate_names:
+		issues.append("Entity name '%s' is answered to by more than one entity" % authored)
+	if broken_connections > 0:
+		issues.append(
+			(
+				"I/O connections with a missing field or a delay that is not one: %d"
+				% broken_connections
+			)
+		)
+
 	# Paint layers without grid
 	if root.paint_layers:
 		var grid_template: HFPaintGrid = root.paint_layers.base_grid

--- a/docs/HammerForge_Data_Portability.md
+++ b/docs/HammerForge_Data_Portability.md
@@ -49,6 +49,7 @@ This document describes how to move data in and out of HammerForge safely.
   }
   ```
 
+  - A line with the five fields of a connection but a blank target or input, or a delay that is not a number, cannot be used and is dropped on import. The import result names how many were dropped rather than losing them in silence. The editor refuses to create one, so a file carrying them was written somewhere else or by hand.
   - There is no `connections { }` block, because `.map` entity bodies are key/value lines and nothing else: a nested brace inside an entity is read as a brush by every parser including this one, so a block would not survive its own round trip.
   - One line per connection, so two outputs on the same event both reach the file. The import reads the key/value lines in file order rather than through a dictionary, which would keep only the last of a repeated key.
   - A line is read back as a connection only if it has five comma-separated fields, a numeric delay, and a target and input that are actually there. An ordinary entity property does not look like that, so wiring is told apart from settings without a naming rule on the key.

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -679,7 +679,7 @@ The primary toolbar keeps the everyday path visible: **Draw**, **Select**, **Pai
 - Entity palette with drag-and-drop placement.
 - Selected `DraftEntity` nodes use the same managed **Delete**, **Ctrl+D Duplicate**, arrow-key X/Z nudge, and PageUp/PageDown Y nudge workflow as brushes, including HammerForge undo/state cleanup.
 - **Entity Properties** (collapsible, context-hidden): auto-generated typed controls based on entity definition. Only visible when an entity is selected.
-- **Entity I/O** (collapsible, context-hidden): Output, Target, Input, Parameter fields. Delay (seconds) and Fire Once checkbox. Add Output / Remove buttons and connection ItemList. Only visible when an entity is selected; connections auto-refresh on selection change. **Show I/O Lines** checkbox to visualize connections in the viewport.
+- **Entity I/O** (collapsible, context-hidden): Output, Target, Input, Parameter fields. Delay (seconds) and Fire Once checkbox. Add Output / Remove buttons and connection ItemList. An output needs a name, a target and an input — blank is refused rather than added as a connection that does nothing — and the delay has to be zero seconds or more. Only visible when an entity is selected; connections auto-refresh on selection change. **Show I/O Lines** checkbox to visualize connections in the viewport.
 - **I/O Wiring** (collapsible, context-hidden, collapsed by default): Quick-wire form (output name, target dropdown, input name, parameter, delay, fire-once). Only visible when an entity is selected. Connection summary shows triggers and triggered-by counts. **Highlight** toggle button pulses all linked entities in the viewport. **Connection Presets** picker with 6 built-in patterns (Door+Light+Sound, Button→Toggle, Alarm Sequence, Pickup+Remove, Damage+Break, Timer Lights) plus user-saved presets. Target tag mapping lets you assign preset target placeholders to actual entity names.
 
 > **Progressive disclosure:** During greyboxing, the Objects tab shows only the entity palette and create button. Entity Properties, Entity I/O, and I/O Wiring sections appear automatically when you select an entity, keeping the UI clean when you're focused on shapes and layout.
@@ -1264,7 +1264,7 @@ Modifier keys
 
 General keyboard shortcuts
 - Delete: remove selected brushes and DraftEntities.
-- Ctrl+D: duplicate selected brushes and DraftEntities.
+- Ctrl+D: duplicate selected brushes and DraftEntities. A copy of a named entity takes the next free name (`door_1` becomes `door_2`), because the authored name is the address I/O is aimed at and two entities cannot share one. The copy keeps its own outputs, so a duplicated button goes on firing at what the original fired at.
 - Arrow keys: nudge selected brushes and DraftEntities (XZ plane).
 - PageUp/PageDown: nudge selected brushes and DraftEntities (Y axis).
 - Escape: clear selection.

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,483 tests across 179 scripts**: **3,476 passing tests**, seven intentional no-assert safety tests, and **17,763 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,492 tests across 179 scripts**: **3,485 passing tests**, seven intentional no-assert safety tests, and **17,783 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_entity_names_and_io.gd
+++ b/tests/test_entity_names_and_io.gd
@@ -220,3 +220,112 @@ func test_an_imported_output_is_not_also_an_entity_property():
 		assert_false(node.entity_data.has("OnLit"), "Wiring should not land in entity_data")
 		assert_false(node.entity_data.has("targetname"), "and nor should the name")
 	DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+
+
+# ===========================================================================
+# A duplicate must not answer to the original's address (#341)
+# ===========================================================================
+
+
+func test_duplicating_a_named_entity_gives_the_copy_its_own_name():
+	var door := _point_entity("func_door")
+	door.set_meta("entity_name", "door_1")
+	var info: Dictionary = root.build_duplicate_entity_info(door, Vector3(64, 0, 0))
+	root.create_entities_from_infos([info])
+	assert_eq(root.find_entities_by_name("door_1").size(), 1, "only the original answers to door_1")
+	assert_eq(root.find_entities_by_name("door_2").size(), 1, "the copy took the next number")
+
+
+func test_a_run_of_duplicates_keeps_taking_the_next_free_number():
+	var door := _point_entity("func_door")
+	door.set_meta("entity_name", "door_1")
+	for _i in 3:
+		root.create_entities_from_infos([root.build_duplicate_entity_info(door, Vector3(64, 0, 0))])
+	for expected in ["door_1", "door_2", "door_3", "door_4"]:
+		assert_eq(root.find_entities_by_name(expected).size(), 1, "%s is one entity" % expected)
+
+
+func test_a_name_without_a_number_gets_one():
+	var door := _point_entity("func_door")
+	door.set_meta("entity_name", "door")
+	root.create_entities_from_infos([root.build_duplicate_entity_info(door, Vector3.ZERO)])
+	assert_eq(root.find_entities_by_name("door").size(), 1)
+	assert_eq(root.find_entities_by_name("door_2").size(), 1)
+
+
+func test_a_copy_keeps_firing_at_what_the_original_fired_at():
+	var door := _point_entity("func_door")
+	door.set_meta("entity_name", "door_1")
+	var button := _point_entity("func_button")
+	button.set_meta("entity_name", "button_1")
+	root.add_entity_output(button, "OnPressed", "door_1", "Open")
+	root.create_entities_from_infos([root.build_duplicate_entity_info(button, Vector3.ZERO)])
+	var copies: Array = root.find_entities_by_name("button_2")
+	assert_eq(copies.size(), 1, "the copy got its own address")
+	var outputs: Array = root.get_entity_outputs(copies[0])
+	assert_eq(outputs.size(), 1, "and kept its wiring")
+	assert_eq(str(outputs[0]["target_name"]), "door_1", "still aimed at the same door")
+
+
+func test_validate_reports_two_entities_on_one_authored_name():
+	var a := _point_entity("func_door")
+	a.set_meta("entity_name", "door_1")
+	var b := _point_entity("func_door")
+	b.set_meta("entity_name", "door_1")
+	var report: Dictionary = root.validate_level(false)
+	var found := false
+	for issue in report.get("issues", []):
+		if str(issue).findn("door_1") >= 0:
+			found = true
+	assert_true(found, "a shared address is a level defect")
+
+
+# ===========================================================================
+# An output has to be wiring (#342)
+# ===========================================================================
+
+
+func test_an_output_with_a_missing_field_is_refused():
+	var button := _point_entity("func_button")
+	root.add_entity_output(button, "", "door_1", "Open")
+	root.add_entity_output(button, "OnPressed", "", "Open")
+	root.add_entity_output(button, "OnPressed", "door_1", "")
+	root.add_entity_output(button, "OnPressed", "   ", "Open")
+	assert_eq(root.get_entity_outputs(button).size(), 0, "none of those is a connection")
+
+
+func test_an_output_with_a_delay_that_is_not_one_is_refused():
+	var button := _point_entity("func_button")
+	for delay in [NAN, INF, -INF, -5.0]:
+		root.add_entity_output(button, "OnPressed", "door_1", "Open", "", delay)
+	assert_eq(root.get_entity_outputs(button).size(), 0)
+	root.add_entity_output(button, "OnPressed", "door_1", "Open", "", 0.5)
+	assert_eq(root.get_entity_outputs(button).size(), 1, "a real delay still goes through")
+
+
+func test_wiring_that_survives_export_survives_the_import_back():
+	var button := _point_entity("func_button")
+	button.set_meta("entity_name", "button_1")
+	root.add_entity_output(button, "OnPressed", "door_1", "Open", "", 0.25)
+	_box("solid")
+	var text: String = MapIOType.export_map_from_level(root, QuakeAdapter.new())
+	var parsed: Dictionary = MapIOType.parse_map_text(text)
+	var total := 0
+	for entity in parsed.get("entities", []):
+		total += (entity.get("entity_io_outputs", []) as Array).size()
+	assert_eq(total, 1, "the round trip keeps the connection the editor showed")
+	assert_eq(parsed.get("errors", []).size(), 0, "and drops nothing on the way")
+
+
+func test_the_importer_says_when_it_drops_a_connection():
+	var text := (
+		'{\n"classname" "func_button"\n"origin" "0 0 0"\n"targetname" "button_1"\n'
+		+ '"OnPressed" "door_1,Open,,0.0,0"\n"OnPressed" "door_1,,,0.0,0"\n}\n'
+	)
+	var parsed: Dictionary = MapIOType.parse_map_text(text)
+	var errors: Array = parsed.get("errors", [])
+	var mentioned := false
+	for err in errors:
+		if str(err).findn("dropped") >= 0:
+			mentioned = true
+	assert_true(mentioned, "a line that looks like wiring and is not must be reported")

--- a/tests/test_entity_props.gd
+++ b/tests/test_entity_props.gd
@@ -318,14 +318,20 @@ func test_roundtrip_preserves_the_authored_entity_name():
 	assert_eq(str(restored.get_meta("entity_name", "")), "key_door_target")
 
 
-func test_duplicate_info_keeps_the_authored_entity_name():
+func test_duplicate_info_gives_the_copy_an_authored_name_of_its_own():
+	# #251 was the copy coming back with no authored name at all, which left it
+	# wired to nothing. It carries one, but it has to be its own: the authored
+	# name is the address, and two entities cannot answer to one.
 	var e = _make_draft_entity("info_target")
 	e.set_meta("entity_name", "key_door_target")
 
 	var dup = sys.restore_entity_from_info(sys.build_duplicate_info(e, Vector3(64, 0, 0)))
 
 	assert_not_null(dup)
-	assert_eq(str(dup.get_meta("entity_name", "")), "key_door_target")
+	var copied := str(dup.get_meta("entity_name", ""))
+	assert_ne(copied, "", "a copy still has to be addressable")
+	assert_ne(copied, "key_door_target", "and not at the original's address")
+	assert_string_starts_with(copied, "key_door_target", "named after what it came from")
 
 
 func test_roundtrip_without_a_name_sets_no_meta():


### PR DESCRIPTION
Fixes #341, fixes #342. Both are the authored name and the wiring hung off it.

A duplicate copied the authored name, so `find_entities_by_name("door_1")` returned two entities and every output aimed at `door_1` fired at both. The copy takes the next free name now — `door_1` becomes `door_2`, a name with no number gets one — and keeps its own outputs, because a copied button should go on firing at the door the original fired at.

`add_entity_output()` accepted blank names and a NaN or negative delay, all of which reached the exported `.map` and three of which this project's own importer drops on the way back. Refused at the setter; the importer counts the lines it drops and names the count in the import result, so `.map` stops losing wiring in silence. A line only counts as a loss when it has the five fields of a connection and fails on one of them — an ordinary entity property is not wiring.

`validate_level()` reports two entities on one authored name and a connection with a field missing, since a paste, an import or a hand edit can produce either without going through the setters.

One existing test, from #251, asserted that a duplicate keeps the original's authored name. #251 was about the copy coming back with *no* name and wired to nothing; it still has one, it just has to be its own. Rewritten to say that.

Docs: CHANGELOG, the user guide's Entity I/O and duplicate entries, and the data portability note on connection lines.