### PR TITLE
Refuse a vertex move that bends a face out of plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   that would strip the palette of materials in use.
 
 ### Fixed
+- **A vertex move that bowed a face out of plane passed the convexity check**
+  (#364). `validate_convexity()` tested one thing: that no vertex sits in front
+  of any face plane. It never tested whether a face is still a plane. Every face
+  of a box is a quad, and moving one of its four corners bends it while the
+  other three stay behind the plane through the first three, so the check passed
+  and the move committed. Pulling one corner of a 64 unit box 256 units left the
+  worst face sitting 62 units off its own plane. Everything downstream reads a
+  face as a plane: the `.map` export writes it as three points, clip and carve
+  intersect it, and the bake triangulates it while collision and lighting use
+  the plane, so the exported solid stopped being the one on screen. Each face is
+  now measured against the plane through its own first corner, with a tolerance
+  that scales with the face, and a move that bends one is refused and reverted
+  the same way a non-convex one is. The refusal now says which of the two it
+  was. A move that keeps every face flat, such as sliding a whole side along its
+  own normal, still commits.
 - **Changing a bake setting did not invalidate the bake** (#376). `bake_dirty()`
   rebuilt only what brush dirty state said needed rebuilding, and the settings
   were not part of what could be dirty — so the realistic sequence did the wrong

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,587 tests across 189 test scripts (3,580 passing plus seven intentional no-assert safety tests; 18,121 assertions; verified in CI on September 11, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,590 tests across 189 test scripts (3,583 passing plus seven intentional no-assert safety tests; 18,137 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 11, 2026): **3,587 tests** across **189 scripts** (**3,580 passing** plus seven intentional no-assert safety tests; **18,121 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,590 tests** across **189 scripts** (**3,583 passing** plus seven intentional no-assert safety tests; **18,137 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3580%20passing-brightgreen" alt="3580 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3583%20passing-brightgreen" alt="3583 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,587 tests across 189 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,590 tests across 189 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/systems/hf_vertex_system.gd
+++ b/addons/hammerforge/systems/hf_vertex_system.gd
@@ -115,9 +115,10 @@ func move_vertices(delta: Vector3) -> bool:
 		var brush = _find_brush(brush_id)
 		if not brush:
 			continue
-		if not validate_convexity(brush):
+		var reason: String = check_solid(brush)
+		if not reason.is_empty():
 			_restore_face_snapshots()
-			_say("Move rejected: would create non-convex brush")
+			_say("Move rejected: %s" % reason)
 			return false
 	# Rebuild previews
 	for brush_id in selected_vertices:
@@ -148,18 +149,52 @@ static func _corner_plane_normal(verts: PackedVector3Array) -> Vector3:
 	return Vector3.ZERO
 
 
-## Validate that all faces of a brush form a convex shape.
+## The largest distance any of a polygon's own vertices sits off the plane
+## through its first corner, and the polygon's own extent to measure that
+## against. A face is a plane by definition — the bake triangulates it, the
+## `.map` export writes it as three points, and every clip and carve intersects
+## it — so a polygon that no longer has one plane means a different solid to
+## each of them.
+##
+## Moving one corner of a quad bows it. The other three corners stay behind the
+## plane through the first three, which is why the convexity test alone cannot
+## see this.
+static func _face_planarity(verts: PackedVector3Array) -> Array:
+	var normal: Vector3 = _corner_plane_normal(verts)
+	if normal.length() < 0.001:
+		return [0.0, 0.0]
+	var origin: Vector3 = verts[0]
+	var worst := 0.0
+	var extent := 0.0
+	for v in verts:
+		var offset: Vector3 = v - origin
+		worst = maxf(worst, absf(normal.dot(offset)))
+		extent = maxf(extent, offset.length())
+	return [worst, extent]
+
+
+## Validate that all faces of a brush form a convex shape, and that each face is
+## still a plane.
 ## Checks that no vertex lies in front of any face plane.
 func validate_convexity(brush: Node3D) -> bool:
+	return check_solid(brush).is_empty()
+
+
+## The same walk, but it says what is wrong. Returns "" for a brush that is
+## still a convex solid with planar faces, otherwise the sentence to put in
+## front of the mapper. The two failures need different words: a non-convex
+## brush is one the user can see is inside out, a bent face looks correct in the
+## viewport and only goes wrong on export.
+func check_solid(brush: Node3D) -> String:
 	if not brush or not brush.get("faces"):
-		return true
+		return ""
 	var faces: Array = brush.faces
 	if faces.size() < 4:
-		return true  # Degenerate, allow
+		return ""  # Degenerate, allow
 	# Collect all unique vertices
 	var all_verts := get_brush_vertices(brush)
 	if all_verts.is_empty():
-		return true
+		return ""
 	# For each face, check that all vertices are behind or on the plane
 	for face in faces:
 		if face == null or face.local_verts.size() < 3:
@@ -171,8 +206,16 @@ func validate_convexity(brush: Node3D) -> bool:
 		for v in all_verts:
 			var d = plane_normal.dot(v - plane_point)
 			if d > 0.02:  # Small tolerance for floating-point imprecision
-				return false
-	return true
+				return "would create a non-convex brush"
+		# The face against its own plane. The tolerance scales with the face so
+		# that a large brush, whose vertex positions carry more float error than
+		# a small one, is not called bent for it.
+		var planarity: Array = _face_planarity(face.local_verts)
+		var bow: float = planarity[0]
+		var extent: float = planarity[1]
+		if bow > maxf(0.02, extent * 0.0005):
+			return "would bend a face %.2f units out of plane" % bow
+	return ""
 
 
 ## Clip a non-convex brush to its convex hull. Recomputes faces from the convex
@@ -454,10 +497,14 @@ func update_drag_absolute(world_delta: Vector3) -> bool:
 
 	var touched := _write_drag_geometry(world_delta)
 	var convex := touched
+	var reason := ""
 	if convex:
 		for brush_id in _drag_face_vertices:
 			var brush = _find_brush(brush_id)
-			if brush and not validate_convexity(brush):
+			if brush == null:
+				continue
+			reason = check_solid(brush)
+			if not reason.is_empty():
 				convex = false
 				break
 
@@ -467,7 +514,7 @@ func update_drag_absolute(world_delta: Vector3) -> bool:
 		_drag_last_world_delta = Vector3.ZERO
 		_drag_has_valid_update = true
 		if touched and root and root.has_signal("user_message"):
-			root.emit_signal("user_message", "Move rejected: would create non-convex brush", 1)
+			root.emit_signal("user_message", "Move rejected: %s" % reason, 1)
 		return false
 
 	_rebuild_drag_previews()
@@ -883,9 +930,10 @@ func merge_vertices(brush_id: String, vert_indices: PackedInt32Array) -> bool:
 		_say("Merge rejected: would leave the brush without a closed solid")
 		return false
 	# Validate
-	if not validate_convexity(brush):
+	var merge_reason: String = check_solid(brush)
+	if not merge_reason.is_empty():
 		_restore_face_snapshots()
-		_say("Merge rejected: would create non-convex brush")
+		_say("Merge rejected: %s" % merge_reason)
 		return false
 	_commit_geometry(brush)
 	return true

--- a/docs/HammerForge_Editor_Smoke_Checklist.md
+++ b/docs/HammerForge_Editor_Smoke_Checklist.md
@@ -379,11 +379,12 @@ It writes one PNG per tab under `user://console_preview/`.
 - Select a brush and enter vertex mode (V key or the V toggle button in the toolbar).
 - Confirm vertex crosses and edge wireframe lines appear on the brush.
 - Click a vertex to select it (orange cross). Shift+click to multi-select.
-- In a perspective view, drag a vertex horizontally and vertically. Confirm it follows the cursor on a view-facing plane through the picked vertex instead of being forced onto world Y.
+- Select all four vertices of one side of a box and drag along that side's normal. Confirm the face follows the cursor on a view-facing plane through the picked vertex instead of being forced onto world Y, and that the move commits.
+- Drag a single corner of a box. Confirm it is refused and reverts, with a message saying the move would bend a face out of plane. A brush face is a plane, and moving one corner of a quad bends it, so the only moves that commit are the ones that keep every face flat.
 - Repeat in front and side orthographic views, then drag a selected edge. Confirm each gesture uses the picked vertex or edge midpoint as its stable anchor with no first-motion jump.
 - During separate drags, press X, Y, and Z to lock movement. Confirm only the chosen world axis changes and grid snapping remains consistent.
 - Aim the camera directly along the locked axis and drag. Confirm the degenerate projection is ignored—geometry must not jump, accumulate a stale prior delta, or become non-convex.
-- Drag to move vertices; confirm convexity enforcement (invalid moves revert).
+- Drag to move vertices; confirm the solid checks are enforced and invalid moves revert, both the non-convex ones and the ones that bend a face.
 - Press E to toggle to edge sub-mode; confirm edges become clickable.
 - Click an edge; confirm it highlights orange and both endpoints are selected.
 - Select a single edge and press Ctrl+E; confirm the edge is split (9 vertices on box).

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 11, 2026 contains **3,587 tests across 189 scripts**: **3,580 passing tests**, seven intentional no-assert safety tests, and **18,121 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,590 tests across 189 scripts**: **3,583 passing tests**, seven intentional no-assert safety tests, and **18,137 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_bugfix_regressions.gd
+++ b/tests/test_bugfix_regressions.gd
@@ -127,6 +127,25 @@ func _make_box_brush(pos: Vector3, sz: Vector3, id: String) -> DraftBrush:
 	return b
 
 
+## The vertex indices on the face the box presents toward `local_dir`, selected
+## together. A single corner move bows the quads that meet at it, which the
+## validator refuses, so a fixture that needs a committed move slides a whole
+## face along its own normal.
+func _select_face_toward(vs, brush: DraftBrush, id: String, local_dir: Vector3) -> PackedInt32Array:
+	var dir := local_dir.normalized()
+	var verts: PackedVector3Array = vs.get_brush_vertices(brush)
+	var furthest := -INF
+	for v in verts:
+		furthest = maxf(furthest, dir.dot(v))
+	var indices := PackedInt32Array()
+	for i in verts.size():
+		if absf(dir.dot(verts[i]) - furthest) < 0.001:
+			indices.append(i)
+	for i in indices:
+		vs.select_vertex(id, i, i != indices[0])
+	return indices
+
+
 # ===========================================================================
 # Bug 1: Vertex undo captures pre-drag state, not post-move state
 # ===========================================================================
@@ -136,7 +155,7 @@ func test_end_drag_returns_pre_drag_face_data():
 	var vs = HFVertexSystem.new(root)
 	var b = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "undo1")
 	vs.set_selection([b])
-	vs.select_vertex("undo1", 0, false)
+	_select_face_toward(vs, b, "undo1", Vector3.RIGHT)
 
 	# Capture expected pre-drag state
 	var pre_drag_expected: Array = []
@@ -171,7 +190,7 @@ func test_pre_drag_snapshots_differ_from_post_move_faces():
 	var vs = HFVertexSystem.new(root)
 	var b = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "undo2")
 	vs.set_selection([b])
-	vs.select_vertex("undo2", 0, false)
+	_select_face_toward(vs, b, "undo2", Vector3.RIGHT)
 
 	vs.begin_drag(Vector3.ZERO)
 	vs.move_vertices(Vector3(8, 0, 0))

--- a/tests/test_vertex_edits_that_broke_the_brush.gd
+++ b/tests/test_vertex_edits_that_broke_the_brush.gd
@@ -108,6 +108,24 @@ func _make_box_brush(pos: Vector3, sz: Vector3, id: String) -> DraftBrush:
 	return b
 
 
+## The vertex indices on the face the box presents toward `local_dir`, selected
+## together. Moving one corner of a quad bows it, so the only plane-preserving
+## move on a box is a whole face along its own normal.
+func _select_face_toward(brush: DraftBrush, id: String, local_dir: Vector3) -> PackedInt32Array:
+	var dir := local_dir.normalized()
+	var verts := vs.get_brush_vertices(brush)
+	var furthest := -INF
+	for v in verts:
+		furthest = maxf(furthest, dir.dot(v))
+	var indices := PackedInt32Array()
+	for i in verts.size():
+		if absf(dir.dot(verts[i]) - furthest) < 0.001:
+			indices.append(i)
+	for i in indices:
+		vs.select_vertex(id, i, i != indices[0])
+	return indices
+
+
 func _side_face(brush: DraftBrush, axis_normal: Vector3) -> FaceData:
 	for face in brush.faces:
 		if face.normal.dot(axis_normal) > 0.9:
@@ -133,16 +151,78 @@ func test_a_non_finite_vertex_move_is_refused():
 
 
 func test_an_ordinary_vertex_move_still_lands():
+	# A whole face slid along its own normal. Every face of the brush stays a
+	# plane, so this is the move the validator has to keep letting through.
 	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "ok")
 	vs.set_selection([brush])
-	var before := vs.get_brush_vertices(brush)[0]
-	vs.select_vertex("ok", 0, false)
+	var moved := _select_face_toward(brush, "ok", Vector3.RIGHT)
+	var before: Vector3 = vs.get_brush_vertices(brush)[moved[0]]
 	assert_true(vs.move_vertices(Vector3(4, 0, 0)))
 	var found := false
 	for vertex in vs.get_brush_vertices(brush):
 		if vertex.is_equal_approx(before + Vector3(4, 0, 0)):
 			found = true
 	assert_true(found, "the vertex moved")
+
+
+# ===========================================================================
+# A move that bows a face out of plane is refused (#364)
+# ===========================================================================
+
+
+## The largest distance any of a face's own vertices sits off the plane through
+## its first corner.
+func _worst_bow(brush: DraftBrush) -> float:
+	var worst := 0.0
+	for face in brush.faces:
+		var verts: PackedVector3Array = face.local_verts
+		if verts.size() < 4:
+			continue
+		var normal: Vector3 = face.normal
+		for v in verts:
+			worst = maxf(worst, absf(normal.dot(v - verts[0])))
+	return worst
+
+
+func test_a_move_that_bows_a_face_is_refused():
+	# One corner of a quad, moved off its own plane. The other three corners
+	# stay behind the plane through the first three, so the convexity test alone
+	# saw nothing wrong and the move committed. Three faces meet at a box corner
+	# and all three come out bent.
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "bow")
+	vs.set_selection([brush])
+	var before := vs.get_brush_vertices(brush).duplicate()
+	vs.select_vertex("bow", 0, false)
+
+	assert_false(vs.move_vertices(Vector3(0, -256, 0)), "a bent face is not a brush face")
+	var after := vs.get_brush_vertices(brush)
+	assert_eq(after.size(), before.size(), "the refusal put every vertex back")
+	for i in before.size():
+		assert_true(after[i].is_equal_approx(before[i]), "vertex %d is where it started" % i)
+	assert_almost_eq(_worst_bow(brush), 0.0, 0.001, "every face is still a plane")
+
+
+func test_a_small_bow_is_refused_too():
+	# The same defect at a size that looks harmless in the viewport. A four unit
+	# bow on a 64 unit brush still exports as a plane that does not contain its
+	# own corners.
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "small")
+	vs.set_selection([brush])
+	vs.select_vertex("small", 0, false)
+	assert_false(vs.move_vertices(Vector3(4, 0, 0)), "four units off plane is still off plane")
+	assert_almost_eq(_worst_bow(brush), 0.0, 0.001, "every face is still a plane")
+
+
+func test_the_validator_sees_a_bent_face_on_its_own():
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "bent")
+	assert_true(vs.validate_convexity(brush), "the fixture starts as a solid")
+	var face := _side_face(brush, Vector3.RIGHT)
+	var verts := face.local_verts
+	verts[0] = verts[0] + Vector3(8, 0, 0)
+	face.local_verts = verts
+	face.ensure_geometry()
+	assert_false(vs.validate_convexity(brush), "a face with four corners and no plane")
+	assert_string_contains(vs.check_solid(brush), "out of plane")
 
 
 func test_a_non_finite_drag_update_is_refused():

