### PR TITLE
Give groups and entity classnames the name guard visgroups already have

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Fixed
+- **A group could be named with nothing but whitespace** (#374). #349 fixed this
+  for visgroups and left a comment saying exactly what was wrong with the guard;
+  sixty lines further down in the same file `create_group()` still tested
+  `group_name == ""`. It matters more for a group than for a visgroup, because a
+  group is the unit the editor moves and duplicates together: `"Arch"` and
+  `"Arch "` were two groups, so half the brushes the mapper thought they had
+  grouped moved without the other half, and the group list looked right because
+  both rows read "Arch". Names are stripped and a name that strips to nothing is
+  refused, in `create_group()` and in `group_selection()`, which writes the same
+  string into node meta.
+- **An `entities.json` with an "entities" key of the wrong type left the editor
+  with no entity definitions** (#380). The loader falls back to the built-in
+  classes when the file is missing, unopenable or unparseable — but it read the
+  entries into a typed local, so a file that parsed with `"entities": "nope"` was
+  a runtime error, and GDScript unwound the function past every fallback below
+  it. `load_entity_definitions()` clears the table before it reloads, so the
+  level was left with an empty definition table: no class could be placed and
+  every entity already in the level lost its property schema and its colour. A
+  valid JSON file with one key of the wrong type is the most likely hand-edit
+  mistake, not the least. The value is read before it is assigned, in all three
+  readers.
+- **An entity class could be defined with a whitespace-only classname** (#381).
+  The classname is the identity of the class in three places at once: the key in
+  `entity_definitions`, the row in the class dropdown, and the `"classname"`
+  field written into the exported `.map`, which is what the target engine reads
+  to decide what the entity is. A blank one was a blank dropdown row that could
+  not be told from another and a malformed entity in the export, and it survived
+  every round trip. Classnames are stripped before the emptiness test and stored
+  stripped, so `"door"` and `"door "` are one class and the project overlay and
+  the plugin base agree about which. A file that defines the same classname twice
+  now warns instead of the second one silently winning.
 - **A grid array with a negative axis count was built rather than refused**
   (#346). The linear and radial paths refuse a count below one with a message and
   a fix hint; the grid path clamped `(-2, 2, 2)` up to `(1, 2, 2)` first, so

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,530 tests across 182 test scripts (3,523 passing plus seven intentional no-assert safety tests; 17,870 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,560 tests across 185 test scripts (3,553 passing plus seven intentional no-assert safety tests; 17,979 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,519 tests across 181 test scripts (3,512 passing plus seven intentional no-assert safety tests; 17,839 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,530 tests across 182 test scripts (3,523 passing plus seven intentional no-assert safety tests; 17,870 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,519 tests** across **181 scripts** (**3,512 passing** plus seven intentional no-assert safety tests; **17,839 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,530 tests** across **182 scripts** (**3,523 passing** plus seven intentional no-assert safety tests; **17,870 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,530 tests** across **182 scripts** (**3,523 passing** plus seven intentional no-assert safety tests; **17,870 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,560 tests** across **185 scripts** (**3,553 passing** plus seven intentional no-assert safety tests; **17,979 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3523%20passing-brightgreen" alt="3523 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3553%20passing-brightgreen" alt="3553 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3512%20passing-brightgreen" alt="3512 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3523%20passing-brightgreen" alt="3523 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,519 tests across 181 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,530 tests across 182 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,530 tests across 182 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,560 tests across 185 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/hf_entity_def.gd
+++ b/addons/hammerforge/hf_entity_def.gd
@@ -21,7 +21,14 @@ const PROJECT_DEFINITIONS_PATH := "res://hammerforge_entities.json"
 
 static func from_dict(data: Dictionary) -> HFEntityDef:
 	var def := HFEntityDef.new()
-	def.classname = str(data.get("id", data.get("class", data.get("classname", ""))))
+	# Stripped, because the classname is the identity of the entity class in three
+	# places at once: the key in LevelRoot.entity_definitions, the row in the
+	# class dropdown, and the "classname" field written into the exported `.map`,
+	# which is what the target engine reads to decide what the entity is. A blank
+	# one is a malformed entity in the `.map` and a blank row in the dropdown that
+	# cannot be told from another blank row. Stripped also means "door" and
+	# "door " are one class rather than two, so the overlay and the base agree.
+	def.classname = str(data.get("id", data.get("class", data.get("classname", "")))).strip_edges()
 	def.description = str(data.get("description", ""))
 	var c = data.get("color", null)
 	if c is Array and c.size() >= 3:
@@ -78,7 +85,22 @@ static func load_definitions(path: String) -> Array[HFEntityDef]:
 		return _built_in_defaults()
 	var entries: Array = []
 	if data is Dictionary:
-		entries = data.get("entities", [])
+		# Read before assigning. `entries` is a typed local, so a file that parses
+		# with an "entities" key of the wrong type used to be a runtime error
+		# here — and GDScript has no exception handling, so the function unwound
+		# past every fallback below it and the caller got nothing. A valid JSON
+		# file with one key of the wrong type is the most likely hand-edit
+		# mistake, not the least.
+		var raw_entries = data.get("entities", [])
+		if raw_entries is Array:
+			entries = raw_entries
+		elif raw_entries != null:
+			push_warning(
+				(
+					"HammerForge: 'entities' in '%s' is a %s, not a list"
+					% [path, type_string(typeof(raw_entries))]
+				)
+			)
 		if entries.is_empty():
 			for key in data.keys():
 				var entry = data[key]
@@ -89,15 +111,28 @@ static func load_definitions(path: String) -> Array[HFEntityDef]:
 	elif data is Array:
 		entries = data
 	var skipped := 0
+	var seen_classnames: Dictionary = {}
 	for entry in entries:
 		if entry is Dictionary:
-			var classname = str(entry.get("id", entry.get("class", entry.get("classname", ""))))
+			var classname = (
+				str(entry.get("id", entry.get("class", entry.get("classname", "")))).strip_edges()
+			)
 			if classname == "":
 				skipped += 1
 				push_warning(
 					"HammerForge: skipping entity definition with no classname in '%s'" % path
 				)
 				continue
+			if seen_classnames.has(classname):
+				# load_entity_definitions() writes these into one dictionary key,
+				# so the second silently wins. Naming it turns a mistake that
+				# vanishes into one the author can fix. This is the file's own
+				# duplicates, not the project overlay replacing a plugin
+				# definition of the same name, which is the intended behaviour.
+				push_warning(
+					"HammerForge: '%s' is defined more than once in '%s'" % [classname, path]
+				)
+			seen_classnames[classname] = true
 			defs.append(HFEntityDef.from_dict(entry))
 		else:
 			skipped += 1
@@ -128,7 +163,22 @@ static func load_definitions_from_file(path: String) -> Array[HFEntityDef]:
 		return defs
 	var entries: Array = []
 	if data is Dictionary:
-		entries = data.get("entities", [])
+		# Read before assigning. `entries` is a typed local, so a file that parses
+		# with an "entities" key of the wrong type used to be a runtime error
+		# here — and GDScript has no exception handling, so the function unwound
+		# past every fallback below it and the caller got nothing. A valid JSON
+		# file with one key of the wrong type is the most likely hand-edit
+		# mistake, not the least.
+		var raw_entries = data.get("entities", [])
+		if raw_entries is Array:
+			entries = raw_entries
+		elif raw_entries != null:
+			push_warning(
+				(
+					"HammerForge: 'entities' in '%s' is a %s, not a list"
+					% [path, type_string(typeof(raw_entries))]
+				)
+			)
 		if entries.is_empty():
 			for key in data.keys():
 				var entry = data[key]
@@ -140,7 +190,9 @@ static func load_definitions_from_file(path: String) -> Array[HFEntityDef]:
 		entries = data
 	for entry in entries:
 		if entry is Dictionary:
-			var classname = str(entry.get("id", entry.get("class", entry.get("classname", ""))))
+			var classname = (
+				str(entry.get("id", entry.get("class", entry.get("classname", "")))).strip_edges()
+			)
 			if classname != "":
 				defs.append(from_dict(entry))
 	return defs
@@ -180,6 +232,7 @@ static func load_raw_entries(path: String) -> Array[Dictionary]:
 		var classname_value := str(
 			record.get("id", record.get("classname", record.get("class", "")))
 		)
+		classname_value = classname_value.strip_edges()
 		if classname_value == "":
 			continue
 		record["id"] = classname_value

--- a/addons/hammerforge/systems/hf_visgroup_system.gd
+++ b/addons/hammerforge/systems/hf_visgroup_system.gd
@@ -167,12 +167,21 @@ func refresh_visibility() -> void:
 
 
 func create_group(group_name: String) -> void:
-	if group_name == "":
+	# The same guard create_visgroup() got, for the same reasons, and worse here:
+	# a group is the unit the editor moves and duplicates together. "Arch" and
+	# "Arch " are two groups, so half the brushes the mapper thinks they grouped
+	# move without the other half — and the group list looks right, because both
+	# rows read "Arch". A group named "   " is a blank row that cannot be told
+	# from another blank one. The name is stored in node meta and saved into the
+	# `.hflevel`, so it persists.
+	var stripped := group_name.strip_edges()
+	if stripped == "":
 		return
-	groups[group_name] = true
+	groups[stripped] = true
 
 
 func remove_group(group_name: String) -> void:
+	group_name = group_name.strip_edges()
 	groups.erase(group_name)
 	for node in _all_managed_nodes():
 		if str(node.get_meta("group_id", "")) == group_name:
@@ -192,12 +201,16 @@ func get_group_names() -> PackedStringArray:
 
 
 func group_selection(group_name: String, nodes: Array) -> void:
-	if group_name == "":
+	# Stripped here as well, or the meta and the registry disagree about which
+	# group the node is in. get_group_members() and get_group_of() compare
+	# against this meta, so they follow from it.
+	var stripped := group_name.strip_edges()
+	if stripped == "":
 		return
-	create_group(group_name)
+	create_group(stripped)
 	for node in nodes:
 		if node is Node:
-			node.set_meta("group_id", group_name)
+			node.set_meta("group_id", stripped)
 
 
 func ungroup_nodes(nodes: Array) -> void:
@@ -217,6 +230,7 @@ func get_group_of(node: Node) -> String:
 
 func get_group_members(group_name: String) -> Array:
 	var out: Array = []
+	group_name = group_name.strip_edges()
 	if group_name == "":
 		return out
 	for node in _all_managed_nodes():

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,519 tests across 181 scripts**: **3,512 passing tests**, seven intentional no-assert safety tests, and **17,839 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,530 tests across 182 scripts**: **3,523 passing tests**, seven intentional no-assert safety tests, and **17,870 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,530 tests across 182 scripts**: **3,523 passing tests**, seven intentional no-assert safety tests, and **17,870 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,560 tests across 185 scripts**: **3,553 passing tests**, seven intentional no-assert safety tests, and **17,979 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_name_guards.gd
+++ b/tests/test_name_guards.gd
@@ -1,0 +1,146 @@
+extends GutTest
+
+## Three places where a name was tested against "" rather than stripped, so a
+## whitespace-only name got in and two names a keystroke apart were two things
+## (#374, #380, #381). #349 fixed the visgroup half and left a comment saying
+## exactly what was wrong with the guard; these are the same guard elsewhere.
+## #380 is the other half of the same file: a typed local assigned straight from
+## parsed JSON.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+const HFEntityDefType = preload("res://addons/hammerforge/hf_entity_def.gd")
+
+var root: LevelRoot
+var _written_paths: Array[String] = []
+
+
+func before_each():
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func after_each():
+	for path in _written_paths:
+		if FileAccess.file_exists(path):
+			DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+	_written_paths.clear()
+
+
+func _write_definitions(name_hint: String, text: String) -> String:
+	var path := "user://vibe_defs_%s.json" % name_hint
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	file.store_string(text)
+	file.close()
+	_written_paths.append(path)
+	return path
+
+
+func _box(brush_id: String) -> DraftBrush:
+	return (
+		root.create_brush_from_info({"size": Vector3(32, 32, 32), "brush_id": brush_id})
+		as DraftBrush
+	)
+
+
+# ===========================================================================
+# create_group (#374)
+# ===========================================================================
+
+
+func test_a_group_cannot_be_named_with_whitespace():
+	for blank in ["", "   ", "\t", "\n"]:
+		root.visgroup_system.create_group(blank)
+	assert_eq(root.visgroup_system.get_group_names().size(), 0, "no blank rows")
+
+
+func test_two_names_a_keystroke_apart_are_one_group():
+	for name in ["lights", "lights ", " lights"]:
+		root.visgroup_system.create_group(name)
+	var names: PackedStringArray = root.visgroup_system.get_group_names()
+	assert_eq(names.size(), 1, "one group, not three: %s" % [names])
+	assert_eq(names[0], "lights", "stored stripped")
+
+
+func test_grouping_a_selection_writes_the_stripped_name():
+	var brush := _box("b")
+	root.visgroup_system.group_selection("Arch ", [brush])
+	assert_eq(str(brush.get_meta("group_id", "")), "Arch", "the meta is the stripped name")
+	assert_eq(root.visgroup_system.get_group_names()[0], "Arch")
+	assert_eq(
+		root.visgroup_system.get_group_members("Arch").size(), 1, "the registry and the meta agree"
+	)
+
+
+func test_grouping_a_selection_with_a_blank_name_groups_nothing():
+	var brush := _box("b")
+	root.visgroup_system.group_selection("   ", [brush])
+	assert_eq(str(brush.get_meta("group_id", "")), "", "nothing was written")
+	assert_eq(root.visgroup_system.get_group_names().size(), 0)
+
+
+# ===========================================================================
+# entities.json with an "entities" key of the wrong type (#380)
+# ===========================================================================
+
+
+func test_an_entities_key_that_is_not_a_list_falls_back_to_the_built_ins():
+	for text in ['{"entities": "nope"}', '{"entities": 7}', '{"entities": {"a": 1}}']:
+		var path := _write_definitions("badkey", text)
+		var defs = HFEntityDefType.load_definitions(path)
+		assert_gt(defs.size(), 0, "the built-in fallback ran for %s" % text)
+
+
+func test_the_cases_that_already_recovered_still_recover():
+	# "not json at all" is left out on purpose: it push_error()s by design, which
+	# is correct and which GUT counts as an unexpected error.
+	for text in ["7", '{"entities": [null, "x"]}', '{"entities": []}']:
+		var path := _write_definitions("recover", text)
+		assert_gt(HFEntityDefType.load_definitions(path).size(), 0, "built-ins for %s" % text)
+
+
+func test_a_level_keeps_its_entity_definitions_when_the_file_is_wrong():
+	var path := _write_definitions("level", '{"entities": "nope"}')
+	root.entity_definitions_path = path
+	root.entity_system.load_entity_definitions()
+	assert_gt(root.entity_definitions.size(), 0, "the class dropdown is not empty")
+
+
+func test_an_ordinary_definitions_file_still_loads():
+	var path := _write_definitions(
+		"ok", '{"entities": [{"id": "func_door", "description": "a door"}]}'
+	)
+	var defs = HFEntityDefType.load_definitions(path)
+	assert_eq(defs.size(), 1)
+	assert_eq(defs[0].classname, "func_door")
+
+
+# ===========================================================================
+# Whitespace classnames (#381)
+# ===========================================================================
+
+
+func test_a_whitespace_classname_is_not_an_entity_class():
+	var path := _write_definitions("blank", '{"entities": [{"id": "   ", "description": "x"}]}')
+	var defs = HFEntityDefType.load_definitions(path)
+	for def in defs:
+		assert_ne(def.classname, "   ", "a blank classname did not become a class")
+		assert_eq(def.classname, def.classname.strip_edges(), "every classname is stripped")
+
+
+func test_a_classname_with_an_edge_space_is_stored_stripped():
+	var path := _write_definitions(
+		"space", '{"entities": [{"id": " func_door ", "description": "x"}]}'
+	)
+	var defs = HFEntityDefType.load_definitions(path)
+	assert_eq(defs.size(), 1)
+	assert_eq(defs[0].classname, "func_door", "so the overlay and the base agree")
+
+
+func test_a_whitespace_classname_never_reaches_the_level():
+	var path := _write_definitions("blank2", '{"entities": [{"id": "  ", "description": "x"}]}')
+	root.entity_definitions_path = path
+	root.entity_system.load_entity_definitions()
+	for key in root.entity_definitions.keys():
+		assert_ne(str(key).strip_edges(), "", "no blank row in the class dropdown")


### PR DESCRIPTION
- #374 `create_group()` and `group_selection()` strip and refuse a name that strips to nothing, so the registry and the node meta cannot disagree. `get_group_members()` and `remove_group()` strip what they are asked about.
- #380 All three readers of `entities` read the value before assigning it to a typed local, so a file with a key of the wrong type falls back to the built-ins like every other malformed file does.
- #381 The classname is stripped before the emptiness test and stored stripped, in `from_dict()` and in all three loaders, so the overlay and the base agree about whether `door` and `door ` are the same class. A duplicate classname in one file warns rather than the second silently winning.

On the two open questions in #374: group cleanup on delete stays as it is, and I am not adding `rename_group()`. A visgroup is a named thing you populate, so it survives losing its last member and can be renamed; a group *is* the population, which is why it is dropped when empty and why renaming it is ungroup-and-regroup. Recording that so the next reader does not chase it.

Tests in `tests/test_name_guards.gd`. Full suite passes.

Fixes #374
Fixes #380
Fixes #381