### PR TITLE
Make the merge enforce the rules its own check refuses on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Fixed
+- **`merge_brushes_by_ids()` enforced neither rule `can_merge_brushes()` refuses
+  on** (#383). The operation collected whatever ids it could find and took the
+  first brush's operation for the result, so merging an additive brush with a
+  subtractive one succeeded — a subtractive brush is a hole, and merged into a
+  solid the mapper's doorway became a wall under a message saying "Merged 2
+  brushes" — and a selection with one stale id merged the subset and reported the
+  count it merged. The reachable path is a redo: the pre-check runs before the
+  undo action is opened, and the undo entry stores the method and the ids, so a
+  redo calls the operation directly against a level that has moved on.
+  `merge_brushes_by_ids()` calls the check, which is side effect free and already
+  returns the right message for each case.
 - **A grid array with a negative axis count was built rather than refused**
   (#346). The linear and radial paths refuse a count below one with a message and
   a fix hint; the grid path clamped `(-2, 2, 2)` up to `(1, 2, 2)` first, so

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,519 tests across 181 test scripts (3,512 passing plus seven intentional no-assert safety tests; 17,839 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,523 tests across 182 test scripts (3,516 passing plus seven intentional no-assert safety tests; 17,850 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,523 tests across 182 test scripts (3,516 passing plus seven intentional no-assert safety tests; 17,850 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,582 tests across 188 test scripts (3,575 passing plus seven intentional no-assert safety tests; 18,056 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,519 tests** across **181 scripts** (**3,512 passing** plus seven intentional no-assert safety tests; **17,839 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,523 tests** across **182 scripts** (**3,516 passing** plus seven intentional no-assert safety tests; **17,850 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,523 tests** across **182 scripts** (**3,516 passing** plus seven intentional no-assert safety tests; **17,850 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,582 tests** across **188 scripts** (**3,575 passing** plus seven intentional no-assert safety tests; **18,056 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3512%20passing-brightgreen" alt="3512 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3516%20passing-brightgreen" alt="3516 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3516%20passing-brightgreen" alt="3516 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3575%20passing-brightgreen" alt="3575 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,519 tests across 181 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,523 tests across 182 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,523 tests across 182 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,582 tests across 188 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/systems/hf_brush_system.gd
+++ b/addons/hammerforge/systems/hf_brush_system.gd
@@ -1386,8 +1386,19 @@ func can_merge_brushes(brush_ids: Array) -> HFOpResult:
 
 
 func merge_brushes_by_ids(brush_ids: Array) -> HFOpResult:
-	if brush_ids.size() < 2:
-		return _op_fail("Merge: select at least 2 brushes")
+	# The rules live in can_merge_brushes() and have to hold here, not only at the
+	# one caller that consults it. plugin_edit_actions.gd asks before it opens the
+	# undo action, and the undo entry stores this method and these ids — so a redo
+	# calls straight in, against a level that has moved on since the check ran.
+	# Undo a merge, delete one of the sources, redo, and the operation used to
+	# merge the subset and report the count it merged. The other rule is worse: a
+	# subtractive brush is a hole, and merged into an additive one its geometry
+	# became part of a solid, so the mapper had a doorway and now has a wall,
+	# under a message saying "Merged 2 brushes". can_merge_brushes() is side
+	# effect free and already returns the right message for each case.
+	var check := can_merge_brushes(brush_ids)
+	if not check.ok:
+		return check
 	if root.has_method("tag_full_reconcile"):
 		root.tag_full_reconcile()
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,519 tests across 181 scripts**: **3,512 passing tests**, seven intentional no-assert safety tests, and **17,839 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,523 tests across 182 scripts**: **3,516 passing tests**, seven intentional no-assert safety tests, and **17,850 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,523 tests across 182 scripts**: **3,516 passing tests**, seven intentional no-assert safety tests, and **17,850 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,582 tests across 188 scripts**: **3,575 passing tests**, seven intentional no-assert safety tests, and **18,056 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_merge_enforces_its_own_rules.gd
+++ b/tests/test_merge_enforces_its_own_rules.gd
@@ -1,0 +1,77 @@
+extends GutTest
+
+## `can_merge_brushes()` is where the merge rules are written and
+## `merge_brushes_by_ids()` enforced neither of them (#383). The pre-check in
+## plugin_edit_actions.gd runs before the undo action is opened, and the undo
+## entry stores the method and the ids — so a redo calls the operation directly,
+## against a level that has moved on since the check ran.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+
+var root: LevelRoot
+
+
+func before_each():
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func _brush(brush_id: String, operation: int, position: Vector3) -> DraftBrush:
+	var brush: DraftBrush = (
+		root
+		. create_brush_from_info(
+			{
+				"size": Vector3(64, 64, 64),
+				"brush_id": brush_id,
+				"operation": operation,
+				"transform": Transform3D(Basis.IDENTITY, position),
+			}
+		)
+	)
+	return brush
+
+
+func _brush_count() -> int:
+	return root.draft_brushes_node.get_child_count()
+
+
+func test_a_mixed_operation_merge_is_refused_by_the_operation():
+	_brush("add", CSGShape3D.OPERATION_UNION, Vector3.ZERO)
+	_brush("cut", CSGShape3D.OPERATION_SUBTRACTION, Vector3(32, 0, 0))
+	var before := _brush_count()
+
+	var result: HFOpResult = root.merge_brushes_by_ids(["add", "cut"])
+	assert_false(result.ok, "a hole does not merge into a wall")
+	assert_string_contains(result.message, "same operation type")
+	assert_eq(_brush_count(), before, "nothing was merged")
+
+
+func test_a_stale_id_refuses_the_whole_selection_rather_than_merging_a_subset():
+	_brush("a", CSGShape3D.OPERATION_UNION, Vector3.ZERO)
+	_brush("b", CSGShape3D.OPERATION_UNION, Vector3(32, 0, 0))
+	var before := _brush_count()
+
+	var result: HFOpResult = root.merge_brushes_by_ids(["a", "b", "no_such_brush"])
+	assert_false(result.ok, "the selection is not quietly narrowed")
+	assert_string_contains(result.message, "no_such_brush")
+	assert_eq(_brush_count(), before, "the two real brushes are untouched")
+
+
+func test_the_operation_and_the_check_now_agree():
+	_brush("a", CSGShape3D.OPERATION_UNION, Vector3.ZERO)
+	_brush("cut", CSGShape3D.OPERATION_SUBTRACTION, Vector3(32, 0, 0))
+	for ids in [["a"], ["a", "cut"], ["a", "gone"]]:
+		var check: HFOpResult = root.can_merge_brushes(ids)
+		var done: HFOpResult = root.merge_brushes_by_ids(ids)
+		assert_eq(done.ok, check.ok, "%s: the check and the operation agree" % [ids])
+
+
+func test_an_ordinary_merge_still_works():
+	_brush("a", CSGShape3D.OPERATION_UNION, Vector3.ZERO)
+	_brush("b", CSGShape3D.OPERATION_UNION, Vector3(32, 0, 0))
+	var before := _brush_count()
+	var result: HFOpResult = root.merge_brushes_by_ids(["a", "b"])
+	assert_true(result.ok, result.message)
+	assert_eq(_brush_count(), before - 1, "two brushes became one")


### PR DESCRIPTION
One call at the top of `merge_brushes_by_ids()`. `can_merge_brushes()` is side effect free and already returns the right message for each case, so the pre-check in `plugin_edit_actions.gd` stays useful — it refuses before an undo action is opened — and stops being the only thing between a stale selection and the geometry.

Did the pass over the other `can_*` / operation pairs you suggested. There are four others. `can_hollow_brush()` and `can_clip_brush()` you already checked and they agree. `can_build_generator()` and `can_flip_brushes()` are a different shape: `flip()` skips a displacement brush itself and documents that it does, so the rule holds in the operation rather than only in the check. Nothing else to fix here.

Tests in `tests/test_merge_enforces_its_own_rules.gd`, including one that walks three selections through both the check and the operation and asserts they agree. Full suite passes.

Fixes #383