### PR TITLE
Stop a prefab leaving the level holding something it should not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Fixed
+- **A placed prefab brush kept visgroup names the receiving level had never
+  registered** (#368). `capture_from_selection()` strips `brush_id` and
+  `group_id` because they only mean something in the level the selection came
+  from; `visgroups` is the same kind of thing and was kept. A prefab library
+  shared between levels is the normal way to use prefabs, so the placed brush
+  routinely ended up in a group with no row in the visgroup panel — it could not
+  be shown, hidden, renamed or deleted, `refresh_visibility()` skipped it, the
+  partitioned bake still read the membership off the node, and the `.hflevel`
+  kept it. Stripped on capture now, for entities as well as brushes.
+- **A prefab restore could reissue a live instance id** (#369). `restore_state()`
+  took `next_instance_id` from the saved data and never reconciled it against the
+  records it had just restored, so a state whose instances list held `pfx_1` with
+  a counter of 1 — exactly what a `.hflevel` saved before the counter was
+  captured produces — issued `pfx_1` again for the next placement. The registry
+  write is a plain dictionary assignment, so the second registration overwrote
+  the first silently and the first placement's nodes were left tagged with an id
+  that now resolved to a different prefab. The counter is derived from the
+  restored records, for entity uids as well, and `register_instance()` warns
+  rather than overwrite.
+- **A malformed `.hfprefab` left the level's signal batch open for the session**
+  (#370). `from_dict()` checked that `brush_infos` was an Array and not what was
+  in it, so an entry that was not a Dictionary reached `info.duplicate(true)` in
+  `instantiate()`. GDScript has no exception handling, the function unwound past
+  its own `end_signal_batch()`, and from then on `_emit_or_batch()` queued every
+  level signal and emitted none: the brush list, the entity list, the visgroup
+  panel and the validation badge all froze while editing carried on working, with
+  nothing pointing back at a prefab that failed to place. Non-Dictionary entries
+  are dropped on load with a warning, and `LevelRoot` releases a signal batch
+  that has been open for more than a second with a warning, so no skipped
+  `end_signal_batch()` can take the dock down again.
 - **A grid array with a negative axis count was built rather than refused**
   (#346). The linear and radial paths refuse a count below one with a message and
   a fix hint; the grid path clamped `(-2, 2, 2)` up to `(1, 2, 2)` first, so

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,519 tests across 181 test scripts (3,512 passing plus seven intentional no-assert safety tests; 17,839 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,528 tests across 182 test scripts (3,521 passing plus seven intentional no-assert safety tests; 17,857 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,528 tests across 182 test scripts (3,521 passing plus seven intentional no-assert safety tests; 17,857 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,549 tests across 184 test scripts (3,542 passing plus seven intentional no-assert safety tests; 17,948 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,519 tests** across **181 scripts** (**3,512 passing** plus seven intentional no-assert safety tests; **17,839 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,528 tests** across **182 scripts** (**3,521 passing** plus seven intentional no-assert safety tests; **17,857 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,528 tests** across **182 scripts** (**3,521 passing** plus seven intentional no-assert safety tests; **17,857 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,549 tests** across **184 scripts** (**3,542 passing** plus seven intentional no-assert safety tests; **17,948 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3512%20passing-brightgreen" alt="3512 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3521%20passing-brightgreen" alt="3521 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3521%20passing-brightgreen" alt="3521 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3542%20passing-brightgreen" alt="3542 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,519 tests across 181 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,528 tests across 182 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,528 tests across 182 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,549 tests across 184 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/hf_prefab.gd
+++ b/addons/hammerforge/hf_prefab.gd
@@ -52,6 +52,14 @@ static func capture_from_selection(
 		info.erase("brush_id")
 		# Clear group memberships (prefab instances get their own)
 		info.erase("group_id")
+		# And visgroup membership, for the same reason. A visgroup is a list of
+		# names registered per level, so a prefab placed into a level that has
+		# never had "Lighting" put brushes in a group with no row in the visgroup
+		# panel: it cannot be shown, hidden, renamed or deleted, it is skipped by
+		# refresh_visibility(), the partitioned bake still reads it off the node,
+		# and it is saved. A prefab library shared between levels is the normal
+		# way to use prefabs, so this was the common case.
+		info.erase("visgroups")
 		prefab.brush_infos.append(info)
 
 	# Capture entities
@@ -63,6 +71,9 @@ static func capture_from_selection(
 			var t: Transform3D = info["transform"]
 			t.origin -= centroid
 			info["transform"] = t
+		# The same two, for the same reasons as the brush half above.
+		info.erase("group_id")
+		info.erase("visgroups")
 		prefab.entity_infos.append(info)
 
 	return prefab
@@ -140,6 +151,8 @@ func instantiate(
 
 	# Instantiate brushes
 	for info in b_infos:
+		if not (info is Dictionary):
+			continue
 		var placed_info: Dictionary = info.duplicate(true)
 		# Offset transform by placement position
 		if placed_info.has("transform"):
@@ -157,6 +170,8 @@ func instantiate(
 	var new_entity_names: Array = []
 	var new_entity_nodes: Array = []
 	for info in e_infos:
+		if not (info is Dictionary):
+			continue
 		var placed_info: Dictionary = info.duplicate(true)
 		if placed_info.has("transform"):
 			var t: Transform3D = placed_info["transform"]
@@ -283,13 +298,38 @@ func to_dict() -> Dictionary:
 
 
 ## Deserialize from a dictionary.
+## The Dictionary entries of a decoded list, and a warning about what was dropped.
+##
+## `.hfprefab` files are JSON in the project, so a merge conflict, a truncated
+## write or an older build with a different shape all produce one with an entry
+## that is not a Dictionary. `instantiate()` called `info.duplicate(true)` on it,
+## which is a runtime error, and GDScript has no exception handling — so the
+## function unwound past its own `end_signal_batch()` and left the level's signal
+## batch open for the rest of the editor session, with the dock silently frozen.
+static func _dictionary_entries(raw, what: String) -> Array:
+	if not (raw is Array):
+		if raw != null:
+			HFLog.warn("HFPrefab: '%s' is not a list, ignoring it" % what)
+		return []
+	var out: Array = []
+	var dropped := 0
+	for entry in raw:
+		if entry is Dictionary:
+			out.append(entry)
+		else:
+			dropped += 1
+	if dropped > 0:
+		HFLog.warn("HFPrefab: dropped %d '%s' entries that were not objects" % [dropped, what])
+	return out
+
+
 static func from_dict(data: Dictionary) -> HFPrefab:
 	var prefab = HFPrefab.new()
 	prefab.prefab_name = str(data.get("prefab_name", ""))
 	var raw_brushes = HFLevelIO.decode_variant(data.get("brush_infos", []))
 	var raw_entities = HFLevelIO.decode_variant(data.get("entity_infos", []))
-	prefab.brush_infos = raw_brushes if raw_brushes is Array else []
-	prefab.entity_infos = raw_entities if raw_entities is Array else []
+	prefab.brush_infos = _dictionary_entries(raw_brushes, "brush_infos")
+	prefab.entity_infos = _dictionary_entries(raw_entities, "entity_infos")
 
 	# Tags
 	var raw_tags = data.get("tags", [])
@@ -306,8 +346,8 @@ static func from_dict(data: Dictionary) -> HFPrefab:
 				var vb = HFLevelIO.decode_variant(vd.get("brush_infos", []))
 				var ve = HFLevelIO.decode_variant(vd.get("entity_infos", []))
 				prefab.variants[str(vname)] = {
-					"brush_infos": vb if vb is Array else [],
-					"entity_infos": ve if ve is Array else [],
+					"brush_infos": _dictionary_entries(vb, "variant brush_infos"),
+					"entity_infos": _dictionary_entries(ve, "variant entity_infos"),
 				}
 
 	return prefab

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -298,10 +298,26 @@ func consume_dirty_tags() -> Dictionary:
 
 var _signal_batch_depth := 0
 var _batched_signals: Array = []  # Array of {name: String, args: Array}
+var _signal_batch_opened_msec := -1
+var _signal_batch_stuck_reported := false
+
+## How long an open batch may survive before it is treated as
+## abandoned. Every batch in the plugin is opened and closed inside one
+## synchronous operation, so a batch still open this long afterwards is one whose
+## `end_signal_batch()` was skipped — which GDScript makes easy, since a runtime
+## error unwinds the function and there is no `finally` to put the depth back.
+## The consequence was invisible and permanent: `_emit_or_batch()` queued every
+## level signal for the rest of the editor session, so the brush list, the entity
+## list, the visgroup panel and the validation badge froze while editing carried
+## on working, with nothing pointing at the operation that failed.
+const SIGNAL_BATCH_STUCK_MSEC := 1000
 
 
 ## Begin batching signals. Nested calls are supported (depth-counted).
 func begin_signal_batch() -> void:
+	if _signal_batch_depth == 0:
+		_signal_batch_opened_msec = Time.get_ticks_msec()
+		_signal_batch_stuck_reported = false
 	_signal_batch_depth += 1
 
 
@@ -310,7 +326,30 @@ func end_signal_batch() -> void:
 	_signal_batch_depth -= 1
 	if _signal_batch_depth <= 0:
 		_signal_batch_depth = 0
+		_signal_batch_opened_msec = -1
 		_flush_batched_signals()
+
+
+## Flush and clear a batch nothing closed. Called once per frame from _process.
+func _release_stuck_signal_batch() -> void:
+	if _signal_batch_depth <= 0 or _signal_batch_opened_msec < 0:
+		return
+	if Time.get_ticks_msec() - _signal_batch_opened_msec < SIGNAL_BATCH_STUCK_MSEC:
+		return
+	if not _signal_batch_stuck_reported:
+		_signal_batch_stuck_reported = true
+		push_warning(
+			(
+				(
+					"HammerForge: a signal batch was left open (depth %d, %d queued). "
+					+ "Releasing it so the dock keeps updating."
+				)
+				% [_signal_batch_depth, _batched_signals.size()]
+			)
+		)
+	_signal_batch_depth = 0
+	_signal_batch_opened_msec = -1
+	_flush_batched_signals()
 
 
 ## Queue a signal for emission, or emit immediately if not batching.
@@ -344,6 +383,7 @@ func _flush_batched_signals() -> void:
 func discard_signal_batch() -> void:
 	_batched_signals.clear()
 	_signal_batch_depth = 0
+	_signal_batch_opened_msec = -1
 
 
 func _emit_signal_by_name(signal_name: String, args: Array) -> void:
@@ -625,6 +665,7 @@ func _process(_delta: float) -> void:
 	if not Engine.is_editor_hint():
 		return
 	_process_hflevel_saves()
+	_release_stuck_signal_batch()
 	if io_visualizer:
 		io_visualizer.process(_delta)
 	if subtract_preview and subtract_preview.is_enabled():

--- a/addons/hammerforge/systems/hf_prefab_system.gd
+++ b/addons/hammerforge/systems/hf_prefab_system.gd
@@ -84,6 +84,11 @@ func register_instance(
 			uids.append(uid)
 	rec.entity_uids = uids
 
+	# Overwriting silently is what turns a stale counter into orphaned nodes, so
+	# say so rather than replace. The counter is derived from the restored records
+	# now, which should mean this never fires.
+	if _instances.has(iid):
+		push_warning("HFPrefabSystem: instance id '%s' is already registered" % iid)
 	_instances[iid] = rec
 	# Tag every brush/entity node with the instance_id so we can find them
 	_tag_nodes(rec)
@@ -574,6 +579,15 @@ func quick_save_prefab(
 # ---------------------------------------------------------------------------
 
 
+## The number at the end of a `pfx_N` or `pent_N` id, or 0 if there is not one.
+static func _id_number(id: String) -> int:
+	var underscore := id.rfind("_")
+	if underscore < 0:
+		return 0
+	var tail := id.substr(underscore + 1)
+	return int(tail) if tail.is_valid_int() else 0
+
+
 func capture_state() -> Dictionary:
 	var data: Dictionary = {}
 	data["next_instance_id"] = _next_instance_id
@@ -618,3 +632,16 @@ func restore_state(data: Dictionary) -> void:
 		if rec.instance_id != "":
 			_instances[rec.instance_id] = rec
 			_tag_nodes(rec)
+			# The floor comes from what was restored, not from the stored counter.
+			# A state whose instances list holds `pfx_1` while its
+			# `next_instance_id` is 1 restores cleanly and then issues `pfx_1`
+			# again, and `_instances[iid] = rec` is a plain dictionary write, so
+			# the second registration overwrites the first without a word. The
+			# first placement's nodes are still tagged with that id and now
+			# resolve to a record describing a different prefab, which is how
+			# `set_variant()` ends up orphaning brushes instead of replacing them.
+			# `data.get("next_instance_id", 1)` is exactly what a `.hflevel`
+			# saved before the counter was captured produces.
+			_next_instance_id = maxi(_next_instance_id, _id_number(rec.instance_id) + 1)
+			for uid in rec.entity_uids:
+				_next_entity_uid = maxi(_next_entity_uid, _id_number(str(uid)) + 1)

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,528 tests across 182 scripts**: **3,521 passing tests**, seven intentional no-assert safety tests, and **17,857 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,549 tests across 184 scripts**: **3,542 passing tests**, seven intentional no-assert safety tests, and **17,948 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,519 tests across 181 scripts**: **3,512 passing tests**, seven intentional no-assert safety tests, and **17,839 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,528 tests across 182 scripts**: **3,521 passing tests**, seven intentional no-assert safety tests, and **17,857 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -141,7 +141,7 @@ Grid-based paint layers with chunked storage for large worlds:
 - **Cordon** -- restrict bake to an AABB region with yellow wireframe; skip everything outside
 - **Reference cleanup** -- deleting brushes auto-cleans group/visgroup membership and warns about dangling entity I/O connections
 - **Duplicator** -- create N copies of a brush with progressive offset
-- **Prefabs** -- save brush + entity groups as `.hfprefab` files with variants, tags, and live-linked propagation. Drag from library to instantiate with new IDs and remapped I/O
+- **Prefabs** -- save brush + entity groups as `.hfprefab` files with variants, tags, and live-linked propagation. Drag from library to instantiate with new IDs and remapped I/O. Brush and entity ids, group membership and visgroup membership are all left behind on capture, because they only mean something in the level the selection came from
 - **Measurement** (M key) -- persistent multi-ruler with angle display, Shift+Click chaining, and snap reference alignment
 - **Decal placement** (N key) -- raycast decals onto brush surfaces with live preview
 - **Real-time subtract preview** -- toggle wireframe AABB intersection overlays between additive and subtractive brushes

--- a/tests/test_prefab_instance_integrity.gd
+++ b/tests/test_prefab_instance_integrity.gd
@@ -1,0 +1,141 @@
+extends GutTest
+
+## Three ways a prefab left the level holding something it should not (#368,
+## #369, #370): a visgroup name the level has never registered, an instance id
+## already in use, and a signal batch nothing closed.
+
+const HFPrefabType = preload("res://addons/hammerforge/hf_prefab.gd")
+const HFPrefabSystemType = preload("res://addons/hammerforge/systems/hf_prefab_system.gd")
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+
+var root: LevelRoot
+
+
+func before_each():
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func _box(brush_id: String) -> DraftBrush:
+	return (
+		root.create_brush_from_info({"size": Vector3(32, 32, 32), "brush_id": brush_id})
+		as DraftBrush
+	)
+
+
+# ===========================================================================
+# Visgroup membership does not ride along (#368)
+# ===========================================================================
+
+
+func test_a_captured_prefab_carries_no_visgroup_names():
+	var brush := _box("src")
+	root.create_visgroup("Lighting")
+	root.add_selection_to_visgroup("Lighting", [brush])
+	assert_true(
+		Array(brush.get_meta("visgroups", PackedStringArray())).has("Lighting"),
+		"the fixture put the brush in the visgroup"
+	)
+
+	var prefab = HFPrefabType.capture_from_selection(
+		root.brush_system, root.entity_system, [brush], []
+	)
+	assert_eq(prefab.brush_infos.size(), 1)
+	assert_false(prefab.brush_infos[0].has("visgroups"), "stripped, like brush_id and group_id")
+	assert_false(prefab.brush_infos[0].has("brush_id"))
+	assert_false(prefab.brush_infos[0].has("group_id"))
+
+
+func test_a_placed_prefab_brush_is_in_no_visgroup_the_level_lacks():
+	var brush := _box("src")
+	root.create_visgroup("Lighting")
+	root.add_selection_to_visgroup("Lighting", [brush])
+	var prefab = HFPrefabType.capture_from_selection(
+		root.brush_system, root.entity_system, [brush], []
+	)
+
+	var receiver: LevelRoot = LevelRootType.new()
+	receiver.auto_spawn_player = false
+	receiver.hflevel_autosave_enabled = false
+	add_child_autoqfree(receiver)
+	prefab.instantiate(receiver.brush_system, receiver.entity_system, receiver, Vector3(128, 0, 0))
+
+	assert_eq(receiver.get_visgroup_names().size(), 0, "the receiving level registered nothing")
+	for child in receiver.draft_brushes_node.get_children():
+		var names := Array(child.get_meta("visgroups", PackedStringArray()))
+		assert_eq(names, [], "a placed brush is in no unregistered visgroup")
+
+
+# ===========================================================================
+# The id counter is derived from what was restored (#369)
+# ===========================================================================
+
+
+func test_a_restore_does_not_reissue_a_live_instance_id():
+	var system := HFPrefabSystemType.new(root)
+	var first := system.register_instance("res://a.hfprefab", ["b1"], [])
+	assert_eq(first, "pfx_1")
+
+	# The shape a `.hflevel` saved before next_instance_id was captured produces.
+	var state := system.capture_state()
+	state.erase("next_instance_id")
+	state.erase("next_entity_uid")
+	system.restore_state(state)
+
+	var second := system.register_instance("res://b.hfprefab", ["b2"], [])
+	assert_ne(second, first, "the next id is not one already in the registry")
+	assert_eq(system.get_all_instances().size(), 2, "both placements are registered")
+
+
+func test_a_restore_keeps_a_counter_that_is_already_ahead():
+	var system := HFPrefabSystemType.new(root)
+	system.register_instance("res://a.hfprefab", ["b1"], [])
+	var state := system.capture_state()
+	system.restore_state(state)
+	assert_eq(system.register_instance("res://b.hfprefab", ["b2"], []), "pfx_2")
+
+
+# ===========================================================================
+# A malformed .hfprefab does not take the dock with it (#370)
+# ===========================================================================
+
+
+func test_a_non_dictionary_brush_entry_is_dropped_on_load():
+	var prefab = HFPrefabType.from_dict(
+		{"prefab_name": "x", "brush_infos": [null, {"shape": 0, "size": Vector3(8, 8, 8)}, 7]}
+	)
+	assert_eq(prefab.brush_infos.size(), 1, "only the object survived")
+	assert_eq(prefab.entity_infos.size(), 0)
+
+
+func test_a_brush_infos_that_is_not_a_list_loads_as_empty():
+	var prefab = HFPrefabType.from_dict({"prefab_name": "x", "brush_infos": "nope"})
+	assert_eq(prefab.brush_infos.size(), 0)
+
+
+func test_placing_a_malformed_prefab_leaves_the_signal_batch_closed():
+	var prefab = HFPrefabType.from_dict(
+		{"prefab_name": "x", "brush_infos": [null, {"shape": 0, "size": Vector3(8, 8, 8)}]}
+	)
+	var depth_before: int = root._signal_batch_depth
+	prefab.instantiate(root.brush_system, root.entity_system, root, Vector3.ZERO)
+	assert_eq(root._signal_batch_depth, depth_before, "the batch was closed")
+
+
+func test_a_batch_nothing_closes_is_released_rather_than_left_open():
+	root.begin_signal_batch()
+	assert_eq(root._signal_batch_depth, 1)
+	# Pretend the batch opened long ago, which is what an unwound function
+	# leaves behind.
+	root._signal_batch_opened_msec = 0
+	root._release_stuck_signal_batch()
+	assert_eq(root._signal_batch_depth, 0, "released, so the dock keeps updating")
+
+
+func test_a_batch_that_has_just_opened_is_left_alone():
+	root.begin_signal_batch()
+	root._release_stuck_signal_batch()
+	assert_eq(root._signal_batch_depth, 1, "an ordinary batch is not disturbed")
+	root.end_signal_batch()


### PR DESCRIPTION
- #368 `capture_from_selection()` erases `visgroups` alongside `brush_id` and `group_id`, on entity infos too. Took the strip option rather than the create-on-place one, because that is the consistent choice and carrying organisation into another level is a feature that wants deciding on its own.
- #369 `restore_state()` derives the id floor from the records it restored, for `pent_N` as well as `pfx_N`, and `register_instance()` warns rather than overwrite a live id.
- #370 Both halves. `from_dict()` keeps only Dictionary entries and warns about what it dropped. And `LevelRoot` releases a signal batch that has been open longer than a second, with a warning, so no skipped `end_signal_batch()` can freeze the dock again — every batch in the plugin is opened and closed inside one synchronous call, so a batch that survives a frame boundary is an abandoned one.

Tests in `tests/test_prefab_instance_integrity.gd`. Full suite passes.

Fixes #368
Fixes #369
Fixes #370