### PR TITLE
Put the resize, nudge and array paths through the same guards the create path has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Fixed
+- **The resize path took sizes the create path refuses** (#378). A brush gets
+  its size two ways and the two disagreed completely. `create_brush_from_info()`
+  puts a size through `_usable_size()`, which floors a zero extent, makes a
+  negative one positive, warns about both, and refuses a non-finite one outright.
+  `set_brush_transform_by_id()` — the dock's size fields, the gizmo commit and
+  every scripted resize — wrote the value straight onto the property. A negative
+  size built the brush inside out, a zero size built no volume, and a NaN size
+  poisoned the AABB with no editor action that put it back. The resize path goes
+  through the same funnel now, and refuses a non-finite position with it.
+- **A non-finite nudge offset sent the selection to nowhere** (#379). The only
+  guard was `offset.is_zero_approx()`, which is a magnitude test that a NaN
+  passes. The offset comes from the dock's transform fields and from the
+  arrow-key nudge, which uses `grid_snap`, so one bad number moved every selected
+  brush to a position with no AABB, nothing drawn to click, and the `.hflevel`
+  keeping it. `nudge_brushes_by_id()` and `nudge_entities_by_paths()` refuse a
+  non-finite offset.
+- **An array with a non-finite layout number built every copy at a NaN position**
+  (#382). `can_generate()` checked the copy count and the source count and never
+  looked at the numbers that decide where a copy lands, so five copies meant five
+  lost brushes rather than one. `linear_placements()`, `radial_placements()` and
+  `grid_placements()` lay out nothing when the offset, spacing, step, rise or
+  pivot they were handed is not a number, and `can_generate()` takes the layout
+  parameters so the refusal says which fields to check.
 - **A grid array with a negative axis count was built rather than refused**
   (#346). The linear and radial paths refuse a count below one with a message and
   a fix hint; the grid path clamped `(-2, 2, 2)` up to `(1, 2, 2)` first, so

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,519 tests across 181 test scripts (3,512 passing plus seven intentional no-assert safety tests; 17,839 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,530 tests across 182 test scripts (3,523 passing plus seven intentional no-assert safety tests; 17,877 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,519 tests** across **181 scripts** (**3,512 passing** plus seven intentional no-assert safety tests; **17,839 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,530 tests** across **182 scripts** (**3,523 passing** plus seven intentional no-assert safety tests; **17,877 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3512%20passing-brightgreen" alt="3512 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3523%20passing-brightgreen" alt="3523 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,519 tests across 181 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,530 tests across 182 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/dock_brush_handler.gd
+++ b/addons/hammerforge/dock_brush_handler.gd
@@ -582,7 +582,7 @@ static func on_create_duplicate_array(dock: Object) -> void:
 	# layout controls will happily describe thirty-two thousand brushes, and a
 	# refusal that names the number beats one that says "too many".
 	var check: HFOpResult = HFDuplicator.can_generate(
-		HFDuplicator.placements_for(mode, params).size(), brush_ids.size()
+		HFDuplicator.placements_for(mode, params).size(), brush_ids.size(), params
 	)
 	if not check.ok:
 		dock._set_status(check.user_text(), true)
@@ -692,8 +692,11 @@ static func refresh_array_preview(dock: Object) -> void:
 	if brush_ids.is_empty():
 		_put_array_ghost_away(dock)
 		return
-	var placements := HFDuplicator.placements_for(array_mode(dock), array_params(dock, brush_ids))
-	var check: HFOpResult = HFDuplicator.can_generate(placements.size(), brush_ids.size())
+	var ghost_params := array_params(dock, brush_ids)
+	var placements := HFDuplicator.placements_for(array_mode(dock), ghost_params)
+	var check: HFOpResult = HFDuplicator.can_generate(
+		placements.size(), brush_ids.size(), ghost_params
+	)
 	if not check.ok:
 		dock.level_root.clear_array_preview()
 		_show_array_message(dock, check.user_text())

--- a/addons/hammerforge/hf_duplicator.gd
+++ b/addons/hammerforge/hf_duplicator.gd
@@ -42,8 +42,34 @@ static func _translated(translation: Vector3) -> CopyPlacement:
 	return placement
 
 
+## Whether every number a layout is laid out from is a number.
+##
+## The count is checked by `can_generate()`; these are the values that decide
+## *where* a copy lands, and nothing looked at them. A non-finite one multiplies
+## through the placement arithmetic into a copy at a NaN position: it draws
+## nothing, cannot be box-selected or framed, is invisible to `validate_level()`
+## and is saved into the `.hflevel`. One array action makes as many of those as
+## the count asked for, which is why this is checked here rather than left to the
+## caller.
+static func layout_numbers_finite(params: Dictionary) -> bool:
+	for key in ["offset", "pivot", "spacing"]:
+		if params.has(key) and params[key] is Vector3 and not (params[key] as Vector3).is_finite():
+			return false
+	for key in ["step_degrees", "rise"]:
+		if params.has(key) and not is_finite(float(params[key])):
+			return false
+	return true
+
+
+static func _refuse_layout(what: String) -> Array:
+	HFLog.warn("HFDuplicator: %s is not a number, so no copies were laid out" % what)
+	return []
+
+
 ## A run of copies, each one offset further than the last.
 static func linear_placements(p_count: int, p_offset: Vector3) -> Array:
+	if not p_offset.is_finite():
+		return _refuse_layout("array offset %s" % str(p_offset))
 	var out: Array = []
 	for copy_index in range(1, maxi(0, p_count) + 1):
 		out.append(_translated(p_offset * copy_index))
@@ -54,6 +80,10 @@ static func linear_placements(p_count: int, p_offset: Vector3) -> Array:
 static func radial_placements(
 	p_count: int, p_axis_index: int, p_step_degrees: float, p_pivot: Vector3, p_rise: float = 0.0
 ) -> Array:
+	if not (is_finite(p_step_degrees) and is_finite(p_rise) and p_pivot.is_finite()):
+		return _refuse_layout(
+			"radial step %s, rise %s or pivot %s" % [p_step_degrees, p_rise, str(p_pivot)]
+		)
 	var out: Array = []
 	var climb := HFTransformSystem.axis_vector(p_axis_index) * p_rise
 	for copy_index in range(1, maxi(0, p_count) + 1):
@@ -70,6 +100,8 @@ static func radial_placements(
 ## A lattice of copies. `p_counts` includes the source cell on each axis, so the
 ## cell the source already occupies is not among the placements.
 static func grid_placements(p_counts: Vector3i, p_spacing: Vector3) -> Array:
+	if not p_spacing.is_finite():
+		return _refuse_layout("grid spacing %s" % str(p_spacing))
 	var counts := Vector3i(maxi(1, p_counts.x), maxi(1, p_counts.y), maxi(1, p_counts.z))
 	var out: Array = []
 	for ix in counts.x:
@@ -113,7 +145,12 @@ static func placements_for(mode: int, params: Dictionary) -> Array:
 ## The count the controls ask for is said back, the way the dome builder says the
 ## number of panels it was asked for, because "too many" without a number leaves
 ## the user guessing which control to turn.
-static func can_generate(copy_count: int, source_count: int) -> HFOpResult:
+static func can_generate(copy_count: int, source_count: int, params: Dictionary = {}) -> HFOpResult:
+	if not layout_numbers_finite(params):
+		return HFOpResult.fail(
+			"Array: that layout has a number that is not a number",
+			"Check the offset, spacing, step and rise fields"
+		)
 	if source_count < 1:
 		return HFOpResult.fail("Array: nothing selected to copy", "Select a brush first")
 	if copy_count < 1:
@@ -180,7 +217,7 @@ func _init() -> void:
 ## Create N copies of the source brushes with progressive offset.
 ## brush_system is untyped to avoid circular preload.
 func generate(brush_system, p_count: int, p_offset: Vector3) -> bool:
-	if not can_generate(p_count, source_brush_ids.size()).ok:
+	if not can_generate(p_count, source_brush_ids.size(), {"offset": p_offset}).ok:
 		return false
 	count = p_count
 	offset = p_offset
@@ -229,7 +266,8 @@ func generate_radial(
 	p_pivot: Vector3,
 	p_rise: float = 0.0
 ) -> bool:
-	if not can_generate(p_count, source_brush_ids.size()).ok:
+	var radial_params := {"step_degrees": p_step_degrees, "pivot": p_pivot, "rise": p_rise}
+	if not can_generate(p_count, source_brush_ids.size(), radial_params).ok:
 		return false
 	mode = ArrayMode.RADIAL
 	count = p_count
@@ -260,7 +298,9 @@ func generate_radial(
 ## Create a lattice of copies. `p_counts` includes the source cell on each axis,
 ## so 2x1x2 produces three copies around one original.
 func generate_grid(brush_system, p_counts: Vector3i, p_spacing: Vector3) -> bool:
-	if not can_generate(grid_copy_count(p_counts), source_brush_ids.size()).ok:
+	if not (
+		can_generate(grid_copy_count(p_counts), source_brush_ids.size(), {"spacing": p_spacing}).ok
+	):
 		return false
 	# No clamp: the guard above has already refused anything below one, so the
 	# record holds the counts that were asked for rather than ones nobody typed.
@@ -348,7 +388,7 @@ func regenerate(brush_system, p_mode: int, params: Dictionary) -> bool:
 	# Asked before anything is torn down. A count the layout cannot use is a
 	# refusal with the existing copies still standing, not a demolition
 	# followed by the news that nothing could be built in their place.
-	if not can_generate(requested_copy_count(p_mode, params), source_brush_ids.size()).ok:
+	if not can_generate(requested_copy_count(p_mode, params), source_brush_ids.size(), params).ok:
 		return false
 	clear_instances(brush_system)
 	if not _lay_out(brush_system, p_mode, params):

--- a/addons/hammerforge/systems/hf_brush_system.gd
+++ b/addons/hammerforge/systems/hf_brush_system.gd
@@ -238,7 +238,17 @@ func delete_brush_by_id(brush_id: String) -> HFOpResult:
 
 
 func nudge_brushes_by_id(brush_ids: Array, offset: Vector3) -> void:
-	if brush_ids.is_empty() or offset.is_zero_approx():
+	if brush_ids.is_empty():
+		return
+	# `is_zero_approx()` is a magnitude test, and a non-finite offset is not
+	# approximately zero, so it used to pass. The offset comes from the dock's
+	# transform fields and from the arrow-key nudge, which uses `grid_snap` — so
+	# one bad number sends the whole selection to a position nothing can reach
+	# again: no AABB, nothing drawn to click, and the save keeps it.
+	if not offset.is_finite():
+		HFLog.warn("HFBrushSystem: nudge offset %s is not an offset" % str(offset))
+		return
+	if offset.is_zero_approx():
 		return
 	for brush_id in brush_ids:
 		var brush_key := str(brush_id)
@@ -876,15 +886,32 @@ func apply_material_to_brush_by_id(brush_id: String, mat: Material) -> void:
 		apply_material_to_brush(brush, mat)
 
 
+## The resize path, and the same funnel the create path uses.
+##
+## These two used to disagree about what a size is: `create_brush_from_info()`
+## refuses a non-finite one and coerces a zero or negative one with a warning,
+## while this wrote whatever it was given straight onto the property. A negative
+## size builds the brush inside out, a zero one builds no volume, and a NaN one
+## poisons the AABB with no editor action that puts it back. The dock's size
+## fields come through here, so the resize path was the easier of the two to
+## reach.
 func set_brush_transform_by_id(brush_id: String, size: Vector3, position: Vector3) -> void:
 	if brush_id == "":
+		return
+	if not size.is_finite() or not position.is_finite():
+		HFLog.warn(
+			(
+				"HFBrushSystem: refusing to move brush '%s' to size %s at %s"
+				% [brush_id, str(size), str(position)]
+			)
+		)
 		return
 	var brush = _find_brush_by_id(brush_id)
 	if brush and brush is DraftBrush:
 		var draft := brush as DraftBrush
 		var old_size := draft.size
 		var old_pos := draft.global_position
-		var normalized_size := DraftBrush.normalized_size_for_shape(draft.shape, size)
+		var normalized_size := DraftBrush.normalized_size_for_shape(draft.shape, _usable_size(size))
 		if old_size.is_equal_approx(normalized_size) and old_pos.is_equal_approx(position):
 			return
 		draft.size = normalized_size
@@ -2227,7 +2254,7 @@ func create_duplicate_array(
 	# Asked before _new_duplicator_for, which retires whatever array already owns
 	# these sources and takes its copies with it. A refusal must not cost the user
 	# the array they already had.
-	if not HFDuplicator.can_generate(p_count, brush_ids.size()).ok:
+	if not HFDuplicator.can_generate(p_count, brush_ids.size(), {"offset": p_offset}).ok:
 		return null
 	var dup := _new_duplicator_for(brush_ids)
 	if not dup.generate(self, p_count, p_offset):
@@ -2246,7 +2273,13 @@ func create_radial_array(
 	pivot: Vector3,
 	rise: float = 0.0
 ) -> Variant:
-	if not HFDuplicator.can_generate(p_count, brush_ids.size()).ok:
+	if not (
+		HFDuplicator
+		. can_generate(
+			p_count, brush_ids.size(), {"step_degrees": step_degrees, "pivot": pivot, "rise": rise}
+		)
+		. ok
+	):
 		return null
 	var dup := _new_duplicator_for(brush_ids)
 	if not dup.generate_radial(self, p_count, axis_index, step_degrees, pivot, rise):
@@ -2257,7 +2290,11 @@ func create_radial_array(
 
 ## Lattice of copies. `counts` includes the source cell on each axis.
 func create_grid_array(brush_ids: PackedStringArray, counts: Vector3i, spacing: Vector3) -> Variant:
-	if not HFDuplicator.can_generate(HFDuplicator.grid_copy_count(counts), brush_ids.size()).ok:
+	if not (
+		HFDuplicator
+		. can_generate(HFDuplicator.grid_copy_count(counts), brush_ids.size(), {"spacing": spacing})
+		. ok
+	):
 		return null
 	var dup := _new_duplicator_for(brush_ids)
 	if not dup.generate_grid(self, counts, spacing):
@@ -2303,7 +2340,7 @@ func update_duplicate_array(duplicator_id: String, mode: int, params: Dictionary
 	# stays reachable.
 	if not (
 		HFDuplicator
-		. can_generate(dup.requested_copy_count(mode, params), dup.source_brush_ids.size())
+		. can_generate(dup.requested_copy_count(mode, params), dup.source_brush_ids.size(), params)
 		. ok
 	):
 		return false

--- a/addons/hammerforge/systems/hf_entity_system.gd
+++ b/addons/hammerforge/systems/hf_entity_system.gd
@@ -273,6 +273,11 @@ func delete_entities_by_paths(entity_paths: Array) -> void:
 
 
 func nudge_entities_by_paths(entity_paths: Array, offset: Vector3) -> void:
+	# The same guard the brush nudge has. Entities travel with the selection, so
+	# an offset that cannot be added would take them to the same nowhere.
+	if not offset.is_finite():
+		HFLog.warn("HFEntitySystem: nudge offset %s is not an offset" % str(offset))
+		return
 	for entity_path in entity_paths:
 		var entity := _entity_at_path(entity_path)
 		if entity:

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,519 tests across 181 scripts**: **3,512 passing tests**, seven intentional no-assert safety tests, and **17,839 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,530 tests across 182 scripts**: **3,523 passing tests**, seven intentional no-assert safety tests, and **17,877 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_transform_paths_refuse_non_numbers.gd
+++ b/tests/test_transform_paths_refuse_non_numbers.gd
@@ -1,0 +1,144 @@
+extends GutTest
+
+## The resize, nudge and array paths take numbers a user typed and turn them into
+## a position. Each used to take a value that is not a number and build from it
+## anyway, so the brush ended up somewhere nothing could reach again (#378, #379,
+## #382). The create path already refused all three, which is the behaviour these
+## three now match.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+const HFDuplicatorType = preload("res://addons/hammerforge/hf_duplicator.gd")
+
+var root: LevelRoot
+
+var non_finite := [
+	Vector3(NAN, 0.0, 0.0),
+	Vector3(0.0, INF, 0.0),
+	Vector3(-INF, NAN, INF),
+	Vector3(NAN, NAN, NAN),
+]
+
+
+func before_each():
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func _box(brush_id: String) -> DraftBrush:
+	return (
+		root.create_brush_from_info(
+			{"size": Vector3(64, 64, 64), "brush_id": brush_id, "drag_size_default": Vector3.ONE}
+		)
+		as DraftBrush
+	)
+
+
+func _brush_count() -> int:
+	return root.draft_brushes_node.get_child_count()
+
+
+# ===========================================================================
+# Resize (#378)
+# ===========================================================================
+
+
+func test_a_non_finite_resize_leaves_the_brush_where_it_was():
+	var brush := _box("b")
+	for size in non_finite:
+		root.set_brush_transform_by_id("b", size, brush.global_position)
+		assert_true(brush.size.is_finite(), "size %s was refused" % size)
+		assert_eq(brush.size, Vector3(64, 64, 64))
+
+
+func test_a_non_finite_position_leaves_the_brush_where_it_was():
+	var brush := _box("b")
+	for position in non_finite:
+		root.set_brush_transform_by_id("b", brush.size, position)
+		assert_true(brush.global_position.is_finite(), "position %s was refused" % position)
+
+
+func test_the_resize_path_floors_a_zero_or_negative_size_like_the_create_path():
+	var brush := _box("b")
+	root.set_brush_transform_by_id("b", Vector3(0.0, 64.0, 64.0), brush.global_position)
+	assert_almost_eq(brush.size.x, 0.1, 0.001, "a zero extent is floored, not written")
+
+	root.set_brush_transform_by_id("b", Vector3(-64.0, 64.0, 64.0), brush.global_position)
+	assert_almost_eq(brush.size.x, 64.0, 0.001, "a negative extent is made positive")
+
+
+func test_an_ordinary_resize_still_lands():
+	var brush := _box("b")
+	root.set_brush_transform_by_id("b", Vector3(32, 16, 8), Vector3(10, 0, 0))
+	assert_eq(brush.size, Vector3(32, 16, 8))
+	assert_eq(brush.global_position, Vector3(10, 0, 0))
+
+
+# ===========================================================================
+# Nudge (#379)
+# ===========================================================================
+
+
+func test_a_non_finite_nudge_offset_is_refused():
+	var brush := _box("b")
+	for offset in non_finite:
+		root.nudge_brushes_by_id(["b"], offset)
+		assert_true(brush.global_position.is_finite(), "offset %s was refused" % offset)
+		assert_eq(brush.global_position, Vector3.ZERO)
+
+
+func test_an_ordinary_nudge_still_moves_the_brush():
+	var brush := _box("b")
+	root.nudge_brushes_by_id(["b"], Vector3(64, 0, 0))
+	assert_eq(brush.global_position, Vector3(64, 0, 0))
+
+
+func test_a_non_finite_nudge_offset_is_refused_for_entities():
+	var entity := root.entity_system.place_entity_at_screen(null, Vector2.ZERO, "info_player_start")
+	if entity == null:
+		entity = DraftEntity.new()
+		entity.entity_type = "info_player_start"
+		root.entity_system.add_entity(entity)
+	entity.global_position = Vector3(8, 0, 0)
+	var path := str(root.get_path_to(entity))
+	root.nudge_entities_by_paths([path], Vector3(NAN, 0, 0))
+	assert_eq(entity.global_position, Vector3(8, 0, 0), "the entity did not move")
+
+
+# ===========================================================================
+# Array (#382)
+# ===========================================================================
+
+
+func test_a_non_finite_layout_number_lays_out_no_copies():
+	assert_eq(HFDuplicatorType.linear_placements(5, Vector3(NAN, 0, 0)).size(), 0)
+	assert_eq(HFDuplicatorType.grid_placements(Vector3i(2, 2, 2), Vector3(0, INF, 0)).size(), 0)
+	assert_eq(HFDuplicatorType.radial_placements(5, 1, NAN, Vector3.ZERO, 0.0).size(), 0)
+	assert_eq(HFDuplicatorType.radial_placements(5, 1, 30.0, Vector3.ZERO, INF).size(), 0)
+	assert_eq(HFDuplicatorType.radial_placements(5, 1, 30.0, Vector3(NAN, 0, 0), 0.0).size(), 0)
+
+
+func test_can_generate_refuses_a_layout_number_that_is_not_a_number():
+	var check: HFOpResult = HFDuplicatorType.can_generate(5, 1, {"offset": Vector3(NAN, 0, 0)})
+	assert_false(check.ok, "the offset is checked where the count is")
+	assert_true(check.message.contains("not a number"), check.message)
+	assert_true(HFDuplicatorType.can_generate(5, 1, {"offset": Vector3(64, 0, 0)}).ok)
+
+
+func test_an_array_with_a_non_finite_offset_builds_nothing():
+	_box("src")
+	var before := _brush_count()
+	assert_null(
+		root.brush_system.create_duplicate_array(PackedStringArray(["src"]), 5, Vector3(NAN, 0, 0))
+	)
+	assert_eq(_brush_count(), before, "no copies were made")
+
+
+func test_an_ordinary_array_is_still_built():
+	_box("src")
+	var before := _brush_count()
+	assert_not_null(
+		root.brush_system.create_duplicate_array(PackedStringArray(["src"]), 3, Vector3(64, 0, 0))
+	)
+	assert_eq(_brush_count(), before + 3, "three copies")


### PR DESCRIPTION
Three places where a number that is not a number reached brush geometry, all in the transform paths.

- #378 `set_brush_transform_by_id()` wrote the size straight onto the property. It goes through `_usable_size()` now, the same funnel `create_brush_from_info()` uses, and refuses a non-finite position with it.
- #379 `nudge_brushes_by_id()` guarded with `is_zero_approx()`, which a NaN passes. It and `nudge_entities_by_paths()` refuse a non-finite offset.
- #382 `can_generate()` checked the counts and never the layout numbers. The three placement builders lay out nothing when handed one that is not finite, and `can_generate()` takes the parameters so the message names the fields.

Tests in `tests/test_transform_paths_refuse_non_numbers.gd`. Full suite passes.

Fixes #378
Fixes #379
Fixes #382