### PR TITLE
Remove the material usage tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog, and this project follows semantic versioning.
 
 ## [Unreleased]
+### Removed
+- **The material usage tracker** (#375). `record_usage()`, `release_usage()`,
+  `rebuild_usage()`, `find_unused_materials()` and `get_usage_count()` had no
+  caller anywhere — not the dock, not the plugin, not the state system, not the
+  test suite — and `rebuild_usage()` counted the wrong thing: it read
+  `child.material_override`, which is the draft preview tint the brush system
+  sets for operation colouring, rather than `FaceData.material_idx`, which is
+  what the Paint tab writes, what the `.hflevel` stores and what the bake reads.
+  A level whose every face was painted with a material reported that material as
+  unused. Nothing could go wrong today because nothing called it; the risk was
+  the next person to want "find unused materials" finding five ready-made
+  functions with plausible names and wiring them up to a "Remove unused" button
+  that would strip the palette of materials in use.
+
 ### Fixed
 - **A grid array with a negative axis count was built rather than refused**
   (#346). The linear and radial paths refuse a count below one with a message and

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -269,8 +269,7 @@ Entity types and brush entity classes are data-driven via `HFEntityDef` (`hf_ent
 
 `MaterialManager` (`material_manager.gd`) manages the shared material palette:
 - **Library persistence**: `save_library(path)` / `load_library(path)` serialize material resource paths to JSON.
-- **Usage tracking**: `record_usage()` / `release_usage()` / `rebuild_usage()` track which materials are used by brushes.
-- **Cleanup**: `find_unused_materials()` returns palette materials not used by any brush.
+- **Usage tracking**: none. Materials are assigned per face via `FaceData.material_idx`, so usage is a count per palette index, not per resource path.
 - **Prototype textures**: `HFPrototypeTextures.load_all_into(manager)` batch-loads 150 built-in SVG textures as `StandardMaterial3D` resources. The dock exposes this via the "Refresh Prototypes" button in the Paint tab → Materials section.
 - **Visual browser**: `HFMaterialBrowser` (`ui/hf_material_browser.gd`) provides a thumbnail grid with search, pattern/color filters, favorites, hover preview, context menu, and drag-and-drop. Replaces the text-only `ItemList`.
 - **Texture Picker**: T key activates an eyedropper that raycasts to a face, reads `FaceData.material_idx`, and sets it as the browser's current selection.

--- a/addons/hammerforge/material_manager.gd
+++ b/addons/hammerforge/material_manager.gd
@@ -4,9 +4,6 @@ class_name MaterialManager
 
 @export var materials: Array[Material] = []
 
-## Tracks how many brushes reference each material resource path.
-var _usage_counts: Dictionary = {}
-
 ## Path to the last saved/loaded material library (for auto-reload).
 var _library_path := ""
 
@@ -103,52 +100,3 @@ func load_library(path: String) -> bool:
 ## Returns the path of the last saved/loaded library, or empty string.
 func get_library_path() -> String:
 	return _library_path
-
-
-# ---------------------------------------------------------------------------
-# Usage Tracking
-# ---------------------------------------------------------------------------
-
-
-## Record that a material resource path is used by one more brush.
-func record_usage(resource_path: String) -> void:
-	if resource_path == "":
-		return
-	_usage_counts[resource_path] = int(_usage_counts.get(resource_path, 0)) + 1
-
-
-## Record that a material resource path is used by one fewer brush.
-func release_usage(resource_path: String) -> void:
-	if resource_path == "" or not _usage_counts.has(resource_path):
-		return
-	var count := int(_usage_counts[resource_path]) - 1
-	if count <= 0:
-		_usage_counts.erase(resource_path)
-	else:
-		_usage_counts[resource_path] = count
-
-
-## Rebuild usage counts by scanning all brushes under a parent node.
-func rebuild_usage(brushes_parent: Node) -> void:
-	_usage_counts.clear()
-	if not brushes_parent:
-		return
-	for child in brushes_parent.get_children():
-		var mat: Material = child.get("material_override")
-		if mat and mat.resource_path != "":
-			record_usage(mat.resource_path)
-
-
-## Returns materials in the palette that are not used by any brush.
-func find_unused_materials() -> Array[Material]:
-	var unused: Array[Material] = []
-	for mat in materials:
-		if mat and mat.resource_path != "":
-			if not _usage_counts.has(mat.resource_path):
-				unused.append(mat)
-	return unused
-
-
-## Returns the usage count for a material resource path.
-func get_usage_count(resource_path: String) -> int:
-	return int(_usage_counts.get(resource_path, 0))

--- a/docs/HammerForge_Texture_Materials.md
+++ b/docs/HammerForge_Texture_Materials.md
@@ -83,7 +83,7 @@ Notes:
 - Per-face materials override the DraftBrush material for preview and face-material bake.
 - The palette is saved in `.hflevel`.
 - **Library persistence**: the palette can be saved to / loaded from a JSON library file via `MaterialManager.save_library()` / `load_library()`. This preserves the material list across projects. Missing or unloadable materials are preserved as `null` placeholder slots to keep palette indices stable.
-- **Usage tracking**: `MaterialManager` tracks which materials are referenced by brushes. Use `find_unused_materials()` to identify palette entries that are no longer in use.
+- **Unused materials**: there is no usage tracker. The one that existed counted `material_override`, which HammerForge only uses for the draft preview tint, rather than `FaceData.material_idx`, which is what the Paint tab writes and the bake reads, so it reported the material every face was painted with as unused. It was removed rather than left as a correct-looking implementation of the wrong model.
 
 ## UV Editor
 The Paint tab → UV Editor section shows a simple per-face UV editor.

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -1052,7 +1052,7 @@ A `LevelRoot` can read from somewhere else instead through its `entity_definitio
 The material palette can be saved and loaded as a JSON library file:
 - **Save**: preserves resource paths of all palette materials.
 - **Load**: restores the palette from saved paths.
-- **Usage tracking**: materials in use by brushes are tracked; `find_unused_materials()` identifies cleanup candidates.
+- **Unused materials**: not tracked. Material assignment is per face, through `FaceData.material_idx`, so "is this palette slot used" is a question about face slots rather than about a resource path.
 
 ## Prototype Textures
 HammerForge includes 150 built-in SVG prototype textures organized as 15 patterns in 10 color variations. Click **Refresh Prototypes** in the Paint tab → Materials section to add them all to the palette. The **Material Browser** displays them as a visual thumbnail grid with search and pattern/color filters — no need to memorize names. Patterns include solid, brick, checker, cross, diamond, dots, hex, stripes (diagonal/horizontal), triangles, zigzag, and directional arrows (up/down/left/right).

--- a/tools/vibe/scenarios/materials.gd
+++ b/tools/vibe/scenarios/materials.gd
@@ -140,58 +140,38 @@ func _removing_a_slot_reaches_every_brush_container() -> void:
 				break
 
 
-## `MaterialManager` carries `record_usage`, `release_usage`, `rebuild_usage`,
-## `find_unused_materials` and `get_usage_count`. What calls them, and what would
-## they say if something did.
+## `MaterialManager` carried `record_usage`, `release_usage`, `rebuild_usage`,
+## `find_unused_materials` and `get_usage_count`. Nothing called any of them, and
+## `rebuild_usage()` counted `child.material_override` rather than
+## `FaceData.material_idx`, which is the only way HammerForge assigns a material.
+## The block was removed (#375); this checks it has not come back.
 func _the_usage_tracker() -> void:
 	var root: Node3D = await fresh_root()
 	var mm = root.get_material_manager()
-	# Written to disk so they have a resource_path. The tracker is keyed on that
-	# string and skips any material without one, so an in-memory palette would
-	# make it look right by accident.
-	var red := _mat(Color.RED, "red")
-	var green := _mat(Color.GREEN, "green")
-	ResourceSaver.save(red, "user://vibe_red.tres")
-	ResourceSaver.save(green, "user://vibe_green.tres")
-	red.take_over_path("user://vibe_red.tres")
-	green.take_over_path("user://vibe_green.tres")
-	root.set_materials([red, green])
-
-	# Use them the only way HammerForge actually assigns a material: per face.
-	var b := box(root, Vector3(64, 64, 64))
-	for face in b.faces:
-		face.material_idx = 0
-	await frame()
-
-	mm.rebuild_usage(root.draft_brushes_node)
-	var unused = mm.find_unused_materials()
-	note("palette", root.get_material_names())
-	note("every face of the one brush is on slot 0", _face_slots(b))
-	var unused_names: Array = []
-	for m in unused:
-		unused_names.append(m.resource_path)
-	note("find_unused_materials() after rebuild_usage()", "%d: %s" % [unused.size(), unused_names])
-	note("usage count for the material every face is on", mm.get_usage_count(red.resource_path))
-
-	var with_paths := 0
-	for m in root.get_materials():
-		if m != null and m.resource_path != "":
-			with_paths += 1
+	var gone: Array = []
+	for method in [
+		"record_usage",
+		"release_usage",
+		"rebuild_usage",
+		"find_unused_materials",
+		"get_usage_count",
+	]:
+		if mm.has_method(method):
+			gone.append(method)
 	note(
-		"palette materials that have a resource_path",
-		"%d of %d" % [with_paths, root.get_materials().size()]
+		"usage-tracking methods still on MaterialManager",
+		"%d: %s" % [gone.size(), gone] if not gone.is_empty() else "none, as of #375"
 	)
-
-	# What rebuild_usage actually reads.
-	note(
-		"rebuild_usage reads",
-		"child.material_override on the direct children of the node it is given -- never face.material_idx"
-	)
-	known(
-		375,
-		"the material usage tracker is keyed on the wrong thing and has no caller",
-		(
-			"every face of the level's only brush is on '%s', and after rebuild_usage() its usage count is %d and find_unused_materials() returns %s -- the tracker counts `child.material_override`, never FaceData.material_idx; record_usage, release_usage, rebuild_usage, find_unused_materials and get_usage_count have no caller anywhere in the repo, tests included"
-			% [red.resource_path, mm.get_usage_count(red.resource_path), unused_names]
+	if not gone.is_empty():
+		known(
+			375,
+			"the material usage tracker is back",
+			(
+				(
+					"%s is on MaterialManager again. It counted child.material_override, "
+					+ "never FaceData.material_idx, so it reported the material every face "
+					+ "in the level was painted with as unused."
+				)
+				% [gone]
+			)
 		)
-	)


### PR DESCRIPTION
Took the delete option. It has no callers, it is not tested, and it describes a material model the editor does not use — `material_override` is the draft preview tint the brush system sets for operation colouring, not how a material is assigned. Forty-seven lines and one dictionary.

Fixing and wiring it is the other option and it is a real feature: usage would be a count per palette *index*, walking `face.material_idx` over `_iter_managed_brush_nodes()`, plus a Paint tab action to reach it. That wants its own decision rather than arriving as a bug fix, and leaving the wrong-model version in place is the thing the issue asked to close off.

`tools/vibe/scenarios/materials.gd` now checks the methods have not come back rather than measuring what they said, and runs clean. Docs updated in three places. Full suite passes.

Fixes #375