### PR TITLE
Refuse three inputs the sibling paths already refuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Fixed
+- **A grid array with a negative axis count was built rather than refused**
+  (#346). The linear and radial paths refuse a count below one with a message and
+  a fix hint; the grid path clamped `(-2, 2, 2)` up to `(1, 2, 2)` first, so
+  `can_generate()` was asked about three copies and an array the mapper never
+  described was created without a word. `grid_copy_count()` answers -1 for a
+  count below one on any axis, which the existing refusal already covers, and
+  `generate_grid()` no longer clamps — so the record holds the counts that were
+  asked for rather than ones nobody typed.
+- **A visgroup could be named with nothing but whitespace** (#349). The guard
+  tested `vg_name == ""`, so `""` was refused and `"   "` was not: the visgroup
+  existed, showed in the dock as a blank row, could not be told apart from
+  another blank one, and was saved into the `.hflevel` on its members. Names are
+  stripped and a name that strips to nothing is refused, on create and on rename.
+  Stored stripped as well, so `lights` and `lights ` are one visgroup rather than
+  two a keystroke apart.
+- **Surface paint layers stacked on a face without a cap** (#351). 64 layers on
+  one face is 64 walked on every `rebuild_preview()`, written into the
+  `.hflevel` and read back, and past a handful the composite is not visibly
+  different — `get_painted_albedo()` blends them at every texel, so each extra
+  one is preview time, save size and load time for nothing. A face takes at most
+  8, refused with a message that says the limit, checked in the dock before the
+  undo action opens so Add does not report success over a layer that was not
+  added. `SurfacePaint` honours the same cap, because painting into a layer index
+  creates the layers below it. `remove_surface_paint_layer()` returns whether it
+  removed something, so a no-op can be told from a removal.
 - **The heightmap scale and the terrain layer height took any number** (#350).
   #320 refused a non-finite value at the displacement paint setters for this
   reason; the terrain layer has the same two knobs and did not get the same

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,509 tests across 180 test scripts (3,502 passing plus seven intentional no-assert safety tests; 17,816 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,519 tests across 181 test scripts (3,512 passing plus seven intentional no-assert safety tests; 17,839 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,509 tests** across **180 scripts** (**3,502 passing** plus seven intentional no-assert safety tests; **17,816 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,519 tests** across **181 scripts** (**3,512 passing** plus seven intentional no-assert safety tests; **17,839 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3502%20passing-brightgreen" alt="3502 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3512%20passing-brightgreen" alt="3512 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,509 tests across 180 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,519 tests across 181 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/dock.gd
+++ b/addons/hammerforge/dock.gd
@@ -4663,6 +4663,14 @@ func _on_surface_paint_layer_add() -> void:
 	var face_idx = _surface_active_brush.faces.find(_surface_active_face)
 	if brush_id == "" or face_idx < 0:
 		return
+	if _surface_active_face.paint_layers.size() >= level_root.MAX_SURFACE_PAINT_LAYERS:
+		# Checked before the undo action opens, so Add does not report success
+		# over a layer the face cannot blend.
+		_set_status(
+			"A face blends at most %d surface paint layers" % level_root.MAX_SURFACE_PAINT_LAYERS,
+			true
+		)
+		return
 	_commit_state_action("Add Surface Paint Layer", "add_surface_paint_layer", [brush_id, face_idx])
 	_refresh_surface_paint_layers()
 

--- a/addons/hammerforge/hf_duplicator.gd
+++ b/addons/hammerforge/hf_duplicator.gd
@@ -132,9 +132,16 @@ static func can_generate(copy_count: int, source_count: int) -> HFOpResult:
 
 ## How many copies a grid of these counts makes. The counts include the source
 ## cell on each axis, so the source itself is not a copy.
+##
+## A count below one on any axis is not a grid, and this answers -1 for it rather
+## than clamping it up to one. `can_generate()` already refuses a copy count below
+## one with the right message, which is how the linear and radial paths treat the
+## same mistake; clamping here was what stopped the grid path reaching it, so a
+## mapper who typed a minus sign got a plausible array they never described.
 static func grid_copy_count(p_counts: Vector3i) -> int:
-	var counts := Vector3i(maxi(1, p_counts.x), maxi(1, p_counts.y), maxi(1, p_counts.z))
-	return counts.x * counts.y * counts.z - 1
+	if p_counts.x < 1 or p_counts.y < 1 or p_counts.z < 1:
+		return -1
+	return p_counts.x * p_counts.y * p_counts.z - 1
 
 
 ## How many copies a rebuild with these parameters would make, worked out
@@ -255,7 +262,9 @@ func generate_radial(
 func generate_grid(brush_system, p_counts: Vector3i, p_spacing: Vector3) -> bool:
 	if not can_generate(grid_copy_count(p_counts), source_brush_ids.size()).ok:
 		return false
-	var counts := Vector3i(maxi(1, p_counts.x), maxi(1, p_counts.y), maxi(1, p_counts.z))
+	# No clamp: the guard above has already refused anything below one, so the
+	# record holds the counts that were asked for rather than ones nobody typed.
+	var counts := p_counts
 	mode = ArrayMode.GRID
 	grid_counts = counts
 	grid_spacing = p_spacing

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -1730,31 +1730,52 @@ func clip_brush_to_convex(brush_id: String) -> bool:
 	return vertex_system.clip_to_convex(brush_id)
 
 
-func add_surface_paint_layer(brush_id: String, face_idx: int) -> void:
+## How many textures may be blended over one face.
+##
+## `get_painted_albedo()` composites the layers into one image by walking every
+## layer at every texel, and that runs on each `rebuild_preview()` and again at
+## bake. Past a handful the result is not visibly different and each extra layer
+## is preview time, save size and load time for nothing. Nothing in the dock
+## stopped a mapper clicking Add, because there was no limit to stop them at.
+const MAX_SURFACE_PAINT_LAYERS := 8
+
+
+## Returns whether a layer was added.
+func add_surface_paint_layer(brush_id: String, face_idx: int) -> bool:
 	var brush = brush_system.find_brush_by_id(brush_id)
 	if not brush or not (brush is DraftBrush):
-		return
+		return false
 	var draft := brush as DraftBrush
 	if face_idx < 0 or face_idx >= draft.faces.size():
-		return
-	draft.faces[face_idx].paint_layers.append(FaceData.PaintLayer.new())
+		return false
+	var face: FaceData = draft.faces[face_idx]
+	if face.paint_layers.size() >= MAX_SURFACE_PAINT_LAYERS:
+		HFLog.warn(
+			"LevelRoot: a face blends at most %d surface paint layers" % MAX_SURFACE_PAINT_LAYERS
+		)
+		return false
+	face.paint_layers.append(FaceData.PaintLayer.new())
 	draft.rebuild_preview()
 	tag_brush_dirty(brush_id)
+	return true
 
 
-func remove_surface_paint_layer(brush_id: String, face_idx: int, layer_idx: int) -> void:
+## Returns whether a layer was removed, so a caller can tell a removal from a
+## no-op — an index out of range used to do nothing and say nothing.
+func remove_surface_paint_layer(brush_id: String, face_idx: int, layer_idx: int) -> bool:
 	var brush = brush_system.find_brush_by_id(brush_id)
 	if not brush or not (brush is DraftBrush):
-		return
+		return false
 	var draft := brush as DraftBrush
 	if face_idx < 0 or face_idx >= draft.faces.size():
-		return
+		return false
 	var layers = draft.faces[face_idx].paint_layers
 	if layer_idx < 0 or layer_idx >= layers.size():
-		return
+		return false
 	layers.remove_at(layer_idx)
 	draft.rebuild_preview()
 	tag_brush_dirty(brush_id)
+	return true
 
 
 func set_surface_paint_layer_texture(

--- a/addons/hammerforge/surface_paint.gd
+++ b/addons/hammerforge/surface_paint.gd
@@ -40,9 +40,17 @@ func paint_at_uv(
 			img.set_pixel(x, y, Color(next, current.g, current.b, 1.0))
 
 
+## How many textures may be blended over one face. The same cap
+## `LevelRoot.add_surface_paint_layer()` enforces, because painting into a layer
+## index creates the layers below it and would otherwise walk straight past it.
+const MAX_PAINT_LAYERS := 8
+
+
 func _ensure_layer(face: FaceData, layer_idx: int) -> FaceData.PaintLayer:
 	if layer_idx < 0:
 		layer_idx = 0
+	if layer_idx >= MAX_PAINT_LAYERS:
+		return null
 	while face.paint_layers.size() <= layer_idx:
 		face.paint_layers.append(FaceData.PaintLayer.new())
 	return face.paint_layers[layer_idx]

--- a/addons/hammerforge/systems/hf_visgroup_system.gd
+++ b/addons/hammerforge/systems/hf_visgroup_system.gd
@@ -24,10 +24,16 @@ func _init(level_root: Node3D) -> void:
 
 
 func create_visgroup(vg_name: String, color: Color = Color.WHITE) -> void:
-	if vg_name == "":
+	# The guard tested the wrong thing: "" was refused and "   " was not, so a
+	# visgroup could exist that shows in the dock as a blank row, cannot be told
+	# apart from another blank one, and is saved into the `.hflevel` on its
+	# members. Stored stripped as well, so "lights" and "lights " are one
+	# visgroup rather than two a keystroke apart.
+	var stripped := vg_name.strip_edges()
+	if stripped == "":
 		return
-	if not visgroups.has(vg_name):
-		visgroups[vg_name] = {"visible": true, "color": color}
+	if not visgroups.has(stripped):
+		visgroups[stripped] = {"visible": true, "color": color}
 
 
 func remove_visgroup(vg_name: String) -> void:
@@ -50,6 +56,7 @@ func remove_visgroup(vg_name: String) -> void:
 ## Merging two visgroups is a different operation, and one somebody should have
 ## to ask for by name.
 func rename_visgroup(old_name: String, new_name: String) -> bool:
+	new_name = new_name.strip_edges()
 	if old_name == "" or new_name == "" or old_name == new_name:
 		return false
 	if not visgroups.has(old_name):

--- a/docs/HammerForge_Texture_Materials.md
+++ b/docs/HammerForge_Texture_Materials.md
@@ -113,6 +113,7 @@ Controls:
 
 Notes:
 - Weights are stored per face as images (default 256x256).
+- A face takes at most 8 paint layers. They are composited into one image at every texel on each preview rebuild and again at bake, so past a handful each extra layer costs preview time, save size and load time without looking different.
 - Surface paint updates the DraftBrush preview immediately.
 - Surface paint does not modify floor paint layers.
 - If paint affects floors, set `Paint Target = Surface` in the Paint tab → Surface Paint section.

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -532,7 +532,9 @@ refuses and says why. Destroy the displacement first if you need the mirror.
   closed ring. Each copy is turned as well as moved, so a ring of arches faces
   outward rather than all facing the same way.
 - **Grid** — a 3D lattice. Set the cell count per axis (counting the original)
-  and the X/Y/Z offset becomes the spacing.
+  and the X/Y/Z offset becomes the spacing. Every axis needs at least one cell;
+  a count below that is refused rather than treated as one, the same way the
+  linear and radial counts are.
 
 **Turn any of those controls and the copies draw themselves.** A pale wireframe
 shows the copies **Create Array** would make, standing where they would stand,
@@ -1405,7 +1407,7 @@ Preview lines during placement: green ticks for stairs, yellow for railings, ora
 Visgroups let you organize your map into logical groups and toggle their visibility.
 
 1. Open the **Test** tab in the dock.
-2. Type a name in the Visgroup field and click **New** to create a visgroup.
+2. Type a name in the Visgroup field and click **New** to create a visgroup. The name is stored trimmed, and a name that is only spaces is refused — a visgroup that renders as a blank row cannot be picked out or described.
 3. Select brushes/entities in the viewport, then click **Add Sel** to add them to the visgroup.
 4. Click the visgroup name in the list to toggle between **[V]** (visible) and **[H]** (hidden).
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,509 tests across 180 scripts**: **3,502 passing tests**, seven intentional no-assert safety tests, and **17,816 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,519 tests across 181 scripts**: **3,512 passing tests**, seven intentional no-assert safety tests, and **17,839 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_array_limits.gd
+++ b/tests/test_array_limits.gd
@@ -129,4 +129,7 @@ func test_grid_copy_count_matches_the_placements():
 		"and that is how many placements there are"
 	)
 	assert_eq(HFDuplicatorType.grid_copy_count(Vector3i(1, 1, 1)), 0, "1x1x1 makes none")
-	assert_eq(HFDuplicatorType.grid_copy_count(Vector3i(0, -4, 1)), 0, "and nor does a bad count")
+	# A count below one is not a grid that makes no copies, it is not a grid.
+	# -1 is what `can_generate()` already refuses, so the grid path gets the same
+	# message as the linear and radial ones rather than a clamp.
+	assert_eq(HFDuplicatorType.grid_copy_count(Vector3i(0, -4, 1)), -1, "and a bad count is not")

--- a/tests/test_refusals_the_siblings_make.gd
+++ b/tests/test_refusals_the_siblings_make.gd
@@ -1,0 +1,131 @@
+extends GutTest
+
+## Three places where one path clamped or accepted what its sibling paths
+## refused outright. Each is the odd one out rather than a new rule.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+const HFDuplicatorType = preload("res://addons/hammerforge/hf_duplicator.gd")
+const SurfacePaintType = preload("res://addons/hammerforge/surface_paint.gd")
+
+var root: LevelRoot
+
+
+func before_each():
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func _box(brush_id: String) -> DraftBrush:
+	return (
+		root.create_brush_from_info({"size": Vector3(32, 32, 32), "brush_id": brush_id})
+		as DraftBrush
+	)
+
+
+func _brush_count() -> int:
+	return root.draft_brushes_node.get_child_count()
+
+
+# ===========================================================================
+# A grid count below one is refused, like the linear and radial counts (#346)
+# ===========================================================================
+
+
+func test_a_grid_with_a_negative_axis_count_is_refused():
+	_box("src")
+	var ids := PackedStringArray(["src"])
+	var before := _brush_count()
+	for counts in [Vector3i(-2, 2, 2), Vector3i(2, -2, 2), Vector3i(2, 2, -2), Vector3i(0, 2, 2)]:
+		assert_null(
+			root.brush_system.create_grid_array(ids, counts, Vector3(64, 0, 0)),
+			"%s is not a grid" % counts
+		)
+	assert_eq(_brush_count(), before, "nothing was built")
+
+
+func test_the_linear_and_radial_paths_still_refuse_the_same_way():
+	_box("src")
+	var ids := PackedStringArray(["src"])
+	assert_null(root.brush_system.create_duplicate_array(ids, -4, Vector3(64, 0, 0)))
+	assert_null(root.brush_system.create_radial_array(ids, -4, 1, 30.0, Vector3.ZERO))
+
+
+func test_an_ordinary_grid_is_still_built():
+	_box("src")
+	var dup = root.brush_system.create_grid_array(
+		PackedStringArray(["src"]), Vector3i(2, 2, 2), Vector3(64, 64, 64)
+	)
+	assert_not_null(dup, "2x2x2 is seven copies")
+	assert_eq(HFDuplicatorType.grid_copy_count(Vector3i(2, 2, 2)), 7)
+
+
+func test_a_single_cell_grid_makes_no_copies_and_is_refused():
+	assert_eq(HFDuplicatorType.grid_copy_count(Vector3i(1, 1, 1)), 0)
+	assert_false(HFDuplicatorType.can_generate(0, 1).ok, "no copies is not an array")
+
+
+# ===========================================================================
+# A visgroup name has to render as something (#349)
+# ===========================================================================
+
+
+func test_a_name_of_only_whitespace_is_not_a_name():
+	root.create_visgroup("   ")
+	root.create_visgroup("\t")
+	root.create_visgroup("")
+	assert_eq(root.visgroup_system.visgroups.size(), 0, "none of those is a name")
+
+
+func test_a_name_is_stored_stripped_so_one_keystroke_is_not_two_visgroups():
+	root.create_visgroup("lights")
+	root.create_visgroup("lights ")
+	root.create_visgroup(" lights")
+	assert_eq(root.visgroup_system.visgroups.size(), 1, "one visgroup, not three")
+	assert_true(root.visgroup_system.visgroups.has("lights"))
+
+
+func test_renaming_to_whitespace_is_refused():
+	root.create_visgroup("lights")
+	assert_false(root.visgroup_system.rename_visgroup("lights", "   "))
+	assert_true(root.visgroup_system.visgroups.has("lights"), "still there under its own name")
+
+
+# ===========================================================================
+# Surface paint layers have a ceiling (#351)
+# ===========================================================================
+
+
+func test_surface_paint_layers_stop_at_the_cap():
+	var brush := _box("b1")
+	var added := 0
+	for _i in 64:
+		if root.add_surface_paint_layer("b1", 0):
+			added += 1
+	assert_eq(added, root.MAX_SURFACE_PAINT_LAYERS, "Add stops saying yes at the cap")
+	assert_eq(
+		brush.faces[0].paint_layers.size(), root.MAX_SURFACE_PAINT_LAYERS, "and stops adding them"
+	)
+
+
+func test_removing_a_layer_says_whether_it_removed_one():
+	var brush := _box("b1")
+	root.add_surface_paint_layer("b1", 0)
+	assert_false(root.remove_surface_paint_layer("b1", 0, -1), "-1 is not a layer")
+	assert_false(root.remove_surface_paint_layer("b1", 0, 9999), "nor is 9999")
+	assert_eq(brush.faces[0].paint_layers.size(), 1, "and neither removed anything")
+	assert_true(root.remove_surface_paint_layer("b1", 0, 0), "0 is")
+	assert_eq(brush.faces[0].paint_layers.size(), 0)
+
+
+func test_painting_into_a_layer_past_the_cap_does_not_create_it():
+	var brush := _box("b1")
+	var painter := SurfacePaintType.new()
+	add_child_autoqfree(painter)
+	painter.paint_at_uv(brush.faces[0], 999, Vector2(0.5, 0.5), 0.1, 1.0)
+	assert_lte(
+		brush.faces[0].paint_layers.size(),
+		root.MAX_SURFACE_PAINT_LAYERS,
+		"painting into an index creates the layers below it"
+	)

--- a/tests/test_transform_array.gd
+++ b/tests/test_transform_array.gd
@@ -214,13 +214,14 @@ func test_grid_array_rejects_a_single_cell():
 	)
 
 
-func test_grid_array_clamps_a_zero_count_to_one():
+func test_grid_array_refuses_a_zero_count_rather_than_clamping_it():
+	# It used to clamp (0, 2, 0) up to (1, 2, 1) and build an array nobody
+	# described. The linear and radial paths refuse the same mistake.
 	_make_brush(Vector3.ZERO, Vector3(32, 32, 32), "src")
 	var dup = brushes.create_grid_array(
 		PackedStringArray(["src"]), Vector3i(0, 2, 0), Vector3(64, 64, 64)
 	)
-	assert_not_null(dup)
-	assert_eq(dup.get_all_instance_ids().size(), 1)
+	assert_null(dup, "a grid needs at least one cell on every axis")
 
 
 # ===========================================================================


### PR DESCRIPTION
Fixes #346, fixes #349, fixes #351. Three places where one path clamped or accepted what its siblings refused outright. Each is the odd one out, not a new rule.

- A grid array clamped `(-2, 2, 2)` up to `(1, 2, 2)` before `can_generate()` saw it, so a minus-sign slip built a plausible array with no message, and the record held counts nobody typed. `grid_copy_count()` answers -1 for a count below one, which the existing 'that layout makes no copies' refusal already covers, and `generate_grid()` no longer clamps.
- `create_visgroup()` tested `vg_name == ""`, so `""` was refused and `"   "` was not. Names are stripped on create and rename, and a name that strips to nothing is refused — which also means `lights` and `lights ` are one visgroup rather than two a keystroke apart.
- A face took unlimited surface paint layers. `get_painted_albedo()` composites them at every texel on each preview rebuild and again at bake, so past a handful each extra layer is time and save size for nothing. Eight, refused with a message, checked in the dock before the undo action opens. `SurfacePaint` honours the same cap, because painting into a layer index creates the layers below it. Removal returns whether it removed something.

Two existing tests asserted the grid clamp and were rewritten. Confirmed with the cutting, housekeeping and appearance vibe scenarios as well as the suite.

Docs: CHANGELOG, the user guide's Grid array and Visgroups entries, and the Surface Paint notes.