### PR TITLE
Give validate_level a geometry pass and let it see a NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Fixed
+- **`validate_level()` could not see a brush whose size was NaN** (#371). Its one
+  size check was a comparison, and every comparison against NaN is false — an
+  infinite size is legitimately `> 0.0` as well. The validator is the backstop:
+  a mapper with a NaN-sized brush saw a clean badge, baked, and got a mesh with a
+  poisoned AABB with nothing anywhere naming the brush responsible, and no way to
+  find it by eye because a NaN size draws nothing. Finite is tested first, so the
+  report says what is actually wrong, and `auto_fix` puts the default size back.
+  The brush transform is checked the same way, and reported rather than repaired,
+  because there is no honest repair for a non-finite origin.
+- **`validate_level()` checked no brush geometry, and owned two repairs nothing
+  called** (#372). `weld_brush_vertices()` and `fix_non_planar_faces()` worked and
+  were tested and had no caller outside the suite — no dock button, no menu item,
+  and not `validate()` itself in `auto_fix` or out of it. Meanwhile a brush with
+  no faces, a face bowed off its own plane, and a face with a NaN vertex all
+  validated clean. Fixing the setters that create those states does nothing for a
+  `.hflevel` saved last week or a `.map` imported from another editor, which is
+  the ground the validator covers. `validate()` now reports all four, and
+  `auto_fix` deletes a brush with no faces (there is nothing to repair), calls
+  `fix_non_planar_faces()` on a bowed one and `weld_brush_vertices()` on vertices
+  a weld apart, and leaves a non-finite vertex reported only.
 - **A grid array with a negative axis count was built rather than refused**
   (#346). The linear and radial paths refuse a count below one with a message and
   a fix hint; the grid path clamped `(-2, 2, 2)` up to `(1, 2, 2)` first, so

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,519 tests across 181 test scripts (3,512 passing plus seven intentional no-assert safety tests; 17,839 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,528 tests across 182 test scripts (3,521 passing plus seven intentional no-assert safety tests; 17,854 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,528 tests across 182 test scripts (3,521 passing plus seven intentional no-assert safety tests; 17,854 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,569 tests across 186 test scripts (3,562 passing plus seven intentional no-assert safety tests; 17,994 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,519 tests** across **181 scripts** (**3,512 passing** plus seven intentional no-assert safety tests; **17,839 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,528 tests** across **182 scripts** (**3,521 passing** plus seven intentional no-assert safety tests; **17,854 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,528 tests** across **182 scripts** (**3,521 passing** plus seven intentional no-assert safety tests; **17,854 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,569 tests** across **186 scripts** (**3,562 passing** plus seven intentional no-assert safety tests; **17,994 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3512%20passing-brightgreen" alt="3512 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3521%20passing-brightgreen" alt="3521 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3521%20passing-brightgreen" alt="3521 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3562%20passing-brightgreen" alt="3562 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,519 tests across 181 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,528 tests across 182 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,528 tests across 182 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,569 tests across 186 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/face_data.gd
+++ b/addons/hammerforge/face_data.gd
@@ -579,6 +579,13 @@ func _compute_normal() -> void:
 	if local_verts.size() < 3:
 		normal = Vector3.UP
 		return
+	# A face with a vertex that is not a number has no normal, and asking for one
+	# is an engine error per call rather than a value. The validator reports the
+	# vertex; this just stops the noise.
+	for v in local_verts:
+		if not v.is_finite():
+			normal = Vector3.UP
+			return
 	var a = local_verts[0]
 	var b = local_verts[1]
 	var c = local_verts[2]

--- a/addons/hammerforge/systems/hf_validation_system.gd
+++ b/addons/hammerforge/systems/hf_validation_system.gd
@@ -81,12 +81,25 @@ func validate(auto_fix: bool = false) -> Dictionary:
 		brush_nodes.append_array(root.pending_node.get_children())
 	if root.committed_node:
 		brush_nodes.append_array(root.committed_node.get_children())
+	var geometry_repairs: Array[DraftBrush] = []
+	var brushes_to_delete: Array[DraftBrush] = []
 	for node in brush_nodes:
 		if not (node is DraftBrush):
 			continue
 		var brush := node as DraftBrush
 		var size = brush.size
-		if size.x <= 0.0 or size.y <= 0.0 or size.z <= 0.0:
+		# Finite first, then the sign. Every comparison against NaN is false and
+		# an infinite size is legitimately `> 0.0`, so the sign test below could
+		# not see either — and this is the backstop: a mapper with a NaN-sized
+		# brush saw a clean badge, baked, and got a mesh with a poisoned AABB
+		# with nothing anywhere naming the brush responsible. The brush cannot be
+		# found by eye either, because a NaN size draws nothing.
+		if not size.is_finite():
+			issues.append("Brush size is not a number: %s" % brush.name)
+			if auto_fix:
+				brush.size = root.brush_size_default
+				fixed += 1
+		elif size.x <= 0.0 or size.y <= 0.0 or size.z <= 0.0:
 			# A negative size is not a zero size. It builds the brush inside out,
 			# with every face normal pointing the opposite way from the vertices
 			# it holds, and saying "zero" sends the reader looking for the wrong
@@ -99,6 +112,26 @@ func validate(auto_fix: bool = false) -> Dictionary:
 					max(0.1, abs(size.x)), max(0.1, abs(size.y)), max(0.1, abs(size.z))
 				)
 				brush.size = next
+				fixed += 1
+		# The transform has the same effect and nothing checked it either. There
+		# is no honest repair for a non-finite origin or basis, so this reports.
+		if not brush.global_transform.is_finite():
+			issues.append("Brush position is not a number: %s" % brush.name)
+		_check_brush_geometry(brush, issues, geometry_repairs, brushes_to_delete)
+
+	# The repairs and the deletion happen after the walk, so the loop is not
+	# mutating the list it is reading.
+	if auto_fix:
+		for brush in geometry_repairs:
+			var repaired := fix_non_planar_faces(brush)
+			repaired += weld_brush_vertices(brush)
+			if repaired > 0:
+				fixed += repaired
+				if root.has_method("tag_brush_dirty"):
+					root.tag_brush_dirty(str(brush.brush_id))
+		for brush in brushes_to_delete:
+			if is_instance_valid(brush) and root.brush_system:
+				root.brush_system.delete_brush(brush)
 				fixed += 1
 
 	# Invalid face indices in selection
@@ -508,6 +541,98 @@ func _edge_key(a: Vector3, b: Vector3) -> Array:
 	):
 		return [ai, bi]
 	return [bi, ai]
+
+
+## The geometry checks validate() had none of.
+##
+## Fixing the setters that create these states does nothing for a `.hflevel`
+## saved last week, a `.map` imported from another editor, or a file that was
+## hand-edited. The validator is what covers that ground, and it checked brush
+## size, face selection indices, material slots, UV projections, entity names,
+## I/O fields and paint layer grids — and nothing about the faces themselves,
+## while owning two geometry repairs that nothing called.
+func _check_brush_geometry(
+	brush: DraftBrush, issues: Array, repairs: Array[DraftBrush], to_delete: Array[DraftBrush]
+) -> void:
+	if brush.faces.is_empty():
+		# A live, selectable, saved brush with no geometry. It exports as a solid
+		# with no planes, which is malformed in both `.map` formats, and the
+		# mapper cannot find it to delete it because it draws nothing. There is
+		# nothing to repair, so the fix is to remove it.
+		issues.append("Brush has no faces: %s" % brush.name)
+		to_delete.append(brush)
+		return
+	var non_finite := 0
+	var worst_drift := 0.0
+	var coincident := false
+	for face in brush.faces:
+		if face == null:
+			continue
+		var verts: PackedVector3Array = face.local_verts
+		for v in verts:
+			if not v.is_finite():
+				non_finite += 1
+		if verts.size() < 3:
+			continue
+		for i in verts.size():
+			for j in range(i + 1, verts.size()):
+				# Near but not identical, which is what weld_brush_vertices()
+				# repairs: it snaps a group to its average, so afterwards the pair
+				# is exactly coincident rather than gone. A pair that is already
+				# exactly coincident is a degenerate face, not a weld job.
+				var gap := verts[i].distance_to(verts[j])
+				if gap > 0.0 and gap <= weld_tolerance:
+					coincident = true
+		worst_drift = maxf(worst_drift, _face_plane_drift(face))
+	if non_finite > 0:
+		# No honest repair: there is no nearest position to a NaN, and the value
+		# poisons the brush AABB and normal and propagates through any later clip
+		# or carve. Report it and name the brush.
+		issues.append("Brush has %d vertices that are not numbers: %s" % [non_finite, brush.name])
+	if worst_drift > planarity_tolerance:
+		issues.append("Brush face is not a plane (%.4f unit drift): %s" % [worst_drift, brush.name])
+		repairs.append(brush)
+	elif coincident:
+		issues.append("Brush has vertices a weld apart: %s" % brush.name)
+		repairs.append(brush)
+
+
+## How far the furthest vertex of a face sits off the plane through its first
+## three non-collinear vertices, or 0.0 when the face has no measurable plane.
+func _face_plane_drift(face) -> float:
+	var verts: PackedVector3Array = face.local_verts
+	if verts.size() < 4:
+		return 0.0  # triangles are always planar
+	var anchor: Vector3 = verts[0]
+	if not anchor.is_finite():
+		return 0.0
+	var normal := Vector3.ZERO
+	for i in range(1, verts.size() - 1):
+		if not verts[i].is_finite() or not verts[i + 1].is_finite():
+			continue
+		# Both edges have to be real edges. A pair of near-coincident vertices
+		# normalises to a direction that has nothing to do with the face, and the
+		# plane built from it reports the rest of the face as drift — so a brush
+		# with two vertices welded together came back as "not a plane" instead.
+		if (
+			(verts[i] - anchor).length() <= weld_tolerance
+			or (verts[i + 1] - anchor).length() <= weld_tolerance
+		):
+			continue
+		var candidate: Vector3 = (verts[i + 1] - anchor).normalized().cross(
+			(verts[i] - anchor).normalized()
+		)
+		if candidate.length() > 0.0001:
+			normal = candidate.normalized()
+			break
+	if normal.length_squared() < 0.0001 or not normal.is_finite():
+		return 0.0
+	var drift := 0.0
+	for v in verts:
+		if not v.is_finite():
+			continue
+		drift = maxf(drift, absf(normal.dot(v - anchor)))
+	return drift
 
 
 # ---------------------------------------------------------------------------

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -820,9 +820,11 @@ Click **Check Bake Issues** to scan for potential problems before baking:
 - **Occlusion coverage** (severity 0, info): reports occluder count and estimated coverage as a percentage of baked AABB surface area. Appears when occluders exist.
 - **Micro-gaps** (severity 1): near-coincident but not-exactly-equal vertices across different brushes that would cause seam tearing after bake. Detected within `weld_tolerance` (default 0.001 units).
 
-**Auto-fix helpers** (available via GDScript API on `level_root.validation_system`):
+**Auto-fix helpers** (also reachable directly on `level_root.validation_system`):
 - `weld_brush_vertices(brush)` — snaps near-coincident vertices to their average. Refreshes face normals and bounds automatically.
 - `fix_non_planar_faces(brush)` — projects drifting vertices back onto the face plane.
+
+`validate_level(true)` runs both over every brush in the level as part of its geometry pass, so a level imported from another editor can be cleaned up without calling them per brush. That pass also reports a brush whose size or transform is not a number, a brush with no faces (which auto-fix deletes, since there is nothing to repair), and a vertex that is not a number (reported only — there is no nearest position to a NaN).
 
 Both tolerances (`weld_tolerance`, `planarity_tolerance`) are configurable per-instance for noisy imported geometry.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,528 tests across 182 scripts**: **3,521 passing tests**, seven intentional no-assert safety tests, and **17,854 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,569 tests across 186 scripts**: **3,562 passing tests**, seven intentional no-assert safety tests, and **17,994 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,519 tests across 181 scripts**: **3,512 passing tests**, seven intentional no-assert safety tests, and **17,839 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,528 tests across 182 scripts**: **3,521 passing tests**, seven intentional no-assert safety tests, and **17,854 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_validator_sees_broken_geometry.gd
+++ b/tests/test_validator_sees_broken_geometry.gd
@@ -1,0 +1,121 @@
+extends GutTest
+
+## The validator is the backstop, and it was blind to the worst cases (#371,
+## #372). Fixing the setters that create these states does nothing for a
+## `.hflevel` saved last week, a `.map` imported from another editor, or a file
+## that was hand-edited, and that is the ground the validator covers.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+
+var root: LevelRoot
+
+
+func before_each():
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func _box(brush_id: String) -> DraftBrush:
+	return (
+		root.create_brush_from_info({"size": Vector3(64, 64, 64), "brush_id": brush_id})
+		as DraftBrush
+	)
+
+
+func _report() -> Array:
+	return root.validate_level().get("issues", [])
+
+
+func _mentions(report: Array, fragment: String) -> bool:
+	for issue in report:
+		if str(issue).contains(fragment):
+			return true
+	return false
+
+
+# ===========================================================================
+# A size that is not a number (#371)
+# ===========================================================================
+
+
+func test_a_clean_level_still_reports_nothing_about_geometry():
+	_box("b")
+	var report := _report()
+	assert_false(_mentions(report, "Brush"), "an ordinary box is not an issue: %s" % [report])
+
+
+func test_a_non_finite_brush_size_is_reported():
+	for size in [Vector3(NAN, 64, 64), Vector3(64, INF, 64), Vector3(NAN, NAN, NAN)]:
+		var brush := _box("b")
+		brush.size = size
+		assert_true(_mentions(_report(), "size is not a number"), "%s was reported" % size)
+		root.brush_system.delete_brush(brush)
+
+
+func test_auto_fix_gives_a_non_finite_size_the_default_back():
+	var brush := _box("b")
+	brush.size = Vector3(NAN, 64, 64)
+	var result: Dictionary = root.validate_level(true)
+	assert_gt(int(result.get("fixed", 0)), 0, "something was repaired")
+	assert_true(brush.size.is_finite(), "the size is a size again: %s" % brush.size)
+
+
+func test_a_non_finite_brush_position_is_reported():
+	var brush := _box("b")
+	brush.global_position = Vector3(NAN, 0, 0)
+	assert_true(_mentions(_report(), "position is not a number"))
+
+
+# ===========================================================================
+# Geometry the validator checked nothing about (#372)
+# ===========================================================================
+
+
+func test_a_brush_with_no_faces_is_reported():
+	var brush := _box("b")
+	brush.faces = []
+	assert_true(_mentions(_report(), "no faces"), "a faceless brush is an issue")
+
+
+func test_auto_fix_removes_a_brush_with_no_faces():
+	var brush := _box("b")
+	brush.faces = []
+	var before := root.draft_brushes_node.get_child_count()
+	root.validate_level(true)
+	assert_lt(
+		root.draft_brushes_node.get_child_count(), before, "there is nothing to repair, so it goes"
+	)
+
+
+func test_a_non_finite_vertex_is_reported():
+	var brush := _box("b")
+	var verts: PackedVector3Array = brush.faces[0].local_verts
+	verts[0] = Vector3(NAN, 0, 0)
+	brush.faces[0].local_verts = verts
+	assert_true(_mentions(_report(), "vertices that are not numbers"))
+
+
+func test_a_face_bowed_out_of_plane_is_reported_and_repaired():
+	var brush := _box("b")
+	var verts: PackedVector3Array = brush.faces[0].local_verts
+	verts[3] = verts[3] + brush.faces[0].normal * 32.0
+	brush.faces[0].local_verts = verts
+	brush.faces[0].ensure_geometry()
+	assert_true(_mentions(_report(), "not a plane"), "the bow is reported")
+
+	var result: Dictionary = root.validate_level(true)
+	assert_gt(int(result.get("fixed", 0)), 0, "the repair that already existed was called")
+	assert_false(_mentions(_report(), "not a plane"), "and the bow is gone")
+
+
+func test_vertices_a_weld_apart_are_reported_and_welded():
+	var brush := _box("b")
+	var verts: PackedVector3Array = brush.faces[0].local_verts
+	verts[1] = verts[0] + Vector3(0.0001, 0.0, 0.0)
+	brush.faces[0].local_verts = verts
+	brush.faces[0].ensure_geometry()
+	assert_true(_mentions(_report(), "a weld apart"))
+	root.validate_level(true)
+	assert_false(_mentions(_report(), "a weld apart"), "welded")


### PR DESCRIPTION
- #371 Finite is tested before the sign, so the report names what is wrong and an infinite size is not read as valid. `auto_fix` restores `brush_size_default`. The transform is checked the same way and reported only.
- #372 `validate()` reports a brush with no faces, a vertex that is not a number, a face bowed off its own plane, and vertices a weld apart. `auto_fix` deletes the faceless brush and calls `fix_non_planar_faces()` and `weld_brush_vertices()`, which is the caller they did not have.

Two things the sweep did not predict, both caught by the new tests:

The drift measurement has to skip degenerate edges. A pair of near-coincident vertices normalises to a direction unrelated to the face, and the plane built from it reported the rest of the face as 45 units of drift — so a brush with a weld job came back as "not a plane".

And the coincident-vertex check had to be narrowed to *near but not identical*. `weld_brush_vertices()` snaps a group to its average, it does not remove the duplicate, so a check for exactly-coincident vertices would have reported forever after its own repair ran.

Tests in `tests/test_validator_sees_broken_geometry.gd`. Full suite passes.

Fixes #371
Fixes #372