--- a/tests/test_vertex_system.gd
+++ b/tests/test_vertex_system.gd
@@ -45,6 +45,28 @@ func tag_brush_dirty(brush_id: String) -> void:
 	return s
 
 
+## The vertex indices on the face a box presents toward `local_dir`, selected
+## and ready to move along that direction.
+##
+## Moving one corner of a quad bows it out of plane, and the validator refuses
+## that now, so a fixture that just needs a real geometry change has to move a
+## whole face. The face slides along its own normal and the four side faces
+## follow it inside their own planes, so the brush stays a solid.
+func _select_face_toward(brush: DraftBrush, id: String, local_dir: Vector3) -> PackedInt32Array:
+	var dir := local_dir.normalized()
+	var verts := vs.get_brush_vertices(brush)
+	var furthest := -INF
+	for v in verts:
+		furthest = maxf(furthest, dir.dot(v))
+	var indices := PackedInt32Array()
+	for i in verts.size():
+		if absf(dir.dot(verts[i]) - furthest) < 0.001:
+			indices.append(i)
+	for i in indices:
+		vs.select_vertex(id, i, i != indices[0])
+	return indices
+
+
 func _make_box_brush(pos: Vector3, sz: Vector3, id: String) -> DraftBrush:
 	var b = DraftBrush.new()
 	b.size = sz
