### PR TITLE
Make a bake setting change invalidate the bake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on Keep a Changelog, and this project follows semantic versi
 
 ## [Unreleased]
 ### Fixed
+- **Changing a bake setting did not invalidate the bake** (#376). `bake_dirty()`
+  rebuilt only what brush dirty state said needed rebuilding, and the settings
+  were not part of what could be dirty — so the realistic sequence did the wrong
+  thing quietly: hide a visgroup to work on something, bake to check it, turn
+  "bake visible only" off, bake again, and the level that ships is missing every
+  brush in that visgroup. The second bake finished, said it succeeded, and left
+  the previous result standing. `bake_visible_only` is only the easiest to
+  measure; every setting that decides what goes into the bake or how it is built
+  had the same problem, several of them less visible in the result than a missing
+  box. The bake system hashes those settings and compares against the ones the
+  last successful bake ran with, so a setting change is a change. A hash rather
+  than a flag per setter, because most of these properties had no setter and the
+  hash covers the `.hflevel` load path for free.
 - **A grid array with a negative axis count was built rather than refused**
   (#346). The linear and radial paths refuse a count below one with a message and
   a fix hint; the grid path clamped `(-2, 2, 2)` up to `(1, 2, 2)` first, so

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,519 tests across 181 test scripts (3,512 passing plus seven intentional no-assert safety tests; 17,839 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,524 tests across 182 test scripts (3,517 passing plus seven intentional no-assert safety tests; 17,904 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,524 tests across 182 test scripts (3,517 passing plus seven intentional no-assert safety tests; 17,904 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,587 tests across 189 test scripts (3,580 passing plus seven intentional no-assert safety tests; 18,121 assertions; verified in CI on September 11, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,524 tests** across **182 scripts** (**3,517 passing** plus seven intentional no-assert safety tests; **17,904 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,587 tests** across **189 scripts** (**3,580 passing** plus seven intentional no-assert safety tests; **18,121 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -545,6 +545,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,519 tests** across **181 scripts** (**3,512 passing** plus seven intentional no-assert safety tests; **17,839 assertions**).
+Full suite (verified in CI on September 11, 2026): **3,524 tests** across **182 scripts** (**3,517 passing** plus seven intentional no-assert safety tests; **17,904 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3517%20passing-brightgreen" alt="3517 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3580%20passing-brightgreen" alt="3580 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3512%20passing-brightgreen" alt="3512 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3517%20passing-brightgreen" alt="3517 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,519 tests across 181 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,524 tests across 182 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,524 tests across 182 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,587 tests across 189 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/systems/hf_bake_system.gd
+++ b/addons/hammerforge/systems/hf_bake_system.gd
@@ -27,6 +27,12 @@ enum BakeStatus { NOT_RUN, SUCCESS, FAILED, BUSY, NOTHING_TO_DO }
 
 var root: Node3D
 var _last_dirty_brush_ids: Dictionary = {}  # brush_id -> true; captured at bake start
+
+## The bake settings the last successful bake ran with, and whether there has
+## been one. Any other signature means the baked result no longer answers the
+## settings that are set — but only once there is a result for them to go stale.
+var _last_bake_settings_signature: int = 0
+var _has_baked_once: bool = false
 var _last_bake_success: bool = false
 var _last_bake_status: int = BakeStatus.NOT_RUN
 var _bake_in_flight := false
@@ -393,6 +399,70 @@ func _bake_selected_impl(
 		root.bake_finished.emit(false)
 
 
+## Every setting that decides what goes into the bake, or how it is built.
+##
+## Compared against the value the last successful bake ran with. A hash rather
+## than a flag on each setter: most of these properties have no setter, and the
+## hash covers the `.hflevel` load path for free, which a setter-set flag would
+## not. The cordon is in here because it decides which brushes are in the bake at
+## all, and `bake_material_override` by resource path because a Material has no
+## stable hash across a reload.
+## Every setting that decides what goes into the bake, or how it is built.
+##
+## Compared against the values the last successful bake ran with. A hash rather
+## than a flag on each setter: most of these properties have no setter, and the
+## hash covers the `.hflevel` load path for free, which a setter-set flag would
+## not. The cordon is in here because it decides which brushes are in the bake at
+## all.
+const BAKE_SETTING_NAMES := [
+	"bake_visible_only",
+	"bake_use_face_materials",
+	"bake_collision_mode",
+	"bake_collision_layer_index",
+	"bake_convex_clean",
+	"bake_convex_simplify",
+	"bake_lightmap_uv2",
+	"bake_lightmap_texel_size",
+	"bake_unwrap_uv0",
+	"bake_generate_lods",
+	"bake_chunk_size",
+	"bake_merge_meshes",
+	"bake_use_multimesh",
+	"bake_use_atlas",
+	"bake_generate_occluders",
+	"bake_occluder_min_area",
+	"bake_navmesh",
+	"bake_navmesh_cell_size",
+	"bake_navmesh_cell_height",
+	"bake_navmesh_agent_height",
+	"bake_navmesh_agent_radius",
+	"bake_auto_connectors",
+	"bake_connector_mode",
+	"bake_connector_stair_height",
+	"bake_connector_width",
+	"bake_wire_io",
+	"cordon_enabled",
+	"cordon_aabb",
+]
+
+
+func bake_settings_signature() -> int:
+	# Read by name, because a test root shim carries only the properties its test
+	# needs and a missing one should be "not set" rather than an error.
+	var values: Array = []
+	for name in BAKE_SETTING_NAMES:
+		values.append(root.get(name))
+	# A Material has no stable hash across a reload, so it goes in by path.
+	var override_path := ""
+	var override = root.get("bake_material_override")
+	if override != null:
+		override_path = str(override.resource_path)
+		if override_path == "":
+			override_path = str(override.get_instance_id())
+	values.append(override_path)
+	return values.hash()
+
+
 ## Rebuild from authoritative source when brush or structural dirty state exists.
 ## Missing dirty IDs represent deletions and therefore still require a bake.
 func bake_dirty(collision_layer_mask: int = 0, preview_mode: int = 0) -> bool:
@@ -402,6 +472,14 @@ func bake_dirty(collision_layer_mask: int = 0, preview_mode: int = 0) -> bool:
 		return false
 	var dirty_ids: Array = root._dirty_brush_ids.keys()
 	var full_reconcile_started: bool = root._full_reconcile_needed
+	# A changed setting is a change. Nothing marked the bake settings dirty, so a
+	# rebake after one was flipped took the "no changed brushes" path and left the
+	# previous result standing: hide a visgroup, bake to check something, turn
+	# "bake visible only" off, bake again, and the level that ships is missing
+	# every brush in that visgroup. Nothing about the result said it was stale.
+	if _has_baked_once and bake_settings_signature() != _last_bake_settings_signature:
+		root._log("Bake settings changed since the last bake, rebuilding in full")
+		return await bake(true, false, collision_layer_mask, preview_mode)
 	if dirty_ids.is_empty() and not full_reconcile_started:
 		_last_bake_status = BakeStatus.NOTHING_TO_DO
 		root.emit_signal("user_message", "No changed brushes since last bake", 1)
@@ -578,9 +656,15 @@ func bake(
 ) -> bool:
 	if not _try_begin_bake():
 		return false
+	var signature := bake_settings_signature()
 	await _bake_impl(apply_cuts, hide_live, collision_layer_mask, preview_mode, force_csg)
 	_bake_in_flight = false
 	_last_bake_status = BakeStatus.SUCCESS if _last_bake_success else BakeStatus.FAILED
+	if _last_bake_success:
+		# Taken before the bake ran, so a setting changed while it was in flight
+		# is still a change the next bake has to answer for.
+		_last_bake_settings_signature = signature
+		_has_baked_once = true
 	return _last_bake_success
 
 

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -805,7 +805,7 @@ The **Test → Advanced Bake** section exposes additional controls:
   - **Width** (SpinBox, 1–8): connector width in grid cells.
   Connectors are generated before navmesh baking, so the navmesh automatically covers connector surfaces. Auto-connectors are skipped during selection bakes (Bake Selected) to avoid pulling in unrelated geometry.
 
-The main **Bake** button is smart: if only specific brushes have been modified since the last bake, it automatically uses incremental bake (`Bake Changed`) instead of a full re-bake.
+The main **Bake** button is smart: if only specific brushes have been modified since the last bake, it automatically uses incremental bake (`Bake Changed`) instead of a full re-bake. Changing a bake setting counts as a change — the settings the last bake ran with are compared against the ones now set, so a rebake after flipping Bake Visible Only, a collision mode, a navmesh parameter or the cordon rebuilds in full rather than returning the previous result.
 
 ### Bake Issue Detection
 Click **Check Bake Issues** to scan for potential problems before baking:

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,524 tests across 182 scripts**: **3,517 passing tests**, seven intentional no-assert safety tests, and **17,904 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,587 tests across 189 scripts**: **3,580 passing tests**, seven intentional no-assert safety tests, and **18,121 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,519 tests across 181 scripts**: **3,512 passing tests**, seven intentional no-assert safety tests, and **17,839 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 11, 2026 contains **3,524 tests across 182 scripts**: **3,517 passing tests**, seven intentional no-assert safety tests, and **17,904 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_bake_settings_invalidate_the_bake.gd
+++ b/tests/test_bake_settings_invalidate_the_bake.gd
@@ -1,0 +1,100 @@
+extends GutTest
+
+## A bake setting change was not a change (#376). `bake_dirty()` rebuilt only
+## what brush dirty state said needed rebuilding, and the settings were not part
+## of what could be dirty, so flipping one and baking again left the previous
+## result standing with nothing about it saying so.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+
+var root: LevelRoot
+
+
+func before_each():
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func _box(brush_id: String, position: Vector3) -> DraftBrush:
+	return (
+		(
+			root
+			. create_brush_from_info(
+				{
+					"size": Vector3(64, 64, 64),
+					"brush_id": brush_id,
+					"transform": Transform3D(Basis.IDENTITY, position),
+				}
+			)
+		)
+		as DraftBrush
+	)
+
+
+func _signature() -> int:
+	return root.bake_system.bake_settings_signature()
+
+
+func test_every_setting_that_changes_the_bake_changes_the_signature():
+	var before := _signature()
+	for name in root.bake_system.BAKE_SETTING_NAMES:
+		var original = root.get(name)
+		match typeof(original):
+			TYPE_BOOL:
+				root.set(name, not original)
+			TYPE_INT:
+				root.set(name, original + 1)
+			TYPE_FLOAT:
+				root.set(name, original + 1.0)
+			TYPE_AABB:
+				root.set(name, AABB(Vector3(1, 1, 1), Vector3(8, 8, 8)))
+			_:
+				continue
+		assert_ne(_signature(), before, "%s is in the signature" % name)
+		root.set(name, original)
+		assert_eq(_signature(), before, "%s put back" % name)
+
+
+func test_the_material_override_is_in_the_signature():
+	var before := _signature()
+	root.bake_material_override = StandardMaterial3D.new()
+	assert_ne(_signature(), before, "the override decides how the bake looks")
+	root.bake_material_override = null
+	assert_eq(_signature(), before)
+
+
+func test_a_level_that_has_never_baked_still_reports_nothing_to_do():
+	root._dirty_brush_ids = {}
+	root._full_reconcile_needed = false
+	var ok: bool = await root.bake_dirty()
+	assert_false(ok, "no bake has happened, so there is no result to go stale")
+	assert_eq(root.bake_system.get_last_bake_status(), 4, "still NOTHING_TO_DO")
+
+
+func test_a_rebake_after_a_setting_changes_rebuilds_rather_than_doing_nothing():
+	_box("a", Vector3.ZERO)
+	_box("b", Vector3(256, 0, 0))
+	assert_true(await root.bake(), "the first bake")
+	root._dirty_brush_ids = {}
+	root._full_reconcile_needed = false
+
+	# Nothing changed: the rebake still declines, as it always did.
+	assert_false(await root.bake_dirty(), "no changes at all is still nothing to do")
+
+	# One setting flipped, no brush touched.
+	root.bake_visible_only = not root.bake_visible_only
+	assert_true(
+		await root.bake_dirty(),
+		"a changed setting is a change, so the result is built from the settings that are set"
+	)
+
+
+func test_a_rebake_after_the_cordon_changes_rebuilds():
+	_box("a", Vector3.ZERO)
+	assert_true(await root.bake())
+	root._dirty_brush_ids = {}
+	root._full_reconcile_needed = false
+	root.cordon_enabled = true
+	assert_true(await root.bake_dirty(), "the cordon decides which brushes are in the bake")


### PR DESCRIPTION
`HFBakeSystem.bake_settings_signature()` hashes the 28 settings that decide what goes into the bake or how it is built, plus the material override by resource path. `bake()` records it on success; `bake_dirty()` compares and rebuilds in full when it differs.

Took the hash rather than a `_bake_settings_dirty` flag per setter, for the reason the issue gives: most of these properties had no setter, and the hash covers the `.hflevel` load path without any extra wiring.

Two details worth flagging:

The check is gated on a bake having actually happened. Without that, a freshly loaded level's first `bake_dirty()` did a full bake instead of saying "no changed brushes", which an existing test caught and was right to — nothing has been baked, so there is no result to go stale.

The settings are read by name through `root.get()`. The bake tests use root shims that carry only the properties each test needs, and a missing one should read as unset rather than error.

The cordon is in the signature, because it decides which brushes are in the bake at all.

Tests in `tests/test_bake_settings_invalidate_the_bake.gd`, including one that walks every name in the list, changes it, and asserts the signature moved and moves back. Full suite passes.

Fixes #376