### PR TITLE
Bound the bake and grid settings, and make a cordon a region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Fixed
+- **The bake and grid settings that take a number were unbounded** (#373). #361
+  did this for the terrain settings; these are the same list and were not
+  touched. 22 of 23 out-of-range values landed and stayed. The dock SpinBoxes
+  have ranges so the editor UI cannot produce them, but the `.hflevel` can: it is
+  JSON, it is hand-editable, it gets merged, and it gets written by older builds
+  with different defaults — and an `@export_range` constrains the inspector
+  widget only, not an assignment or a load. Each of these now has a clamping
+  setter with a finiteness guard first, since `clampf()` and `maxf()` both pass
+  NaN through, which is exactly how `grid_snap`'s `max(value, 0.0)` let one past.
+  That one mattered most: every consumer is written
+  `grid_snap if grid_snap > 0.0 else <fallback>`, so a NaN read as "snapping is
+  off" everywhere while the dock still showed a number.
+  `apply_hflevel_settings()` writes the properties, so the load path goes through
+  the setters and is covered by the same change.
+- **A cordon AABB with a negative size baked an empty level and reported
+  success** (#377). An AABB with a negative size is a constructible value of the
+  type and is not a region: Godot's `intersects()` errors on it and returns false
+  for everything, so every brush read as outside the cordon. Nothing said so —
+  the bake reported success and the cordon wireframe draws the same box either
+  way — and the dock's six min/max SpinBoxes are the natural way to produce one.
+  `cordon_aabb` has a setter that refuses a non-finite position or size and calls
+  `.abs()` on a negative one, which is the fix Godot's own error message names
+  and makes a min/max pair entered in either order mean the same region.
 - **A grid array with a negative axis count was built rather than refused**
   (#346). The linear and radial paths refuse a count below one with a message and
   a fix hint; the grid path clamped `(-2, 2, 2)` up to `(1, 2, 2)` first, so

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,519 tests across 181 test scripts (3,512 passing plus seven intentional no-assert safety tests; 17,839 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,528 tests across 182 test scripts (3,521 passing plus seven intentional no-assert safety tests; 17,890 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,528 tests across 182 test scripts (3,521 passing plus seven intentional no-assert safety tests; 17,890 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,578 tests across 187 test scripts (3,571 passing plus seven intentional no-assert safety tests; 18,045 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,519 tests** across **181 scripts** (**3,512 passing** plus seven intentional no-assert safety tests; **17,839 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,528 tests** across **182 scripts** (**3,521 passing** plus seven intentional no-assert safety tests; **17,890 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,528 tests** across **182 scripts** (**3,521 passing** plus seven intentional no-assert safety tests; **17,890 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,578 tests** across **187 scripts** (**3,571 passing** plus seven intentional no-assert safety tests; **18,045 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3512%20passing-brightgreen" alt="3512 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3521%20passing-brightgreen" alt="3521 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3521%20passing-brightgreen" alt="3521 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3571%20passing-brightgreen" alt="3571 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,519 tests across 181 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,528 tests across 182 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,528 tests across 182 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,578 tests across 187 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -60,6 +60,52 @@ enum AxisLock { NONE, X, Y, Z }
 # Export vars
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Bounds for the settings that take a number
+#
+# #361 did this for the terrain settings. These are the same list and were not
+# touched. The dock SpinBoxes have ranges, so the editor UI cannot produce a
+# value outside them, but the `.hflevel` can: it is JSON, it is hand-editable, it
+# gets merged, and it gets written by older builds with different defaults. An
+# `@export_range` constrains the inspector widget only. It does not clamp an
+# assignment and it is not enforced on load.
+#
+# Finiteness is checked first, because `clampf()` and `maxf()` both pass NaN
+# through. `grid_snap` is the subtle one: every consumer is written
+# `grid_snap if grid_snap > 0.0 else <fallback>`, and `NAN > 0.0` is false, so a
+# NaN read as "snapping is off" everywhere while the dock still showed a number.
+# ---------------------------------------------------------------------------
+
+const MIN_GRID_PLANE_SIZE := 1.0
+const MAX_GRID_PLANE_SIZE := 100000.0
+const MIN_ROTATE_SNAP_DEGREES := 1.0
+const MAX_ROTATE_SNAP_DEGREES := 180.0
+const MIN_BAKE_CHUNK_SIZE := 1.0
+const MAX_BAKE_CHUNK_SIZE := 16384.0
+const MIN_LIGHTMAP_TEXEL_SIZE := 0.001
+const MAX_LIGHTMAP_TEXEL_SIZE := 16.0
+const MIN_NAVMESH_CELL := 0.01
+const MAX_NAVMESH_CELL := 16.0
+const MIN_NAVMESH_AGENT := 0.01
+const MAX_NAVMESH_AGENT := 256.0
+const MIN_CONNECTOR_STAIR_HEIGHT := 0.01
+const MAX_CONNECTOR_STAIR_HEIGHT := 256.0
+const MIN_CONNECTOR_WIDTH := 1
+const MAX_CONNECTOR_WIDTH := 64
+
+
+## A value inside the range, or the one already there when it is not a number.
+##
+## Refusing rather than substituting is deliberate: there is no nearest value to
+## a NaN, and a setting that silently became a number nobody chose is the same
+## class of surprise as one that stayed NaN.
+static func _bounded(value: float, low: float, high: float, current: float) -> float:
+	if not is_finite(value):
+		HFLog.warn("HammerForge: %s is not a setting value, keeping %s" % [value, current])
+		return current
+	return clampf(value, low, high)
+
+
 var _grid_snap: float = 16.0
 @export var grid_snap: float = 16.0:
 	set(value):
@@ -69,18 +115,60 @@ var _grid_snap: float = 16.0
 @export var brush_size_default: Vector3 = Vector3(32, 32, 32)
 @export_range(1, 32, 1) var bake_collision_layer_index: int = 1
 @export var bake_material_override: Material = null
-@export var bake_chunk_size: float = 32.0
+var _bake_chunk_size: float = 32.0
+@export var bake_chunk_size: float = 32.0:
+	set(value):
+		_bake_chunk_size = _bounded(
+			value, MIN_BAKE_CHUNK_SIZE, MAX_BAKE_CHUNK_SIZE, _bake_chunk_size
+		)
+	get:
+		return _bake_chunk_size
 @export var bake_merge_meshes: bool = false
 @export var bake_generate_lods: bool = false
 @export var bake_unwrap_uv0: bool = false
 @export var bake_lightmap_uv2: bool = false
-@export var bake_lightmap_texel_size: float = 0.1
+var _bake_lightmap_texel_size: float = 0.1
+@export var bake_lightmap_texel_size: float = 0.1:
+	set(value):
+		_bake_lightmap_texel_size = _bounded(
+			value, MIN_LIGHTMAP_TEXEL_SIZE, MAX_LIGHTMAP_TEXEL_SIZE, _bake_lightmap_texel_size
+		)
+	get:
+		return _bake_lightmap_texel_size
 @export var bake_use_face_materials: bool = false
 @export var bake_navmesh: bool = false
-@export var bake_navmesh_cell_size: float = 0.3
-@export var bake_navmesh_cell_height: float = 0.25
-@export var bake_navmesh_agent_height: float = 2.0
-@export var bake_navmesh_agent_radius: float = 0.4
+var _bake_navmesh_cell_size: float = 0.3
+@export var bake_navmesh_cell_size: float = 0.3:
+	set(value):
+		_bake_navmesh_cell_size = _bounded(
+			value, MIN_NAVMESH_CELL, MAX_NAVMESH_CELL, _bake_navmesh_cell_size
+		)
+	get:
+		return _bake_navmesh_cell_size
+var _bake_navmesh_cell_height: float = 0.25
+@export var bake_navmesh_cell_height: float = 0.25:
+	set(value):
+		_bake_navmesh_cell_height = _bounded(
+			value, MIN_NAVMESH_CELL, MAX_NAVMESH_CELL, _bake_navmesh_cell_height
+		)
+	get:
+		return _bake_navmesh_cell_height
+var _bake_navmesh_agent_height: float = 2.0
+@export var bake_navmesh_agent_height: float = 2.0:
+	set(value):
+		_bake_navmesh_agent_height = _bounded(
+			value, MIN_NAVMESH_AGENT, MAX_NAVMESH_AGENT, _bake_navmesh_agent_height
+		)
+	get:
+		return _bake_navmesh_agent_height
+var _bake_navmesh_agent_radius: float = 0.4
+@export var bake_navmesh_agent_radius: float = 0.4:
+	set(value):
+		_bake_navmesh_agent_radius = _bounded(
+			value, MIN_NAVMESH_AGENT, MAX_NAVMESH_AGENT, _bake_navmesh_agent_radius
+		)
+	get:
+		return _bake_navmesh_agent_radius
 @export var bake_visible_only: bool = false
 @export var bake_use_multimesh: bool = false
 @export var bake_use_atlas: bool = false
@@ -91,8 +179,23 @@ var _grid_snap: float = 16.0
 ## surfaces rarely block enough pixels to justify the culling overhead.
 @export var bake_occluder_min_area: float = 4.0
 @export var bake_connector_mode: int = 0  # HFAutoConnector.ConnectorMode (RAMP=0, STAIRS=1, AUTO=2)
-@export var bake_connector_stair_height: float = 0.25
-@export var bake_connector_width: int = 2
+var _bake_connector_stair_height: float = 0.25
+@export var bake_connector_stair_height: float = 0.25:
+	set(value):
+		_bake_connector_stair_height = _bounded(
+			value,
+			MIN_CONNECTOR_STAIR_HEIGHT,
+			MAX_CONNECTOR_STAIR_HEIGHT,
+			_bake_connector_stair_height
+		)
+	get:
+		return _bake_connector_stair_height
+var _bake_connector_width: int = 2
+@export var bake_connector_width: int = 2:
+	set(value):
+		_bake_connector_width = clampi(value, MIN_CONNECTOR_WIDTH, MAX_CONNECTOR_WIDTH)
+	get:
+		return _bake_connector_width
 @export var bake_use_thread_pool: bool = true
 ## Collision shape strategy: 0 = single trimesh (legacy), 1 = per-brush convex hulls,
 ## 2 = per-visgroup partitioned bodies.
@@ -102,7 +205,12 @@ var _grid_snap: float = 16.0
 ## broadphase and produce better navigation meshes.
 @export var bake_convex_clean: bool = true
 ## Simplification threshold for convex hull generation (0 = no simplification).
-@export_range(0.0, 1.0, 0.01) var bake_convex_simplify: float = 0.0
+var _bake_convex_simplify: float = 0.0
+@export_range(0.0, 1.0, 0.01) var bake_convex_simplify: float = 0.0:
+	set(value):
+		_bake_convex_simplify = _bounded(value, 0.0, 1.0, _bake_convex_simplify)
+	get:
+		return _bake_convex_simplify
 var _hflevel_autosave_enabled: bool = true
 @export var hflevel_autosave_enabled: bool = true:
 	set(value):
@@ -135,16 +243,35 @@ var _grid_visible: bool = false
 		return _grid_visible
 @export var grid_follow_brush: bool = false
 @export var debug_logging: bool = false
-@export var grid_plane_size: float = 500.0
+var _grid_plane_size: float = 500.0
+@export var grid_plane_size: float = 500.0:
+	set(value):
+		_grid_plane_size = _bounded(
+			value, MIN_GRID_PLANE_SIZE, MAX_GRID_PLANE_SIZE, _grid_plane_size
+		)
+	get:
+		return _grid_plane_size
 @export var grid_color: Color = Color(0.85, 0.95, 1.0, 0.15)
 @export_range(1, 16, 1) var grid_major_line_frequency: int = 4
 @export var texture_lock: bool = true
 ## Step, in degrees, used by the rotate hotkeys and the dock's rotate buttons.
-@export_range(1.0, 180.0, 1.0) var rotate_snap_degrees: float = 15.0
+var _rotate_snap_degrees: float = 15.0
+@export_range(1.0, 180.0, 1.0) var rotate_snap_degrees: float = 15.0:
+	set(value):
+		_rotate_snap_degrees = _bounded(
+			value, MIN_ROTATE_SNAP_DEGREES, MAX_ROTATE_SNAP_DEGREES, _rotate_snap_degrees
+		)
+	get:
+		return _rotate_snap_degrees
 ## Where rotate and flip pivot: 0 selection centre, 1 world origin, 2 active object.
 @export_enum("Selection Center", "World Origin", "Active Object") var transform_pivot_mode: int = 0
 @export var cordon_enabled: bool = false
-@export var cordon_aabb: AABB = AABB(Vector3(-128, -128, -128), Vector3(256, 256, 256))
+var _cordon_aabb: AABB = AABB(Vector3(-128, -128, -128), Vector3(256, 256, 256))
+@export var cordon_aabb: AABB = AABB(Vector3(-128, -128, -128), Vector3(256, 256, 256)):
+	set(value):
+		_set_cordon_aabb(value)
+	get:
+		return _cordon_aabb
 
 # ---------------------------------------------------------------------------
 # Signals — Central registry.  Subsystems and UI should subscribe to these
@@ -2902,7 +3029,28 @@ func clear_face_hover_highlight() -> void:
 	_face_hover_last_face_idx = -1
 
 
+## Normalise a cordon into a region.
+##
+## An AABB with a negative size is a constructible value of the type and is not a
+## region: Godot own intersects() errors on it and returns false for everything,
+## so every brush read as outside the cordon and the bake produced an empty level
+## and reported success. The cordon wireframe draws the same box either way, so
+## there was nothing on screen to go on. abs() is the fix Godot own error message
+## names, and it makes a min/max pair entered in either order mean the same
+## region, which is what the dock six SpinBoxes make easy to get backwards.
+func _set_cordon_aabb(value: AABB) -> void:
+	if not value.position.is_finite() or not value.size.is_finite():
+		HFLog.warn("HammerForge: cordon %s is not a region, keeping %s" % [value, _cordon_aabb])
+		return
+	_cordon_aabb = value.abs()
+
+
 func _set_grid_snap(value: float) -> void:
+	if not is_finite(value):
+		# max() passes NaN through, which is how the one setter that already
+		# refused a negative snap let a NaN past.
+		HFLog.warn("HammerForge: grid snap %s is not a snap, keeping %s" % [value, _grid_snap])
+		return
 	var clamped = max(value, 0.0)
 	if is_equal_approx(_grid_snap, clamped):
 		return

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,519 tests across 181 scripts**: **3,512 passing tests**, seven intentional no-assert safety tests, and **17,839 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,528 tests across 182 scripts**: **3,521 passing tests**, seven intentional no-assert safety tests, and **17,890 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,528 tests across 182 scripts**: **3,521 passing tests**, seven intentional no-assert safety tests, and **17,890 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,578 tests across 187 scripts**: **3,571 passing tests**, seven intentional no-assert safety tests, and **18,045 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -138,7 +138,7 @@ Grid-based paint layers with chunked storage for large worlds:
 
 - **Visgroups** -- named visibility groups ("walls", "detail", "lighting") with per-group show/hide
 - **Grouping** (Ctrl+G / Ctrl+U) -- persistent groups that select and move together
-- **Cordon** -- restrict bake to an AABB region with yellow wireframe; skip everything outside
+- **Cordon** -- restrict bake to an AABB region with yellow wireframe; skip everything outside. A min/max pair entered in either order means the same region, and a cordon with a non-finite corner is refused rather than stored
 - **Reference cleanup** -- deleting brushes auto-cleans group/visgroup membership and warns about dangling entity I/O connections
 - **Duplicator** -- create N copies of a brush with progressive offset
 - **Prefabs** -- save brush + entity groups as `.hfprefab` files with variants, tags, and live-linked propagation. Drag from library to instantiate with new IDs and remapped I/O

--- a/tests/test_bake_and_grid_setting_bounds.gd
+++ b/tests/test_bake_and_grid_setting_bounds.gd
@@ -1,0 +1,152 @@
+extends GutTest
+
+## #361 bounded the terrain settings that take a number. The bake and grid
+## settings are the same list and were not touched (#373), and the cordon is the
+## same shape one type up (#377). The dock SpinBoxes have ranges; the `.hflevel`
+## does not, and it is JSON that gets hand-edited and merged.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+
+var root: LevelRoot
+
+
+func before_each():
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func _box(brush_id: String) -> DraftBrush:
+	return (
+		root.create_brush_from_info({"size": Vector3(64, 64, 64), "brush_id": brush_id})
+		as DraftBrush
+	)
+
+
+# ===========================================================================
+# The numbers (#373)
+# ===========================================================================
+
+
+func test_no_bake_or_grid_setting_keeps_a_value_that_is_not_a_number():
+	var before := {
+		"grid_snap": root.grid_snap,
+		"grid_plane_size": root.grid_plane_size,
+		"rotate_snap_degrees": root.rotate_snap_degrees,
+		"bake_chunk_size": root.bake_chunk_size,
+		"bake_lightmap_texel_size": root.bake_lightmap_texel_size,
+		"bake_navmesh_cell_size": root.bake_navmesh_cell_size,
+		"bake_navmesh_cell_height": root.bake_navmesh_cell_height,
+		"bake_navmesh_agent_height": root.bake_navmesh_agent_height,
+		"bake_navmesh_agent_radius": root.bake_navmesh_agent_radius,
+		"bake_connector_stair_height": root.bake_connector_stair_height,
+		"bake_convex_simplify": root.bake_convex_simplify,
+	}
+	for key in before.keys():
+		root.set(key, NAN)
+		assert_eq(root.get(key), before[key], "%s refused NaN" % key)
+		root.set(key, INF)
+		assert_true(is_finite(root.get(key)), "%s refused inf" % key)
+
+
+func test_the_settings_that_must_be_positive_are_floored():
+	root.bake_chunk_size = -32.0
+	assert_gt(root.bake_chunk_size, 0.0, "a chunk size is a size")
+	root.bake_lightmap_texel_size = 0.0
+	assert_gt(root.bake_lightmap_texel_size, 0.0, "a texel size is a size")
+	root.bake_navmesh_cell_size = 0.0
+	assert_gt(root.bake_navmesh_cell_size, 0.0)
+	root.bake_navmesh_cell_height = -1.0
+	assert_gt(root.bake_navmesh_cell_height, 0.0)
+	root.bake_navmesh_agent_radius = -5.0
+	assert_gt(root.bake_navmesh_agent_radius, 0.0)
+	root.bake_connector_stair_height = 0.0
+	assert_gt(root.bake_connector_stair_height, 0.0)
+	root.bake_connector_width = -4
+	assert_gte(root.bake_connector_width, 1, "a piece count is at least one")
+	root.grid_plane_size = 0.0
+	assert_gt(root.grid_plane_size, 0.0)
+
+
+func test_the_settings_with_a_declared_range_are_held_to_it():
+	root.bake_convex_simplify = 5.0
+	assert_lte(root.bake_convex_simplify, 1.0, "the export_range is enforced on assignment now")
+	root.bake_convex_simplify = -1.0
+	assert_gte(root.bake_convex_simplify, 0.0)
+	root.rotate_snap_degrees = 0.0
+	assert_gte(root.rotate_snap_degrees, 1.0, "a zero step makes the rotate buttons a no-op")
+	root.rotate_snap_degrees = 100000.0
+	assert_lte(root.rotate_snap_degrees, 180.0)
+
+
+func test_ordinary_values_still_land():
+	root.bake_chunk_size = 64.0
+	root.bake_convex_simplify = 0.5
+	root.rotate_snap_degrees = 45.0
+	root.grid_snap = 8.0
+	assert_eq(root.bake_chunk_size, 64.0)
+	assert_almost_eq(root.bake_convex_simplify, 0.5, 0.001)
+	assert_eq(root.rotate_snap_degrees, 45.0)
+	assert_eq(root.grid_snap, 8.0)
+
+
+func test_a_poisoned_settings_block_from_a_file_does_not_land():
+	(
+		root
+		. state_system
+		. apply_hflevel_settings(
+			{
+				"grid_snap": NAN,
+				"bake_chunk_size": -1.0,
+				"bake_lightmap_texel_size": 0.0,
+				"bake_navmesh_cell_size": NAN,
+				"bake_convex_simplify": 9.0,
+				"bake_connector_width": -4,
+			}
+		)
+	)
+	assert_true(is_finite(root.grid_snap), "grid snap is still a snap")
+	assert_gt(root.grid_snap, 0.0, "and not silently off")
+	assert_gt(root.bake_chunk_size, 0.0)
+	assert_gt(root.bake_lightmap_texel_size, 0.0)
+	assert_true(is_finite(root.bake_navmesh_cell_size))
+	assert_lte(root.bake_convex_simplify, 1.0)
+	assert_gte(root.bake_connector_width, 1)
+
+
+# ===========================================================================
+# The cordon (#377)
+# ===========================================================================
+
+
+func test_a_cordon_entered_backwards_is_the_same_region_either_way():
+	root.cordon_aabb = AABB(Vector3(128, 128, 128), Vector3(-256, -256, -256))
+	assert_eq(root.cordon_aabb.size, Vector3(256, 256, 256), "normalised by abs()")
+	assert_eq(root.cordon_aabb.position, Vector3(-128, -128, -128))
+
+
+func test_a_non_finite_cordon_is_refused():
+	var before: AABB = root.cordon_aabb
+	root.cordon_aabb = AABB(Vector3.ZERO, Vector3(NAN, NAN, NAN))
+	assert_eq(root.cordon_aabb, before, "the cordon that was there is still there")
+	root.cordon_aabb = AABB(Vector3(INF, 0, 0), Vector3(256, 256, 256))
+	assert_eq(root.cordon_aabb, before)
+
+
+func test_an_inverted_cordon_no_longer_bakes_an_empty_level():
+	_box("b")
+	root.cordon_enabled = true
+	root.cordon_aabb = AABB(Vector3(128, 128, 128), Vector3(-256, -256, -256))
+	assert_true(
+		root.cordon_aabb.intersects(AABB(Vector3(-32, -32, -32), Vector3(64, 64, 64))),
+		"the box at the origin is inside the cordon"
+	)
+
+
+func test_a_cordon_block_from_a_file_with_the_wrong_contents_is_refused():
+	var before: AABB = root.cordon_aabb
+	root.state_system.apply_hflevel_settings(
+		{"cordon_aabb_pos": [0.0, 0.0, 0.0], "cordon_aabb_size": [NAN, NAN, NAN]}
+	)
+	assert_eq(root.cordon_aabb, before, "a NaN size did not become the cordon")


### PR DESCRIPTION
- #373 Eleven settings get a backing var and a clamping setter, with the finiteness guard first because `clampf()` and `maxf()` both pass NaN through. `grid_snap` gets the same guard on the setter it already had. `apply_hflevel_settings()` writes the properties, so the load path is covered by the same change, and there is a test that feeds it the exact poisoned block from the report.
- #377 `cordon_aabb` has a setter that refuses a non-finite position or size and calls `.abs()` on a negative one. The array-length half of that issue is already handled in `apply_hflevel_settings()` — it checks both arrays are length 3 — so what was left was the contents and the sign.

On the open question about an empty cordon: leaving a zero-size cordon alone. It is degenerate but `intersects()` is true for one touching a brush, so it bakes something rather than nothing, and a deliberately tiny cordon is legitimate. The failure mode worth a message was the inverted one, and that is now impossible to store.

Tests in `tests/test_bake_and_grid_setting_bounds.gd`. Full suite passes.

Fixes #373
Fixes #377