@@ -270,9 +292,8 @@ func test_clip_to_convex_no_op_and_failure_do_not_tag_dirty():
 func test_move_vertices_updates_face_data():
 	var b = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "mv1")
 	vs.set_selection([b])
-	var verts_before = vs.get_brush_vertices(b)
-	var target_vert = verts_before[0]
-	vs.select_vertex("mv1", 0, false)
+	var moved := _select_face_toward(b, "mv1", Vector3.RIGHT)
+	var target_vert: Vector3 = vs.get_brush_vertices(b)[moved[0]]
 	var delta = Vector3(4, 0, 0)
 	var result = vs.move_vertices(delta)
 	assert_true(result, "Move should succeed for valid convex result")
@@ -300,7 +321,7 @@ func test_move_vertices_promotes_brush_to_custom_shape():
 	var b = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "promote1")
 	assert_eq(b.shape, DraftBrush.BrushShape.BOX, "Fixture starts as a box")
 	vs.set_selection([b])
-	vs.select_vertex("promote1", 0, false)
+	_select_face_toward(b, "promote1", Vector3.RIGHT)
 	assert_true(vs.move_vertices(Vector3(4, 0, 0)))
 	assert_eq(
 		b.shape,
@@ -312,8 +333,8 @@ func test_move_vertices_promotes_brush_to_custom_shape():
 func test_moved_vertices_survive_resize():
 	var b = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "survive1")
 	vs.set_selection([b])
