### PR TITLE
Read a level state before clearing the level for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Fixed
+- **A malformed `.hflevel` emptied the level instead of refusing to load**
+  (#347). `restore_state()` cleared the level and then read the state it had been
+  handed, so a key holding the wrong kind of thing gave a raw engine error with
+  the level already gone. It is not an internal-only path: `load_hflevel()` lands
+  there, so does undo, a prefab drop and a whole-level replace, and a `.hflevel`
+  is JSON on disk that gets truncated, hand edited, written by an older version
+  or synced half finished. `HFValidation.level_state_problem()` checks the shape
+  before anything is cleared, and a state that does not pass leaves the level
+  exactly as it was and says why. Only the keys `restore_state()` types are
+  checked, and only when present, so a state from a newer version is not refused
+  for carrying something extra.
+  - **One unreadable entry costs that entry, not the load.** A brush or entity
+    entry that is not a dictionary is skipped and counted, the way the `.map`
+    importer already handles a malformed brush (#318), and the count is reported.
+  - Restoring a state no longer writes `pending` and `committed` flags back into
+    the caller's own dictionaries.
+- **A brush with a size that is not a size was built rather than skipped**
+  (#348). #289 and #311 made `create_brush_from_info()` coerce a zero or negative
+  size, and `maxf()` passes a NaN straight through, so a state restore — the load
+  path, and the undo replay — built a brush whose AABB then poisoned the level
+  AABB, the chunking and the saved file, with no editor action able to fix it.
+  A non-finite size is refused at that same entry point, so every caller gets it:
+  there is a nearest size a user plainly meant by zero, and there is no nearest
+  size to a NaN.
 - **Duplicating a wired entity left two entities on one address** (#341). I/O is
   addressed by the authored name, and `build_duplicate_entity_info()` copied it
   along with everything else — so `find_entities_by_name("door_1")` returned both,

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,492 tests across 179 test scripts (3,485 passing plus seven intentional no-assert safety tests; 17,783 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,498 tests across 179 test scripts (3,491 passing plus seven intentional no-assert safety tests; 17,794 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,492 tests** across **179 scripts** (**3,485 passing** plus seven intentional no-assert safety tests; **17,783 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,498 tests** across **179 scripts** (**3,491 passing** plus seven intentional no-assert safety tests; **17,794 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3485%20passing-brightgreen" alt="3485 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3491%20passing-brightgreen" alt="3491 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,492 tests across 179 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,498 tests across 179 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/hf_validation.gd
+++ b/addons/hammerforge/hf_validation.gd
@@ -77,3 +77,48 @@ static func require_nodes(root: Object, property_names: Array, context: String =
 		push_warning("[HFValidation] missing on root: %s (%s)" % [missing, context])
 		return false
 	return true
+
+
+## What is wrong with the shape of a level state, or "" when nothing is.
+##
+## `restore_state()` reads a state into typed locals, so a key holding the wrong
+## kind of thing is an engine error mid-restore — and by then the level has
+## already been cleared, so a malformed `.hflevel` does not fail to load, it
+## destroys what was loaded and then fails. A `.hflevel` is JSON on disk: it gets
+## truncated by a full disk, edited by hand, written by an older version, or
+## synced half finished, and every one of those arrives here.
+##
+## Only the keys `restore_state()` types are checked, and only when present, so a
+## state written by a newer version is not refused for carrying something extra.
+static func level_state_problem(state: Dictionary) -> String:
+	const ARRAY_KEYS := [
+		"brushes",
+		"pending",
+		"committed",
+		"entities",
+		"materials",
+		"generators",
+		"duplicators",
+		"hollows",
+		"paint_layers",
+		"paint_connectors",
+	]
+	const DICTIONARY_KEYS := [
+		"face_selection",
+		"visgroups",
+		"groups",
+		"terrain_regions",
+		"floor",
+		"sun",
+		"prefab_instances",
+	]
+	for key in ARRAY_KEYS:
+		if state.has(key) and not (state[key] is Array):
+			return "'%s' should be a list and is a %s" % [key, type_string(typeof(state[key]))]
+	for key in DICTIONARY_KEYS:
+		if state.has(key) and not (state[key] is Dictionary):
+			return (
+				"'%s' should be a set of values and is a %s"
+				% [key, type_string(typeof(state[key]))]
+			)
+	return ""

--- a/addons/hammerforge/systems/hf_brush_system.gd
+++ b/addons/hammerforge/systems/hf_brush_system.gd
@@ -118,8 +118,16 @@ static func _usable_size(raw) -> Vector3:
 func create_brush_from_info(info: Dictionary) -> Node:
 	if info.is_empty():
 		return null
+	var raw_size = info.get("size", root.drag_size_default)
+	if raw_size is Vector3 and not (raw_size as Vector3).is_finite():
+		# A zero or negative size is coerced, because there is a nearest size a
+		# user plainly meant. There is no nearest size to a NaN, and once one is
+		# on a brush the AABB, the level AABB, the chunking and the saved file all
+		# take it and no editor action gets the brush back.
+		HFLog.warn("HFBrushSystem: brush size %s is not a size" % str(raw_size))
+		return null
 	var shape = info.get("shape", root.BrushShape.BOX)
-	var size = _usable_size(info.get("size", root.drag_size_default))
+	var size = _usable_size(raw_size)
 	var sides = int(info.get("sides", 4))
 	var operation = info.get("operation", CSGShape3D.OPERATION_UNION)
 	var committed = bool(info.get("committed", false))

--- a/addons/hammerforge/systems/hf_state_system.gd
+++ b/addons/hammerforge/systems/hf_state_system.gd
@@ -142,8 +142,30 @@ func capture_state(include_transient: bool = true) -> Dictionary:
 	return state
 
 
+## One brush out of a state entry, or null when the entry is not one.
+##
+## `extra` is merged in rather than written onto the caller's dictionary, because
+## the state a caller handed in is not ours to edit — the old code set
+## `info["pending"] = true` on the dictionary it was given.
+func _restored_brush(info, extra: Dictionary) -> Node:
+	if not (info is Dictionary):
+		return null
+	var entry: Dictionary = (info as Dictionary).duplicate()
+	for key in extra:
+		entry[key] = extra[key]
+	return root.create_brush_from_info(entry)
+
+
 func restore_state(state: Dictionary) -> void:
 	if state.is_empty():
+		return
+	# Before anything is cleared. The order is what made a malformed state costly:
+	# it did not fail to load, it destroyed what was loaded and then failed.
+	var problem := HFValidation.level_state_problem(state)
+	if problem != "":
+		HFLog.warn("HFStateSystem: this level state cannot be read - %s" % problem)
+		if root.has_signal("user_message"):
+			root.user_message.emit("Level not loaded: %s" % problem, 2)
 		return
 	root.clear_brushes()
 	root.entity_system.clear_entities()
@@ -171,19 +193,27 @@ func restore_state(state: Dictionary) -> void:
 		root.face_selection.clear()
 		root._apply_face_selection()
 	root._brush_id_counter = int(state.get("id_counter", 0))
+	# One unreadable entry costs that entry, not the load. The `.map` importer
+	# already works this way for a malformed brush (#318), and a state can hold
+	# one for the same reasons — an older version, a partial write, a hand edit.
+	var skipped := 0
 	var brushes: Array = state.get("brushes", [])
 	for info in brushes:
-		root.create_brush_from_info(info)
+		if not _restored_brush(info, {}):
+			skipped += 1
 	var pending: Array = state.get("pending", [])
 	for info in pending:
-		info["pending"] = true
-		root.create_brush_from_info(info)
+		if not _restored_brush(info, {"pending": true}):
+			skipped += 1
 	var committed: Array = state.get("committed", [])
 	for info in committed:
-		info["committed"] = true
-		root.create_brush_from_info(info)
+		if not _restored_brush(info, {"committed": true}):
+			skipped += 1
 	var entities: Array = state.get("entities", [])
 	for info in entities:
+		if not (info is Dictionary):
+			skipped += 1
+			continue
 		var entity = root.entity_system.restore_entity_from_info(info)
 		if entity:
 			if info.has("visgroups"):
@@ -232,6 +262,10 @@ func restore_state(state: Dictionary) -> void:
 		root._last_bake_preview_mode = 0
 	if root.prefab_system and state.has("prefab_instances"):
 		root.prefab_system.restore_state(state["prefab_instances"])
+	if skipped > 0:
+		HFLog.warn("HFStateSystem: skipped %d entry this level could not use" % skipped)
+		if root.has_signal("user_message"):
+			root.user_message.emit("Skipped %d unreadable entry in this level" % skipped, 1)
 
 
 func capture_full_state() -> Dictionary:

--- a/docs/HammerForge_MVP_GUIDE.md
+++ b/docs/HammerForge_MVP_GUIDE.md
@@ -124,6 +124,7 @@ See [DEVELOPMENT.md](https://github.com/saworbit/hammerforge/blob/main/DEVELOPME
 ### Persistence (`HFFileSystem` + `HFStateSystem`)
 - `HFStateSystem` captures and restores brush/entity/paint/settings state for undo/redo.
 - `HFFileSystem` handles .hflevel save/load, .map import/export, and glTF export with threaded I/O. Queued writes run in request order, a malformed `.map` is refused before the level is touched, and a failed region sidecar fails the save.
+- A `.hflevel` gets the same treatment. `HFStateSystem.restore_state()` checks the shape of a state before it clears anything, so a truncated or hand-edited file leaves the level as it was and says why rather than emptying it and then failing. One brush or entity entry it cannot read is skipped and counted; the load goes ahead.
 - See [Data Portability](HammerForge_Data_Portability.md) for fidelity boundaries and save-safety behaviour.
 
 ## High-Level Flow

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -1682,6 +1682,7 @@ Use Face Materials (optional):
 - Save .hflevel stores brushes, entities, settings, materials palette, face data, and paint layers.
 - Paint layer data includes per-chunk `material_ids`, `blend_weights` (+ _2/_3), optional `heightmap_b64`, `height_scale`, and terrain slot settings.
 - Load .hflevel restores them. Missing heightmap/material fields default to zero (backward-compatible).
+- A file whose shape cannot be read leaves the open level exactly as it was and reports why, rather than clearing it first. A single brush or entity in an otherwise good file that cannot be read is skipped, the rest loads, and the count of what was skipped is reported.
 - Autosave can write to a configurable path.
 
 ## Capturing Exit-Time Errors

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,492 tests across 179 scripts**: **3,485 passing tests**, seven intentional no-assert safety tests, and **17,783 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,498 tests across 179 scripts**: **3,491 passing tests**, seven intentional no-assert safety tests, and **17,794 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_state_snapshot_isolation.gd
+++ b/tests/test_state_snapshot_isolation.gd
@@ -94,3 +94,99 @@ func test_restore_paint_layers_keeps_terrain_slot_paths_from_an_untyped_payload(
 	assert_eq(layer.terrain_slot_paths[0], "res://grass.tres", "Slot path should survive the load")
 	assert_eq(layer.terrain_slot_uv_scales[0], 2.0, "Slot uv scale should survive the load")
 	assert_eq(layer.terrain_slot_tints[0], Color.RED, "Slot tint should survive the load")
+
+
+# ===========================================================================
+# A malformed state must not cost the level (#347, #348)
+# ===========================================================================
+
+
+func _level_with_one_brush() -> int:
+	root.create_brush_from_info({"size": Vector3(32, 32, 32), "brush_id": "keep"})
+	return root.draft_brushes_node.get_child_count()
+
+
+func test_a_state_of_the_wrong_shape_leaves_the_level_alone():
+	var before := _level_with_one_brush()
+	for bad in [
+		{"brushes": "not a list"},
+		{"entities": {"nope": 1}},
+		{"materials": 7},
+		{"face_selection": []},
+		{"visgroups": "nope"},
+	]:
+		root.restore_state(bad)
+		assert_eq(
+			root.draft_brushes_node.get_child_count(),
+			before,
+			"%s must not clear the level" % str(bad)
+		)
+
+
+func test_a_good_state_still_restores():
+	_level_with_one_brush()
+	var state: Dictionary = root.capture_state()
+	root.clear_brushes()
+	root.restore_state(state)
+	assert_eq(root.draft_brushes_node.get_child_count(), 1, "a real state still loads")
+
+
+func test_one_unreadable_brush_costs_that_brush_and_not_the_load():
+	(
+		root
+		. restore_state(
+			{
+				"brushes":
+				[
+					{"size": Vector3(32, 32, 32), "brush_id": "a"},
+					17,
+					{"size": Vector3(32, 32, 32), "brush_id": "b"},
+				],
+				"entities": [],
+				"materials": [],
+			}
+		)
+	)
+	assert_eq(root.draft_brushes_node.get_child_count(), 2, "the two good ones are here")
+
+
+func test_a_brush_with_a_size_that_is_not_a_size_is_skipped():
+	(
+		root
+		. restore_state(
+			{
+				"brushes":
+				[
+					{"shape": 0, "size": Vector3(NAN, NAN, NAN)},
+					{"shape": 0, "size": Vector3(32, 32, 32), "brush_id": "good"},
+				],
+				"entities": [],
+				"materials": [],
+			}
+		)
+	)
+	assert_eq(root.draft_brushes_node.get_child_count(), 1, "only the buildable one")
+	for child in root.draft_brushes_node.get_children():
+		assert_true(child.size.is_finite(), "no NaN size reached the level")
+
+
+func test_a_zero_size_is_still_coerced_rather_than_skipped():
+	# There is a nearest size a user plainly meant. There is no nearest size to
+	# a NaN, which is why only that one is refused.
+	root.restore_state(
+		{"brushes": [{"shape": 0, "size": Vector3.ZERO}], "entities": [], "materials": []}
+	)
+	assert_eq(root.draft_brushes_node.get_child_count(), 1)
+
+
+func test_restoring_a_state_does_not_write_back_into_it():
+	var state := {
+		"brushes": [{"size": Vector3(32, 32, 32)}],
+		"pending": [{"size": Vector3(32, 32, 32)}],
+		"entities": [],
+		"materials": [],
+	}
+	root.restore_state(state)
+	assert_false(
+		(state["pending"][0] as Dictionary).has("pending"), "the caller's state is not ours to edit"
+	)

--- a/tools/vibe/scenarios/persistence.gd
+++ b/tools/vibe/scenarios/persistence.gd
@@ -135,38 +135,85 @@ func _restore_across_levels() -> void:
 ## A state dictionary that did not come from `capture_state`: truncated, wrong
 ## types, absurd counts. A hand-edited `.hflevel` produces all three.
 func _junk_state() -> void:
-	var cases := {
-		"empty": {},
+	# Two kinds of bad state, and they are not the same failure.
+	#
+	# A state whose *shape* is wrong cannot be read at all, and the level must be
+	# left as it was: the cost used to be that it was cleared first, so a bad file
+	# took the good level with it.
+	#
+	# A state that can be read is a replacement, even when one entry in it is
+	# rubbish. The level is meant to become what the state says, so the check is
+	# that the entries it could read survived and the one it could not was
+	# dropped rather than built.
+	var good := {"shape": 0, "size": Vector3(64, 64, 64)}
+	var unreadable := {
 		"brushes is a string": {"brushes": "nope", "entities": [], "materials": []},
-		"a brush entry is a number": {"brushes": [42], "entities": [], "materials": []},
-		"a brush with no size": {"brushes": [{"shape": 0}], "entities": [], "materials": []},
-		"a brush with a NAN size":
-		{
-			"brushes": [{"shape": 0, "size": Vector3(NAN, NAN, NAN)}],
-			"entities": [],
-			"materials": []
-		},
 		"entities is a dictionary": {"brushes": [], "entities": {}, "materials": []},
-		"materials holds junk": {"brushes": [], "entities": [], "materials": [1, "two", null]},
+		"face_selection is a list": {"brushes": [], "face_selection": [], "materials": []},
 	}
-	for label in cases:
+	var readable := {
+		"empty": [{}, -1],
+		"a brush entry is a number": [{"brushes": [42, good], "entities": [], "materials": []}, 1],
+		"a brush with no size": [{"brushes": [{"shape": 0}], "entities": [], "materials": []}, 1],
+		"a brush with a NAN size":
+		[
+			{
+				"brushes": [{"shape": 0, "size": Vector3(NAN, NAN, NAN)}, good],
+				"entities": [],
+				"materials": []
+			},
+			1
+		],
+		"materials holds junk":
+		[{"brushes": [good], "entities": [], "materials": [1, "two", null]}, 1],
+	}
+
+	note("--- a state whose shape cannot be read must leave the level alone")
+	for label in unreadable:
 		var root: Node3D = await fresh_root()
-		# Furnished first, deliberately. The cost of a malformed state is not
-		# that it fails to load -- it is that the level is cleared before the
-		# state it was handed is looked at, so a bad file takes the good level
-		# with it.
 		_furnish(root)
 		await frame()
 		var before_count: int = root.get_live_brush_count()
-		root.restore_state(cases[label])
+		root.restore_state(unreadable[label])
 		await frame()
+		note(
+			"restore_state with %s" % label,
+			"%d brushes (was %d)" % [root.get_live_brush_count(), before_count]
+		)
+		if root.get_live_brush_count() < before_count:
+			flag(
+				"restore_state with %s emptied a level it could not read" % label,
+				"%d brushes before, %d after" % [before_count, root.get_live_brush_count()]
+			)
+
+	note("--- a state that can be read replaces the level, minus what it could not use")
+	for label in readable:
+		var root: Node3D = await fresh_root()
+		_furnish(root)
+		await frame()
+		var before_count: int = root.get_live_brush_count()
+		var entry: Array = readable[label]
+		var expected: int = int(entry[1])
+		root.restore_state(entry[0])
+		await frame()
+		var after_count: int = root.get_live_brush_count()
 		note(
 			"restore_state with %s" % label,
 			(
 				"%d brushes (was %d), %d materials"
-				% [root.get_live_brush_count(), before_count, root.get_materials().size()]
+				% [after_count, before_count, root.get_materials().size()]
 			)
 		)
+		if expected >= 0 and after_count != expected:
+			flag(
+				"restore_state with %s built %d brushes, not %d" % [label, after_count, expected],
+				"an entry it could not read should be skipped, and the rest should be built"
+			)
+		if expected < 0 and after_count != before_count:
+			flag(
+				"restore_state with an empty state changed the level",
+				"%d brushes before, %d after" % [before_count, after_count]
+			)
 		var junk_materials := 0
 		for m in root.get_materials():
 			if m != null and not (m is Material):
@@ -179,11 +226,5 @@ func _junk_state() -> void:
 				),
 				"get_materials() hands those back to every caller that then reads a Material off them"
 			)
-		if before_count > 0 and root.get_live_brush_count() < before_count:
-			known(
-				347,
-				"restore_state with %s emptied a level it could not replace" % label,
-				"%d brushes before, %d after" % [before_count, root.get_live_brush_count()]
-			)
 		for problem in HFVibe.check_invariants(root):
-			known(348, "restore_state with %s broke an invariant" % label, problem)
+			flag("restore_state with %s broke an invariant" % label, problem)


### PR DESCRIPTION
Fixes #347, fixes #348.

`restore_state()` cleared the level and then read the state, so a truncated or hand-edited `.hflevel` gave a raw engine error with the level already gone. `HFValidation.level_state_problem()` checks the shape first; a state that does not pass leaves the level exactly as it was and reports why. Only the keys `restore_state()` types are checked, and only when present, so a file from a newer version is not refused for carrying something extra.

One unreadable brush or entity entry is skipped and counted rather than failing the load, which is how the `.map` importer already treats a malformed brush (#318).

A non-finite brush size is refused in `create_brush_from_info()` — the same entry point #289 and #311 went through, so every caller gets it. Zero and negative stay coerced: there is a nearest size a user plainly meant by zero, and there is no nearest size to a NaN.

While restoring, the caller's own state dictionaries are no longer written back into with `pending` and `committed` flags.

The persistence vibe scenario was checking both kinds of bad state with one rule — did the brush count drop — which was right while every case was a shape failure. Three of them are now readable states that genuinely say the level has no brushes, so the scenario asks the two questions separately: an unreadable state must leave the level alone, and a readable one replaces it minus the entries it could not use. It runs clean.

Docs: CHANGELOG, the user guide's Save/Load section, and the persistence note in the MVP guide.