### PR TITLE
Refuse the vertex edits that left the brush broken, and stop a split losing the face normal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Fixed
+- **A non-finite vertex move was accepted and wrote NaN into the face data**
+  (#365). `validate_convexity()` is written as a lower bound (`d > 0.02`) and
+  every comparison against NaN is false, so a NaN vertex read as behind every
+  plane of the brush and the move committed. A vertex position is the geometry
+  rather than a parameter used to build it, so the result poisoned the AABB and
+  the normal, propagated through clip and carve into brushes that were never
+  touched, and survived the save with no editor action that put it back.
+  `move_vertices()` and `update_drag_absolute()` refuse a non-finite delta before
+  any face is touched.
+- **Merging every vertex of a brush left a live brush with no faces** (#366).
+  Every face collapsed to a point and was removed, and `validate_convexity()` was
+  then asked about a brush with no faces — its `faces.size() < 4` early-out
+  returns true, so the merge was accepted. The brush stayed in the draft
+  container, selectable, counted and saved, drawing nothing and with no vertex
+  left to move it back. A merge that would leave fewer than four faces is refused
+  with a message, and the snapshot is restored.
+- **Splitting an edge could tell a wall it was a floor** (#367). `split_edge()`
+  inserts the midpoint *on* the edge, so when the split edge is the one at index
+  0 the face's first three vertices are collinear by construction. The normal was
+  computed from exactly those three, measured zero, and fell back to
+  `Vector3.UP` — and the normal is what the convexity check, the bake and the
+  `.map` export read, not the vertices. `_compute_normal()` uses Newell's method
+  over the whole polygon now, which is correct for any planar polygon regardless
+  of collinear runs, and `split_edge()` rotates the vertex list so it starts at
+  an actual corner. The convexity check builds its own plane from the first three
+  non-collinear vertices rather than reading the face normal, because an
+  area-weighted average is the one plane that hides a bend.
 - **A grid array with a negative axis count was built rather than refused**
   (#346). The linear and radial paths refuse a count below one with a message and
   a fix hint; the grid path clamped `(-2, 2, 2)` up to `(1, 2, 2)` first, so

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,519 tests across 181 test scripts (3,512 passing plus seven intentional no-assert safety tests; 17,839 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,529 tests across 182 test scripts (3,522 passing plus seven intentional no-assert safety tests; 17,892 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,529 tests across 182 test scripts (3,522 passing plus seven intentional no-assert safety tests; 17,892 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,540 tests across 183 test scripts (3,533 passing plus seven intentional no-assert safety tests; 17,930 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,519 tests** across **181 scripts** (**3,512 passing** plus seven intentional no-assert safety tests; **17,839 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,529 tests** across **182 scripts** (**3,522 passing** plus seven intentional no-assert safety tests; **17,892 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,529 tests** across **182 scripts** (**3,522 passing** plus seven intentional no-assert safety tests; **17,892 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,540 tests** across **183 scripts** (**3,533 passing** plus seven intentional no-assert safety tests; **17,930 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3512%20passing-brightgreen" alt="3512 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3522%20passing-brightgreen" alt="3522 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3522%20passing-brightgreen" alt="3522 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3533%20passing-brightgreen" alt="3533 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,529 tests across 182 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,540 tests across 183 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,519 tests across 181 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,529 tests across 182 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/face_data.gd
+++ b/addons/hammerforge/face_data.gd
@@ -579,16 +579,42 @@ func _compute_normal() -> void:
 	if local_verts.size() < 3:
 		normal = Vector3.UP
 		return
-	var a = local_verts[0]
-	var b = local_verts[1]
-	var c = local_verts[2]
-	# The edges are normalised before the cross, so what is measured is the angle
-	# between them rather than the area of the triangle. The raw cross product
-	# grows with the square of the face, so an absolute floor on it meant any
-	# small face was called degenerate and given `Vector3.UP` — a 0.01-unit bevel
-	# cap came out facing into the solid whatever winding it was built with, and
-	# the same is true of every tessellation sliver.
-	var n = (c - a).normalized().cross((b - a).normalized())
+	# Newell's method over the whole polygon, not the first three vertices.
+	# Three consecutive vertices can be collinear without the face being
+	# degenerate: `split_edge()` inserts a midpoint *on* an edge, and when the
+	# split edge is the one at index 0 the first three vertices are collinear by
+	# construction. The first-three cross product then measured zero, the
+	# degenerate fallback fired, and a side wall was told it faced up — which is
+	# what `validate_convexity()`, the bake and the `.map` export all read.
+	#
+	# The vertices are made relative to the first one and scaled by the face's
+	# own extent before the sum, so what is measured is the shape rather than its
+	# area. An absolute floor on the raw sum would call any small face
+	# degenerate, which is the bug the previous comment here was about: a
+	# 0.01-unit bevel cap came out facing into the solid whatever winding it was
+	# built with, and the same is true of every tessellation sliver. Newell's sum
+	# is translation invariant, so the shift costs nothing.
+	var origin: Vector3 = local_verts[0]
+	var extent := 0.0
+	for v in local_verts:
+		var offset: Vector3 = v - origin
+		extent = maxf(extent, maxf(absf(offset.x), maxf(absf(offset.y), absf(offset.z))))
+	if extent <= 0.0:
+		normal = Vector3.UP
+		return
+	var inv_extent := 1.0 / extent
+	var count := local_verts.size()
+	var n := Vector3.ZERO
+	for i in count:
+		var current: Vector3 = (local_verts[i] - origin) * inv_extent
+		var next: Vector3 = (local_verts[(i + 1) % count] - origin) * inv_extent
+		n.x += (current.y - next.y) * (current.z + next.z)
+		n.y += (current.z - next.z) * (current.x + next.x)
+		n.z += (current.x - next.x) * (current.y + next.y)
+	# Negated, because HammerForge winds a face clockwise seen from outside and
+	# Newell's sum follows the other hand. This is the winding the old
+	# `(c - a).cross(b - a)` produced.
+	n = -n
 	if n.length() > 0.0001:
 		normal = n.normalized()
 	else:

--- a/addons/hammerforge/systems/hf_vertex_system.gd
+++ b/addons/hammerforge/systems/hf_vertex_system.gd
@@ -58,10 +58,25 @@ func get_brush_vertices(brush: Node3D) -> PackedVector3Array:
 	return verts
 
 
+## Tell the mapper why an edit was refused, when there is a level to tell.
+func _say(text: String) -> void:
+	if root and root.has_signal("user_message"):
+		root.emit_signal("user_message", text, 1)
+
+
 ## Move selected vertices by delta. Updates all faces sharing those vertices.
 ## Returns true if the move was valid (all brushes remain convex).
 func move_vertices(delta: Vector3) -> bool:
 	if selected_vertices.is_empty():
+		return false
+	# Before any face is touched. `validate_convexity()` below is written as a
+	# lower bound (`d > 0.02`), and every comparison against NaN is false, so a
+	# NaN vertex reads as behind every plane of the brush and the move commits.
+	# A vertex position is the geometry rather than a parameter used to build it,
+	# so the result poisons the AABB and the normal, propagates through clip and
+	# carve into brushes that were never touched, and survives the save.
+	if not delta.is_finite():
+		HFLog.warn("HFVertexSystem: vertex move delta %s is not a delta" % str(delta))
 		return false
 	# Snapshot faces before move if not already captured
 	if _pre_drag_faces.is_empty():
@@ -98,10 +113,11 @@ func move_vertices(delta: Vector3) -> bool:
 	# Validate convexity
 	for brush_id in selected_vertices:
 		var brush = _find_brush(brush_id)
-		if brush and not validate_convexity(brush):
+		if not brush:
+			continue
+		if not validate_convexity(brush):
 			_restore_face_snapshots()
-			if root and root.has_signal("user_message"):
-				root.emit_signal("user_message", "Move rejected: would create non-convex brush", 1)
+			_say("Move rejected: would create non-convex brush")
 			return false
 	# Rebuild previews
 	for brush_id in selected_vertices:
@@ -109,6 +125,27 @@ func move_vertices(delta: Vector3) -> bool:
 		if brush:
 			_commit_geometry(brush)
 	return true
+
+
+## The plane through the first corner of a polygon, for the convexity test.
+##
+## `face.normal` is Newell's over the whole polygon, which is the right answer
+## for a planar face and the wrong one here: a face that has been bent has
+## several planes, and the area-weighted average is the one that hides the bend.
+## A dented box would read as convex. This takes the first three vertices that
+## are not collinear instead — the same plane the check used before
+## `_compute_normal()` was widened, and the collinear run `split_edge()` leaves
+## at the front of the list is stepped over rather than measured.
+static func _corner_plane_normal(verts: PackedVector3Array) -> Vector3:
+	var count := verts.size()
+	if count < 3:
+		return Vector3.ZERO
+	var a: Vector3 = verts[0]
+	for i in range(1, count - 1):
+		var n: Vector3 = (verts[i + 1] - a).normalized().cross((verts[i] - a).normalized())
+		if n.length() > 0.0001:
+			return n.normalized()
+	return Vector3.ZERO
 
 
 ## Validate that all faces of a brush form a convex shape.
@@ -128,7 +165,7 @@ func validate_convexity(brush: Node3D) -> bool:
 		if face == null or face.local_verts.size() < 3:
 			continue
 		var plane_point: Vector3 = face.local_verts[0]
-		var plane_normal: Vector3 = face.normal
+		var plane_normal: Vector3 = _corner_plane_normal(face.local_verts)
 		if plane_normal.length() < 0.001:
 			continue
 		for v in all_verts:
@@ -406,6 +443,11 @@ func begin_drag(start_world_pos: Vector3) -> void:
 ## Vector3.ZERO restores the exact starting vertex positions.
 func update_drag_absolute(world_delta: Vector3) -> bool:
 	if not _drag_active or _pre_drag_faces.is_empty():
+		return false
+	# The same guard `move_vertices()` has. A screen-space drag divided by a
+	# zero-length projection arrives here, and the convexity check below cannot
+	# refuse a NaN.
+	if not world_delta.is_finite():
 		return false
 	if _drag_has_valid_update and world_delta.is_equal_approx(_drag_last_world_delta):
 		return true
@@ -735,7 +777,7 @@ func split_edge(brush_id: String, edge: Array) -> bool:
 					new_verts.append(fv[k])
 					if k == j:
 						new_verts.append(midpoint)
-				face.local_verts = new_verts
+				face.local_verts = _rotated_to_a_corner(new_verts)
 				face.ensure_geometry()
 				modified = true
 				break
@@ -748,6 +790,33 @@ func split_edge(brush_id: String, edge: Array) -> bool:
 	# can break convexity.  For splits we only need to verify face integrity.
 	_commit_geometry(brush)
 	return true
+
+
+## The same polygon, started at a vertex that is an actual corner.
+##
+## Inserting a midpoint on the edge at index 0 leaves `[v0, midpoint, v1, ...]`,
+## which is three collinear vertices at the front of the list. `_compute_normal()`
+## reads the whole polygon now, so it no longer minds — but plenty of code reads
+## `local_verts[0..2]` as a plane, and a face whose list starts at a corner costs
+## nothing to produce.
+static func _rotated_to_a_corner(verts: PackedVector3Array) -> PackedVector3Array:
+	var count := verts.size()
+	if count < 3:
+		return verts
+	for start in count:
+		var previous: Vector3 = verts[(start - 1 + count) % count]
+		var current: Vector3 = verts[start]
+		var following: Vector3 = verts[(start + 1) % count]
+		var incoming := (current - previous).normalized()
+		var outgoing := (following - current).normalized()
+		if incoming.cross(outgoing).length() > 0.0001:
+			if start == 0:
+				return verts
+			var out := PackedVector3Array()
+			for offset in count:
+				out.append(verts[(start + offset) % count])
+			return out
+	return verts
 
 
 ## Merge selected vertices in a brush to their centroid. Returns true on success.
@@ -803,9 +872,20 @@ func merge_vertices(brush_id: String, vert_indices: PackedInt32Array) -> bool:
 	# Remove degenerate faces (reverse order)
 	for i in range(faces_to_remove.size() - 1, -1, -1):
 		faces.remove_at(faces_to_remove[i])
+	# Fewer than four faces is not a closed solid. `validate_convexity()` allows
+	# it — `faces.size() < 4` returns true there so a genuinely degenerate
+	# intermediate can pass — which meant merging every vertex of a box removed
+	# all six faces and was accepted. The brush stayed live, selectable, counted
+	# and saved, with no vertex left to move it back and nothing drawn to find
+	# it by.
+	if faces.size() < 4:
+		_restore_face_snapshots()
+		_say("Merge rejected: would leave the brush without a closed solid")
+		return false
 	# Validate
 	if not validate_convexity(brush):
 		_restore_face_snapshots()
+		_say("Merge rejected: would create non-convex brush")
 		return false
 	_commit_geometry(brush)
 	return true

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -1309,7 +1309,7 @@ Use **X**, **Y**, or **Z** to constrain the drag to that world axis. HammerForge
 - **Merge vertices** (Ctrl+W): select 2+ vertices, then press Ctrl+W to merge them to their centroid. Merging is rejected if it would break convexity.
 
 ### Convexity Enforcement
-All vertex operations validate that the brush remains convex. If a move or merge would create a concave shape, the operation is rejected and the brush reverts to its previous state.
+All vertex operations validate that the brush remains convex. If a move or merge would create a concave shape, the operation is rejected and the brush reverts to its previous state. A merge is also rejected if it would leave the brush without a closed solid, which is what merging every vertex of a box would do. A move by an offset that is not a number is refused before any face is touched.
 
 ### Clip to Convex
 If a brush has been deformed into a non-convex shape (e.g., by external editing or import), use the **Convex** button in the vertex edit context toolbar to recompute its convex hull. This:

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,519 tests across 181 scripts**: **3,512 passing tests**, seven intentional no-assert safety tests, and **17,839 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,529 tests across 182 scripts**: **3,522 passing tests**, seven intentional no-assert safety tests, and **17,892 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,529 tests across 182 scripts**: **3,522 passing tests**, seven intentional no-assert safety tests, and **17,892 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,540 tests across 183 scripts**: **3,533 passing tests**, seven intentional no-assert safety tests, and **17,930 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_vertex_edits_that_broke_the_brush.gd
+++ b/tests/test_vertex_edits_that_broke_the_brush.gd
@@ -1,0 +1,264 @@
+extends GutTest
+
+## Three things a vertex edit could do that nothing refused or measured (#365,
+## #366, #367). The convexity check is written as a lower bound, so it cannot see
+## a NaN; it allows a brush with fewer than four faces, so it cannot see a brush
+## the merge emptied; and a split leaves three collinear vertices at the front of
+## a face, which the old first-three-vertices normal read as no normal at all.
+
+const HFVertexSystem = preload("res://addons/hammerforge/systems/hf_vertex_system.gd")
+const DraftBrush = preload("res://addons/hammerforge/brush_instance.gd")
+const FaceData = preload("res://addons/hammerforge/face_data.gd")
+
+var root: Node3D
+var vs: HFVertexSystem
+var draft_node: Node3D
+
+
+func before_each():
+	root = Node3D.new()
+	root.set_script(_root_shim_script())
+	add_child_autoqfree(root)
+	draft_node = Node3D.new()
+	draft_node.name = "DraftBrushes"
+	root.add_child(draft_node)
+	root.draft_brushes_node = draft_node
+	vs = HFVertexSystem.new(root)
+
+
+func after_each():
+	root = null
+	vs = null
+	draft_node = null
+
+
+func _root_shim_script() -> GDScript:
+	var s = GDScript.new()
+	s.source_code = """
+extends Node3D
+
+var draft_brushes_node: Node3D
+var brush_system: RefCounted
+var grid_snap := 8.0
+var drag_size_default := Vector3(32, 32, 32)
+var dirty_brush_ids: Array[String] = []
+signal user_message(msg, level)
+
+func tag_brush_dirty(brush_id: String) -> void:
+	dirty_brush_ids.append(brush_id)
+"""
+	s.reload()
+	return s
+
+
+func _make_box_brush(pos: Vector3, sz: Vector3, id: String) -> DraftBrush:
+	var b = DraftBrush.new()
+	b.size = sz
+	b.brush_id = id
+	draft_node.add_child(b)
+	b.global_position = pos
+	# Build box faces
+	var half = sz * 0.5
+	# CW winding from outside (matches _build_box_faces in production code)
+	var quads = [
+		[
+			Vector3(half.x, -half.y, half.z),
+			Vector3(half.x, half.y, half.z),
+			Vector3(half.x, half.y, -half.z),
+			Vector3(half.x, -half.y, -half.z)
+		],
+		[
+			Vector3(-half.x, -half.y, -half.z),
+			Vector3(-half.x, half.y, -half.z),
+			Vector3(-half.x, half.y, half.z),
+			Vector3(-half.x, -half.y, half.z)
+		],
+		[
+			Vector3(half.x, half.y, -half.z),
+			Vector3(half.x, half.y, half.z),
+			Vector3(-half.x, half.y, half.z),
+			Vector3(-half.x, half.y, -half.z)
+		],
+		[
+			Vector3(half.x, -half.y, half.z),
+			Vector3(half.x, -half.y, -half.z),
+			Vector3(-half.x, -half.y, -half.z),
+			Vector3(-half.x, -half.y, half.z)
+		],
+		[
+			Vector3(-half.x, half.y, half.z),
+			Vector3(half.x, half.y, half.z),
+			Vector3(half.x, -half.y, half.z),
+			Vector3(-half.x, -half.y, half.z)
+		],
+		[
+			Vector3(-half.x, -half.y, -half.z),
+			Vector3(half.x, -half.y, -half.z),
+			Vector3(half.x, half.y, -half.z),
+			Vector3(-half.x, half.y, -half.z)
+		]
+	]
+	var faces: Array[FaceData] = []
+	for quad in quads:
+		var face = FaceData.new()
+		face.local_verts = PackedVector3Array(quad)
+		face.ensure_geometry()
+		faces.append(face)
+	b.faces = faces
+	return b
+
+
+func _side_face(brush: DraftBrush, axis_normal: Vector3) -> FaceData:
+	for face in brush.faces:
+		if face.normal.dot(axis_normal) > 0.9:
+			return face
+	return null
+
+
+# ===========================================================================
+# A non-finite move is refused (#365)
+# ===========================================================================
+
+
+func test_a_non_finite_vertex_move_is_refused():
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "nan")
+	vs.set_selection([brush])
+	vs.select_vertex("nan", 0, false)
+	for delta in [Vector3(NAN, 0, 0), Vector3(0, INF, 0), Vector3(-INF, NAN, INF)]:
+		assert_false(vs.move_vertices(delta), "%s is not a delta" % delta)
+	for vertex in vs.get_brush_vertices(brush):
+		assert_true(vertex.is_finite(), "no vertex was poisoned")
+	for face in brush.faces:
+		assert_true(face.normal.is_finite(), "no face normal was poisoned")
+
+
+func test_an_ordinary_vertex_move_still_lands():
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "ok")
+	vs.set_selection([brush])
+	var before := vs.get_brush_vertices(brush)[0]
+	vs.select_vertex("ok", 0, false)
+	assert_true(vs.move_vertices(Vector3(4, 0, 0)))
+	var found := false
+	for vertex in vs.get_brush_vertices(brush):
+		if vertex.is_equal_approx(before + Vector3(4, 0, 0)):
+			found = true
+	assert_true(found, "the vertex moved")
+
+
+func test_a_non_finite_drag_update_is_refused():
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "drag")
+	vs.set_selection([brush])
+	vs.select_vertex("drag", 0, false)
+	vs.begin_drag(Vector3.ZERO)
+	assert_false(vs.update_drag_absolute(Vector3(NAN, 0, 0)))
+	for vertex in vs.get_brush_vertices(brush):
+		assert_true(vertex.is_finite(), "the drag wrote nothing")
+	vs.cancel_drag()
+
+
+# ===========================================================================
+# A merge that empties the brush is refused (#366)
+# ===========================================================================
+
+
+func test_merging_every_vertex_of_a_box_is_refused():
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "all")
+	vs.set_selection([brush])
+	var all_indices := PackedInt32Array()
+	for i in vs.get_brush_vertices(brush).size():
+		all_indices.append(i)
+	assert_eq(all_indices.size(), 8, "a box has eight vertices")
+
+	assert_false(vs.merge_vertices("all", all_indices), "that is not a solid")
+	assert_eq(brush.faces.size(), 6, "the brush still has its faces")
+	assert_eq(vs.get_brush_vertices(brush).size(), 8, "and its vertices")
+
+
+func test_merging_one_face_worth_of_vertices_is_refused():
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "face")
+	vs.set_selection([brush])
+	var verts := vs.get_brush_vertices(brush)
+	var top := PackedInt32Array()
+	for i in verts.size():
+		if verts[i].y > 0.0:
+			top.append(i)
+	assert_eq(top.size(), 4, "four vertices on the top face")
+	# Five faces survive, which the `faces.size() < 4` guard in
+	# validate_convexity() lets through, so this is refused for being non-convex
+	# rather than for being empty. Either way the brush is not left broken.
+	vs.merge_vertices("face", top)
+	for face in brush.faces:
+		assert_gt(face.local_verts.size(), 2, "no face was left with an edge")
+
+
+func test_the_convexity_check_cannot_be_what_refuses_an_empty_merge():
+	# Why the guard is in merge_vertices() and not in the validator: a brush with
+	# no faces passes validate_convexity(), because the `faces.size() < 4`
+	# early-out is there to let a genuinely degenerate intermediate through. That
+	# is exactly the case an all-vertex merge produces.
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "empty")
+	brush.faces = [] as Array[FaceData]
+	assert_true(vs.validate_convexity(brush), "the validator says nothing about an empty brush")
+
+
+# ===========================================================================
+# A split edge leaves a face that still knows which way it points (#367)
+# ===========================================================================
+
+
+func test_splitting_an_edge_does_not_turn_a_wall_into_a_floor():
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "split")
+	vs.set_selection([brush])
+	var normals_before: Array = []
+	for face in brush.faces:
+		normals_before.append(face.normal)
+
+	var edges := vs.get_brush_edges(brush)
+	assert_gt(edges.size(), 0, "the box has edges")
+	assert_true(vs.split_edge("split", edges[0]), "the split was accepted")
+
+	assert_eq(vs.get_brush_vertices(brush).size(), 9, "one vertex was added")
+	assert_eq(brush.faces.size(), 6, "no face was added or lost")
+	for i in brush.faces.size():
+		assert_true(
+			brush.faces[i].normal.is_equal_approx(normals_before[i]),
+			"face %d still points where it did: %s" % [i, brush.faces[i].normal]
+		)
+
+
+func test_a_split_brush_is_still_convex():
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "convex")
+	vs.set_selection([brush])
+	var edges := vs.get_brush_edges(brush)
+	assert_true(vs.split_edge("convex", edges[0]))
+	assert_true(
+		vs.validate_convexity(brush), "a midpoint on the hull does not make the brush non-convex"
+	)
+
+
+func test_a_collinear_run_does_not_stop_a_face_reporting_its_normal():
+	# The shape `split_edge()` produces: a square with a midpoint on the first
+	# edge, so local_verts[0..2] are collinear by construction.
+	var face := FaceData.new()
+	face.local_verts = PackedVector3Array(
+		[
+			Vector3(-16, 0, -16),
+			Vector3(0, 0, -16),
+			Vector3(16, 0, -16),
+			Vector3(16, 0, 16),
+			Vector3(-16, 0, 16)
+		]
+	)
+	face.ensure_geometry()
+	assert_almost_eq(absf(face.normal.y), 1.0, 0.001, "this face is flat in Y: %s" % face.normal)
+
+
+func test_a_tiny_face_still_reports_its_normal():
+	# The bug the previous comment in _compute_normal() was about: an absolute
+	# floor on the raw cross product called every small face degenerate.
+	var face := FaceData.new()
+	face.local_verts = PackedVector3Array(
+		[Vector3(0, 0, 0), Vector3(0.01, 0, 0), Vector3(0.01, 0, 0.01), Vector3(0, 0, 0.01)]
+	)
+	face.ensure_geometry()
+	assert_almost_eq(absf(face.normal.y), 1.0, 0.001, "a 0.01-unit face has a normal too")


### PR DESCRIPTION
Three of the four vertex issues from the sweep. #364 is not here, see below.

- #365 `move_vertices()` and `update_drag_absolute()` refuse a non-finite delta. The convexity check is a lower bound, so it could never have caught one.
- #366 A merge that would leave fewer than four faces is refused with a message. `validate_convexity()` cannot be the thing that catches this: its `faces.size() < 4` early-out returns true, which is the case an all-vertex merge produces.
- #367 `_compute_normal()` uses Newell's method over the whole polygon, and `split_edge()` rotates the vertex list to start at a real corner. `validate_convexity()` now builds its own plane from the first three non-collinear vertices instead of reading `face.normal` — Newell's area-weighted average is the one plane that hides a bend, and reading it made the check miss a dented box.

**#364 is not in this branch.** Implementing the refusal it asks for rejects every ordinary vertex move: moving one corner of a box bows at least one of the three quads meeting at it, so there is no tolerance that permits a 4-unit bow and refuses a 62-unit one. The real fix is the alternative the issue names, splitting the bent face into planar pieces on commit, and that changes the face model. Left open for its own branch.

Tests in `tests/test_vertex_edits_that_broke_the_brush.gd`. Full suite passes.

Fixes #365
Fixes #366
Fixes #367