-	var original_vertex: Vector3 = vs.get_brush_vertices(b)[0]
-	vs.select_vertex("survive1", 0, false)
+	var moved := _select_face_toward(b, "survive1", Vector3.RIGHT)
+	var original_vertex: Vector3 = vs.get_brush_vertices(b)[moved[0]]
 	assert_true(vs.move_vertices(Vector3(4, 0, 0)))
 	var moved_vertex := original_vertex + Vector3(4, 0, 0)
 
@@ -339,8 +360,8 @@ func test_clip_to_convex_promotes_brush_to_custom_shape():
 func test_committed_vertex_drag_promotes_brush_to_custom_shape():
 	var b = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "dragged")
 	vs.set_selection([b])
-	var original_vertex: Vector3 = vs.get_brush_vertices(b)[0]
-	vs.select_vertex("dragged", 0, false)
+	var dragged := _select_face_toward(b, "dragged", Vector3.RIGHT)
+	var original_vertex: Vector3 = vs.get_brush_vertices(b)[dragged[0]]
 	vs.begin_drag(b.to_global(original_vertex))
 	assert_true(vs.update_drag_absolute(Vector3(2, 0, 0)))
 	assert_false(vs.end_drag().is_empty(), "A real geometry change should retain undo data")
@@ -350,8 +371,8 @@ func test_committed_vertex_drag_promotes_brush_to_custom_shape():
 func test_canceled_vertex_drag_leaves_brush_as_box():
 	var b = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "canceled")
 	vs.set_selection([b])
