### PR TITLE
Track the two remaining test uid files

### DIFF
--- a/tests/test_refusals_the_siblings_make.gd.uid
+++ b/tests/test_refusals_the_siblings_make.gd.uid
@@ -1,0 +1,1 @@
+uid://3e6bps65ocau

--- a/tests/test_terrain_setting_bounds.gd.uid
+++ b/tests/test_terrain_setting_bounds.gd.uid
@@ -1,0 +1,1 @@
+uid://chfj8c33b4g2y


### PR DESCRIPTION
`tests/` now holds 182 test scripts and 180 tracked `.uid` files. These are the two that are missing.

```
tests/test_refusals_the_siblings_make.gd.uid   uid://3e6bps65ocau
tests/test_terrain_setting_bounds.gd.uid       uid://chfj8c33b4g2y
```

Same situation #363 fixed for eight others — those two test scripts landed after it. Godot regenerates the files on every `--headless --import`, so they surface as untracked in every working tree; they turned up again during the class-cache rebuild for #384.

After this, every `tests/*.gd` has its `.uid` committed beside it.