### PR TITLE
Bound the terrain settings that take a number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Fixed
+- **The heightmap scale and the terrain layer height took any number** (#350).
+  #320 refused a non-finite value at the displacement paint setters for this
+  reason; the terrain layer has the same two knobs and did not get the same
+  treatment. `height_scale` multiplies every height on the layer and `layer_y` is
+  the plane its geometry is built on and the paint tool's raycast plane, so a NaN
+  in either put the whole generated layer somewhere that is not a place — and it
+  is saved with the layer, so reopening the level brought it back. Both refuse a
+  non-finite value now. A heightmap scale of zero takes a floor rather than a
+  refusal: it is not non-finite, but it multiplies the sculpt by nothing and
+  reads to a mapper as the terrain having gone, and a very flat terrain is still
+  a thing to want. The floor is on the magnitude, so a negative scale still turns
+  the sculpt upside down.
+- **Region streaming size and memory budget had no ceiling** (#352). Of the three
+  settings, the streaming radius was clamped at both ends, the region size below
+  only, and the budget not at all. `region_size_cells` is the divisor that turns
+  a cell index into a region coordinate, so a million-cell region is the whole
+  world in one region: streaming reports as enabled, the radius-2 neighbourhood
+  is 25 of those, and the budget cannot be met by evicting anything because there
+  is nothing smaller than one region to evict. Both are clamped at both ends now,
+  and `load_region_index()` goes through the setters, because a sidecar written
+  by an older version or by hand is exactly the caller they are for.
 - **A malformed `.hflevel` emptied the level instead of refusing to load**
   (#347). `restore_state()` cleared the level and then read the state it had been
   handed, so a key holding the wrong kind of thing gave a raw engine error with

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,498 tests across 179 test scripts (3,491 passing plus seven intentional no-assert safety tests; 17,794 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,509 tests across 180 test scripts (3,502 passing plus seven intentional no-assert safety tests; 17,816 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,498 tests** across **179 scripts** (**3,491 passing** plus seven intentional no-assert safety tests; **17,794 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,509 tests** across **180 scripts** (**3,502 passing** plus seven intentional no-assert safety tests; **17,816 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3491%20passing-brightgreen" alt="3491 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3502%20passing-brightgreen" alt="3502 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,498 tests across 179 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,509 tests across 180 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/systems/hf_paint_system.gd
+++ b/addons/hammerforge/systems/hf_paint_system.gd
@@ -171,8 +171,21 @@ func set_region_show_grid(value: bool) -> void:
 	_update_region_overlay()
 
 
+## A region has to stay a useful unit of streaming. `region_size_cells` is the
+## divisor that turns a cell index into a region coordinate, so a region of a
+## million cells is the whole world in one region: the radius-2 neighbourhood the
+## streamer keeps resident is then 25 of those, and the memory budget cannot be
+## met by evicting anything because there is nothing smaller than one region to
+## evict. The streaming radius was already clamped at both ends; these two are
+## the rest of that.
+const MIN_REGION_SIZE_CELLS := 64
+const MAX_REGION_SIZE_CELLS := 4096
+const MIN_MEMORY_BUDGET_MB := 32
+const MAX_MEMORY_BUDGET_MB := 8192
+
+
 func set_region_size_cells(value: int) -> void:
-	region_manager.region_size_cells = max(64, value)
+	region_manager.region_size_cells = clampi(value, MIN_REGION_SIZE_CELLS, MAX_REGION_SIZE_CELLS)
 
 
 func set_region_streaming_radius(value: int) -> void:
@@ -180,7 +193,7 @@ func set_region_streaming_radius(value: int) -> void:
 
 
 func set_region_memory_budget_mb(value: int) -> void:
-	region_memory_budget_mb = max(32, value)
+	region_memory_budget_mb = clampi(value, MIN_MEMORY_BUDGET_MB, MAX_MEMORY_BUDGET_MB)
 
 
 func get_region_settings() -> Dictionary:
@@ -595,15 +608,44 @@ func generate_heightmap_noise(settings: Dictionary = {}) -> void:
 	regenerate_paint_layers()
 
 
+## How flat a heightmap may be scaled before it is not a sculpt any more.
+##
+## Zero is not non-finite, so it is not the same defect, but it multiplies every
+## height on the layer by nothing and the sculpt reads to a mapper as gone. The
+## multiplier is what changed, not the heights, so there is nothing to undo by
+## eye. A floor rather than a refusal, because a very flat terrain is a real
+## thing to want — and applied to the magnitude, because a negative scale turns
+## the sculpt upside down, which is also a real thing to want.
+const MIN_HEIGHT_SCALE := 0.001
+
+
 func set_heightmap_scale(value: float) -> void:
+	if not is_finite(value):
+		HFLog.warn("HFPaintSystem: heightmap scale must be a number")
+		return
 	var layer = root.paint_layers.get_active_layer() if root.paint_layers else null
 	if not layer:
 		return
+	if absf(value) < MIN_HEIGHT_SCALE:
+		var floored := -MIN_HEIGHT_SCALE if value < 0.0 else MIN_HEIGHT_SCALE
+		HFLog.warn(
+			(
+				"HFPaintSystem: heightmap scale %f flattens the sculpt. Using %f instead."
+				% [value, floored]
+			)
+		)
+		value = floored
 	layer.height_scale = value
 	regenerate_paint_layers()
 
 
 func set_layer_y(value: float) -> void:
+	if not is_finite(value):
+		# The plane the layer's geometry is built on and the paint tool's raycast
+		# plane. A non-finite value puts the whole generated layer somewhere that
+		# is not a place, and it is saved with the layer.
+		HFLog.warn("HFPaintSystem: the layer height must be a number")
+		return
 	var layer = root.paint_layers.get_active_layer() if root.paint_layers else null
 	if not layer or not layer.grid:
 		return
@@ -662,12 +704,16 @@ func load_region_index(index_data: Dictionary, hflevel_path: String = "") -> voi
 		set_region_base_path(hflevel_path)
 	if index_data.is_empty():
 		return
-	region_manager.region_size_cells = int(
-		index_data.get("region_size_cells", region_manager.region_size_cells)
+	# Through the setters, because a sidecar written by an older version or by
+	# hand is exactly the caller the clamps are for.
+	set_region_size_cells(
+		int(index_data.get("region_size_cells", region_manager.region_size_cells))
 	)
-	region_manager.streaming_radius = int(
-		index_data.get("streaming_radius", region_manager.streaming_radius)
+	set_region_streaming_radius(
+		int(index_data.get("streaming_radius", region_manager.streaming_radius))
 	)
+	if index_data.has("memory_budget_mb"):
+		set_region_memory_budget_mb(int(index_data["memory_budget_mb"]))
 	region_manager.region_index.clear()
 	var regions = index_data.get("regions", [])
 	if regions is Array:

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -1519,7 +1519,7 @@ Notes
 ### Region Streaming (Large Worlds)
 Region streaming keeps large paint grids responsive by loading only nearby regions.
 1. Enable **Streaming** in the Paint tab → Regions section.
-2. Set **Region Size** (cells) and **Stream Radius** (regions).
+2. Set **Region Size** (cells, 64 to 4096) and **Stream Radius** (regions, 0 to 8). Region Size is the divisor that turns a cell index into a region coordinate, so a region as large as the world defeats streaming: the neighbourhood the streamer keeps resident is then a handful of enormous regions, and the memory budget cannot be met because there is nothing smaller than one region to evict. The memory budget is held between 32 MB and 8192 MB for the same reason.
 3. Toggle **Show Region Grid** to visualize loaded regions.
 4. Paint normally; regions auto-load around the cursor.
 
@@ -1531,8 +1531,8 @@ Notes
 Heightmaps add vertical displacement to painted floors:
 1. Paint cells on a layer using Brush/Rect/Line/Bucket.
 2. Click **Import** to load a PNG/EXR heightmap, or **Generate** for procedural noise.
-3. Adjust **Height Scale** to control displacement amplitude.
-4. Adjust **Layer Y** to set the base height of the layer.
+3. Adjust **Height Scale** to control displacement amplitude. It has a small floor, because a scale of zero multiplies every height by nothing and reads as the terrain having gone.
+4. Adjust **Layer Y** to set the base height of the layer. Below the grid origin is fine; both fields take a number and nothing else.
 
 When a layer has a heightmap, its floors are generated as displaced MeshInstance3D nodes (not DraftBrush). These live under `Generated/HeightmapFloors` and are baked directly (bypassing CSG) with trimesh collision shapes.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,498 tests across 179 scripts**: **3,491 passing tests**, seven intentional no-assert safety tests, and **17,794 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,509 tests across 180 scripts**: **3,502 passing tests**, seven intentional no-assert safety tests, and **17,816 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_terrain_setting_bounds.gd
+++ b/tests/test_terrain_setting_bounds.gd
@@ -1,0 +1,118 @@
+extends GutTest
+
+## Terrain settings that take a number and never looked at it. #320 fixed this
+## shape for displacement paint and elevation; the terrain layer has the same two
+## knobs and did not get the same treatment, and the region streaming settings
+## enforce their lower bounds and not their upper ones.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+
+var root: LevelRoot
+
+
+func before_each():
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func _active_layer():
+	root.add_paint_layer()
+	return root.paint_layers.get_active_layer()
+
+
+# ===========================================================================
+# The heightmap scale and the layer height (#350)
+# ===========================================================================
+
+
+func test_a_heightmap_scale_that_is_not_a_number_is_refused():
+	var layer = _active_layer()
+	root.set_heightmap_scale(4.0)
+	for value in [NAN, INF, -INF]:
+		root.set_heightmap_scale(value)
+		assert_almost_eq(layer.height_scale, 4.0, 0.0001, "%s must not stick" % value)
+
+
+func test_a_heightmap_scale_of_zero_does_not_flatten_the_sculpt():
+	var layer = _active_layer()
+	root.set_heightmap_scale(0.0)
+	assert_gt(layer.height_scale, 0.0, "a multiplier of nothing reads as the terrain gone")
+
+
+func test_an_ordinary_heightmap_scale_still_goes_through():
+	var layer = _active_layer()
+	root.set_heightmap_scale(2.5)
+	assert_almost_eq(layer.height_scale, 2.5, 0.0001)
+
+
+func test_a_negative_heightmap_scale_still_turns_the_sculpt_over():
+	# The floor is on the magnitude. Inverting a terrain is a thing to want, the
+	# same way a negative UV scale mirrors a texture.
+	var layer = _active_layer()
+	root.set_heightmap_scale(-8.0)
+	assert_almost_eq(layer.height_scale, -8.0, 0.0001)
+	root.set_heightmap_scale(-0.0000001)
+	assert_lt(layer.height_scale, 0.0, "still upside down")
+	assert_lt(absf(layer.height_scale), 1.0, "and still floored")
+
+
+func test_a_layer_height_that_is_not_a_number_is_refused():
+	var layer = _active_layer()
+	root.set_layer_y(32.0)
+	for value in [NAN, INF, -INF]:
+		root.set_layer_y(value)
+		assert_almost_eq(layer.grid.layer_y, 32.0, 0.0001, "%s must not stick" % value)
+
+
+func test_a_negative_layer_height_still_goes_through():
+	var layer = _active_layer()
+	root.set_layer_y(-64.0)
+	assert_almost_eq(layer.grid.layer_y, -64.0, 0.0001, "below the origin is a place")
+
+
+# ===========================================================================
+# Region streaming (#352)
+# ===========================================================================
+
+
+func _region_settings() -> Dictionary:
+	return root.get_region_settings()
+
+
+func test_a_region_size_is_clamped_at_both_ends():
+	root.set_region_size_cells(0)
+	assert_gte(int(_region_settings()["region_size_cells"]), 64, "still a floor")
+	root.set_region_size_cells(1000000)
+	var size := int(_region_settings()["region_size_cells"])
+	assert_lte(size, 4096, "a region has to stay smaller than the world")
+	assert_gte(size, 64)
+
+
+func test_a_region_size_in_range_is_kept():
+	root.set_region_size_cells(256)
+	assert_eq(int(_region_settings()["region_size_cells"]), 256)
+
+
+func test_a_memory_budget_is_clamped_at_both_ends():
+	root.set_region_memory_budget_mb(1)
+	assert_gte(int(_region_settings()["memory_budget_mb"]), 32)
+	root.set_region_memory_budget_mb(100000)
+	assert_lte(int(_region_settings()["memory_budget_mb"]), 8192, "more than a machine can hold")
+
+
+func test_the_streaming_radius_is_still_clamped():
+	root.set_region_streaming_radius(100000)
+	assert_lte(int(_region_settings()["streaming_radius"]), 8)
+
+
+func test_a_region_sidecar_cannot_smuggle_a_size_past_the_clamp():
+	# An index written by an older version or by hand is the caller these are for.
+	root.paint_system.load_region_index(
+		{"region_size_cells": 1000000, "streaming_radius": 99, "memory_budget_mb": 100000}
+	)
+	var settings := _region_settings()
+	assert_lte(int(settings["region_size_cells"]), 4096)
+	assert_lte(int(settings["streaming_radius"]), 8)
+	assert_lte(int(settings["memory_budget_mb"]), 8192)


### PR DESCRIPTION
Fixes #350, fixes #352. Both are settings in `HFPaintSystem` that enforce some of their range and not the rest.

`set_heightmap_scale()` and `set_layer_y()` refuse a non-finite value, which is what #320 did for the displacement setters — the terrain layer has the same two knobs and was left out. A scale near zero takes a floor instead of a refusal, because a very flat terrain is a real thing to want, and the floor is on the magnitude so a negative scale still turns the sculpt upside down.

`region_size_cells` and `memory_budget_mb` are clamped at both ends, the way `streaming_radius` already was. `load_region_index()` goes through the setters now, since a sidecar written by an older version or by hand is exactly the caller the clamps are for.

Verified with the terrain vibe scenario as well as the suite: every row that used to store the number it was handed now shows the clamped one.

Docs: CHANGELOG, and the user guide's Heightmap Terrain and Region Streaming sections.