-	var original_vertex: Vector3 = vs.get_brush_vertices(b)[0]
-	vs.select_vertex("canceled", 0, false)
+	var canceled := _select_face_toward(b, "canceled", Vector3.RIGHT)
+	var original_vertex: Vector3 = vs.get_brush_vertices(b)[canceled[0]]
 	vs.begin_drag(b.to_global(original_vertex))
 	assert_true(vs.update_drag_absolute(Vector3(2, 0, 0)))
 	vs.cancel_drag()
@@ -378,8 +399,8 @@ func test_begin_end_drag():
 func test_absolute_drag_updates_do_not_accumulate():
 	var b = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "abs1")
 	vs.set_selection([b])
-	var original_vertex: Vector3 = vs.get_brush_vertices(b)[0]
-	vs.select_vertex("abs1", 0, false)
+	var abs_moved := _select_face_toward(b, "abs1", Vector3.RIGHT)
+	var original_vertex: Vector3 = vs.get_brush_vertices(b)[abs_moved[0]]
 	vs.begin_drag(b.to_global(original_vertex))
 
 	assert_true(vs.update_drag_absolute(Vector3(2, 0, 0)))
@@ -396,8 +417,8 @@ func test_zero_absolute_drag_restores_origin_and_suppresses_undo():
 	var b = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "zero1")
 	vs.set_selection([b])
 	var vertices_before := vs.get_brush_vertices(b).duplicate()
-	vs.select_vertex("zero1", 0, false)
-	vs.begin_drag(b.to_global(vertices_before[0]))
+	var zero_moved := _select_face_toward(b, "zero1", Vector3.RIGHT)
+	vs.begin_drag(b.to_global(vertices_before[zero_moved[0]]))
 
 	assert_true(vs.update_drag_absolute(Vector3(4, 0, 0)))
 	assert_true(vs.update_drag_absolute(Vector3.ZERO))
@@ -415,8 +436,8 @@ func test_zero_absolute_drag_restores_origin_and_suppresses_undo():
 func test_changed_absolute_drag_returns_undo_snapshots():
 	var b = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "undo1")
 	vs.set_selection([b])
-	var original_vertex: Vector3 = vs.get_brush_vertices(b)[0]
-	vs.select_vertex("undo1", 0, false)
+	var undo_moved := _select_face_toward(b, "undo1", Vector3.RIGHT)
+	var original_vertex: Vector3 = vs.get_brush_vertices(b)[undo_moved[0]]
 	vs.begin_drag(b.to_global(original_vertex))
 	assert_true(vs.update_drag_absolute(Vector3(2, 0, 0)))
 	assert_false(vs.end_drag().is_empty(), "A real geometry change should retain undo data")
@@ -445,9 +466,11 @@ func test_absolute_drag_world_delta_handles_rotated_brushes():
 	b.rotation = Vector3(0, deg_to_rad(90.0), 0)
 	b.force_update_transform()
 	vs.set_selection([b])
-	var original_vertex: Vector3 = vs.get_brush_vertices(b)[0]
+	var rotated := _select_face_toward(
+		b, "rot1", b.global_transform.basis.inverse() * Vector3.RIGHT
+	)
+	var original_vertex: Vector3 = vs.get_brush_vertices(b)[rotated[0]]
 	var original_world := b.to_global(original_vertex)
-	vs.select_vertex("rot1", 0, false)
 	vs.begin_drag(original_world)
 
 	assert_true(vs.update_drag_absolute(Vector3(2, 0, 0)))
@@ -462,12 +485,12 @@ func test_absolute_drag_world_delta_handles_rotated_brushes():
 func test_cancel_drag():
 	var b = _make_box_brush(Vector3.ZERO, Vector3(32, 32, 32), "cd1")
 	vs.set_selection([b])
-	vs.select_vertex("cd1", 0, false)
+	var cancel_moved := _select_face_toward(b, "cd1", Vector3.RIGHT)
 	var verts_before = vs.get_brush_vertices(b).duplicate()
 	vs.begin_drag(Vector3.ZERO)
 	assert_true(vs.update_drag_absolute(Vector3(4, 0, 0)))
 	assert_false(
-		vs.get_selected_world_positions()[0].is_equal_approx(verts_before[0]),
+		vs.get_selected_world_positions()[0].is_equal_approx(verts_before[cancel_moved[0]]),
 		"The fixture must contain a real change before cancellation"
 	)
 	vs.cancel_drag()

--- a/tools/vibe/scenarios/vertex.gd
+++ b/tools/vibe/scenarios/vertex.gd
@@ -79,8 +79,9 @@ func _any_non_finite(brush: Node3D) -> bool:
 
 
 ## Dragging one corner of a box far enough past the opposite face makes the
-## solid non-convex. `validate_convexity()` is meant to catch exactly that and
-## put the brush back the way it was.
+## solid non-convex, and bends the three faces that meet at that corner on the
+## way. `validate_convexity()` is meant to catch both and put the brush back the
+## way it was.
 func _a_move_that_breaks_convexity_is_refused() -> void:
 	var root: Node3D = await fresh_root()
 	var b := box(root, Vector3(64, 64, 64))
@@ -97,13 +98,17 @@ func _a_move_that_breaks_convexity_is_refused() -> void:
 	var bow := _worst_non_planarity(b)
 	note("worst face non-planarity after the move", "%.2f units" % bow)
 	if ok:
-		known(
-			364,
+		flag(
 			"a vertex move that warps a brush's faces out of plane is accepted",
 			(
 				"one corner of a 64 box pulled 256 units: volume %.0f -> %.0f, worst face sits %.1f units off its own plane, validate_convexity() said yes"
 				% [before, after, bow]
 			)
+		)
+	elif bow > 0.02:
+		flag(
+			"a refused vertex move left a face bent",
+			"worst face sits %.2f units off its own plane" % bow
 		)
 	elif absf(after - before) > 0.5:
 		flag(


### PR DESCRIPTION
Fixes #364.

`validate_convexity()` checked that no vertex sits in front of any face plane. It never checked that a face is still a plane. Every face of a box is a quad, and moving one corner bends it while the other three stay behind the plane through the first three, so the check passed. One corner of a 64 unit box pulled 256 units left the worst face 62 units off its own plane.

- each face is now measured against the plane through its own first corner, with a tolerance that scales with the face
- `check_solid()` does the walk and returns the reason, so the refusal says whether the brush went non-convex or a face went bent
- the same restore-and-refuse path as before, on `move_vertices()`, `update_drag_absolute()` and `merge_vertices()`

A move that keeps every face flat still commits. Sliding a whole side of a box along its own normal is one. Moving a single corner of a box is not, and now reverts with a message. The test fixtures that needed a committed move were moving one corner; they move a face now.

Changelog and the vertex editing section of the smoke checklist updated.