### PR TITLE
Split a bent face into triangles instead of refusing the move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,24 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   functions with plausible names and wiring them up to a "Remove unused" button
   that would strip the palette of materials in use.
 
+### Changed
+- **A vertex move that bends a face now splits it instead of being refused.**
+  A brush face is a plane and every face of a box is a quad, so moving one of
+  its four corners bends it. #364 made that a refusal, which is correct but
+  means no single corner of a box can be dragged at all. On commit each bent
+  face is now cut into triangles along the same fan the bake already uses, so
+  the committed surface is the one that was on screen during the drag, and each
+  triangle keeps its quad's material and projection. Hand-placed UVs on a split
+  face go back to the face projection, because four of them do not describe
+  three vertices. A move that dents the brush is still refused: no
+  triangulation of a bent face makes a concave solid convex, and with the quad
+  in two pieces the dent is finally something the convexity check can see. The
+  refusal now lands on release rather than mid-drag. A bent face carrying a
+  displacement is also still refused, because the displacement is defined over
+  four corners and a split would throw it away. The face count goes up under
+  the mapper, which is the part of this that had to be decided rather than
+  fall out of a missing check.
+
 ### Fixed
 - **A vertex move that bowed a face out of plane passed the convexity check**
   (#364). `validate_convexity()` tested one thing: that no vertex sits in front

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,590 tests across 189 test scripts (3,583 passing plus seven intentional no-assert safety tests; 18,137 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,596 tests across 189 test scripts (3,589 passing plus seven intentional no-assert safety tests; 18,177 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,590 tests** across **189 scripts** (**3,583 passing** plus seven intentional no-assert safety tests; **18,137 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,596 tests** across **189 scripts** (**3,589 passing** plus seven intentional no-assert safety tests; **18,177 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3583%20passing-brightgreen" alt="3583 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3589%20passing-brightgreen" alt="3589 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,590 tests across 189 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,596 tests across 189 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/systems/hf_vertex_system.gd
+++ b/addons/hammerforge/systems/hf_vertex_system.gd
@@ -115,6 +115,10 @@ func move_vertices(delta: Vector3) -> bool:
 		var brush = _find_brush(brush_id)
 		if not brush:
 			continue
+		# A bent face is cut into triangles rather than refused. What is left
+		# after that is a real refusal: a dent, or a displacement that cannot be
+		# split.
+		planarize_faces(brush)
 		var reason: String = check_solid(brush)
 		if not reason.is_empty():
 			_restore_face_snapshots()
@@ -173,6 +177,65 @@ static func _face_planarity(verts: PackedVector3Array) -> Array:
 	return [worst, extent]
 
 
+## How far a face is off its own plane, or 0.0 when it is within tolerance.
+static func _face_bow(face) -> float:
+	if face == null or face.local_verts.size() < 4:
+		return 0.0
+	var planarity: Array = _face_planarity(face.local_verts)
+	var bow: float = planarity[0]
+	var extent: float = planarity[1]
+	if bow > maxf(0.02, extent * 0.0005):
+		return bow
+	return 0.0
+
+
+## Cut every bent face into triangles, which are planar whatever their corners
+## do. Returns the number of faces the brush gained.
+##
+## This is what a vertex editor does instead of refusing the move: a brush face
+## is a plane, and moving one corner of a quad bends it, so the face has to stop
+## being one polygon. The fan is the same one `FaceData.triangulate()` already
+## uses for the bake, so the committed surface is the one that was on screen
+## during the drag.
+##
+## It runs on commit only. Mid-drag the face array has to keep the shape
+## `_capture_drag_geometry()` recorded, because `_write_drag_geometry()` pairs
+## faces with their starting vertices by position in the array.
+##
+## Splitting can leave the brush non-convex — a corner pushed *into* the solid
+## makes a dent whichever diagonal the fan picks — so the caller still runs
+## `check_solid()` afterwards and still has the snapshot to put back.
+func planarize_faces(brush: Node3D) -> int:
+	if not brush or not brush.get("faces"):
+		return 0
+	var rebuilt: Array = []
+	var added := 0
+	for face in brush.faces:
+		if face == null:
+			continue
+		if face.displacement != null or _face_bow(face) <= 0.0:
+			rebuilt.append(face)
+			continue
+		var verts: PackedVector3Array = face.local_verts
+		var template: Dictionary = face.to_dict()
+		for i in range(1, verts.size() - 1):
+			var tri: FaceData = FaceData.from_dict(template)
+			tri.local_verts = PackedVector3Array([verts[0], verts[i], verts[i + 1]])
+			# Four hand-placed UVs do not describe three vertices. Dropping them
+			# puts the triangle back on the face's own projection, which is what
+			# `triangulate()` does with a mismatched array anyway.
+			tri.custom_uvs = PackedVector2Array()
+			tri.ensure_geometry()
+			rebuilt.append(tri)
+		added += verts.size() - 3
+	if added == 0:
+		return 0
+	brush.faces.clear()
+	for f in rebuilt:
+		brush.faces.append(f)
+	return added
+
+
 ## Validate that all faces of a brush form a convex shape, and that each face is
 ## still a plane.
 ## Checks that no vertex lies in front of any face plane.
@@ -185,7 +248,13 @@ func validate_convexity(brush: Node3D) -> bool:
 ## front of the mapper. The two failures need different words: a non-convex
 ## brush is one the user can see is inside out, a bent face looks correct in the
 ## viewport and only goes wrong on export.
-func check_solid(brush: Node3D) -> String:
+##
+## `splitting_allowed` is for the middle of a drag, where a bent face is not yet
+## a problem because `planarize_faces()` will cut it into triangles on commit.
+## A bent face that carries a displacement is still a problem then: the
+## displacement is defined over four corners and a split would throw it away, so
+## that one is refused while the move can still be taken back.
+func check_solid(brush: Node3D, splitting_allowed: bool = false) -> String:
 	if not brush or not brush.get("faces"):
 		return ""
 	var faces: Array = brush.faces
@@ -210,11 +279,11 @@ func check_solid(brush: Node3D) -> String:
 		# The face against its own plane. The tolerance scales with the face so
 		# that a large brush, whose vertex positions carry more float error than
 		# a small one, is not called bent for it.
-		var planarity: Array = _face_planarity(face.local_verts)
-		var bow: float = planarity[0]
-		var extent: float = planarity[1]
-		if bow > maxf(0.02, extent * 0.0005):
-			return "would bend a face %.2f units out of plane" % bow
+		if _face_bow(face) > 0.0:
+			if face.displacement != null:
+				return "would bend a displacement face out of plane"
+			if not splitting_allowed:
+				return "would bend a face %.2f units out of plane" % _face_bow(face)
 	return ""
 
 
@@ -503,7 +572,7 @@ func update_drag_absolute(world_delta: Vector3) -> bool:
 			var brush = _find_brush(brush_id)
 			if brush == null:
 				continue
-			reason = check_solid(brush)
+			reason = check_solid(brush, true)
 			if not reason.is_empty():
 				convex = false
 				break
@@ -594,12 +663,35 @@ func end_drag() -> Dictionary:
 	_drag_active = false
 	var snapshots := _pre_drag_faces.duplicate(true) if changed else {}
 	if changed:
+		# The face array can grow here, which is why it happens on commit and
+		# not during the drag: a bent face is cut into triangles, and
+		# `_write_drag_geometry()` pairs faces with their starting vertices by
+		# position in the array.
+		var refusal := ""
+		for brush_id in _drag_face_vertices:
+			var brush = _find_brush(brush_id)
+			if brush == null:
+				continue
+			planarize_faces(brush)
+			refusal = check_solid(brush)
+			if not refusal.is_empty():
+				break
+		if not refusal.is_empty():
+			# A dent only becomes visible once the bent face is two triangles,
+			# so this is the first point at which the move can be judged.
+			_restore_face_snapshots()
+			_rebuild_drag_previews()
+			_say("Move rejected: %s" % refusal)
+			_clear_drag_state()
+			return {}
 		# Only on commit. Promoting mid-drag would leave a canceled drag with a
 		# CUSTOM brush and no resize handles even though nothing moved.
 		for brush_id in _drag_face_vertices:
 			var brush = _find_brush(brush_id)
 			if brush and brush.has_method("mark_faces_authoritative"):
 				brush.mark_faces_authoritative()
+			if brush and brush.has_method("rebuild_preview"):
+				brush.rebuild_preview()
 	_clear_drag_state()
 	return snapshots
 
@@ -930,6 +1022,7 @@ func merge_vertices(brush_id: String, vert_indices: PackedInt32Array) -> bool:
 		_say("Merge rejected: would leave the brush without a closed solid")
 		return false
 	# Validate
+	planarize_faces(brush)
 	var merge_reason: String = check_solid(brush)
 	if not merge_reason.is_empty():
 		_restore_face_snapshots()

--- a/docs/HammerForge_Editor_Smoke_Checklist.md
+++ b/docs/HammerForge_Editor_Smoke_Checklist.md
@@ -380,11 +380,13 @@ It writes one PNG per tab under `user://console_preview/`.
 - Confirm vertex crosses and edge wireframe lines appear on the brush.
 - Click a vertex to select it (orange cross). Shift+click to multi-select.
 - Select all four vertices of one side of a box and drag along that side's normal. Confirm the face follows the cursor on a view-facing plane through the picked vertex instead of being forced onto world Y, and that the move commits.
-- Drag a single corner of a box. Confirm it is refused and reverts, with a message saying the move would bend a face out of plane. A brush face is a plane, and moving one corner of a quad bends it, so the only moves that commit are the ones that keep every face flat.
+- Drag a single corner of a box away from the solid. Confirm the move commits and the brush gains faces: a brush face is a plane, moving one corner of a quad bends it, so each bent quad is cut into two triangles on release. The face count goes up in the stats and the brush is no longer resizable as a box.
+- Drag a single corner into the solid. Confirm it follows the cursor during the drag and then reverts on release, with a message saying it would create a non-convex brush. A dent only becomes visible once the bent quad is two triangles, so the refusal lands on release rather than mid-drag.
+- Undo the accepted corner drag. Confirm the brush is six faces again.
 - Repeat in front and side orthographic views, then drag a selected edge. Confirm each gesture uses the picked vertex or edge midpoint as its stable anchor with no first-motion jump.
 - During separate drags, press X, Y, and Z to lock movement. Confirm only the chosen world axis changes and grid snapping remains consistent.
 - Aim the camera directly along the locked axis and drag. Confirm the degenerate projection is ignored—geometry must not jump, accumulate a stale prior delta, or become non-convex.
-- Drag to move vertices; confirm the solid checks are enforced and invalid moves revert, both the non-convex ones and the ones that bend a face.
+- Drag to move vertices; confirm a move that would leave the brush non-convex reverts, and a move that only bends a face is kept by splitting that face.
 - Press E to toggle to edge sub-mode; confirm edges become clickable.
 - Click an edge; confirm it highlights orange and both endpoints are selected.
 - Select a single edge and press Ctrl+E; confirm the edge is split (9 vertices on box).

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,590 tests across 189 scripts**: **3,583 passing tests**, seven intentional no-assert safety tests, and **18,137 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,596 tests across 189 scripts**: **3,589 passing tests**, seven intentional no-assert safety tests, and **18,177 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_vertex_edits_that_broke_the_brush.gd
+++ b/tests/test_vertex_edits_that_broke_the_brush.gd
@@ -184,33 +184,143 @@ func _worst_bow(brush: DraftBrush) -> float:
 	return worst
 
 
-func test_a_move_that_bows_a_face_is_refused():
-	# One corner of a quad, moved off its own plane. The other three corners
-	# stay behind the plane through the first three, so the convexity test alone
-	# saw nothing wrong and the move committed. Three faces meet at a box corner
-	# and all three come out bent.
+func test_the_move_that_filed_this_splits_the_faces_it_bends():
+	# One corner of a quad, pulled 256 units. The other three corners stay
+	# behind the plane through the first three, so the convexity test alone saw
+	# nothing wrong and the move committed with the face 62 units off its own
+	# plane.
+	#
+	# The corner goes away from the solid, so the result is a convex spike. The
+	# move is along one axis, so only the face perpendicular to it is bent; the
+	# other two keep the corner inside their own plane. That one quad is cut
+	# into triangles and the move stands.
 	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "bow")
 	vs.set_selection([brush])
-	var before := vs.get_brush_vertices(brush).duplicate()
+	var before := vs.get_brush_vertices(brush)[0]
 	vs.select_vertex("bow", 0, false)
 
-	assert_false(vs.move_vertices(Vector3(0, -256, 0)), "a bent face is not a brush face")
+	assert_true(vs.move_vertices(Vector3(0, -256, 0)), "a spike is still a convex solid")
+	assert_almost_eq(_worst_bow(brush), 0.0, 0.001, "every face is a plane again")
+	assert_eq(brush.faces.size(), 7, "the one bent quad became two triangles")
+	var found := false
+	for vertex in vs.get_brush_vertices(brush):
+		if vertex.is_equal_approx(before + Vector3(0, -256, 0)):
+			found = true
+	assert_true(found, "the corner is where it was dragged to")
+
+
+func test_a_corner_pulled_outward_splits_the_faces_it_bends():
+	# The same thing at a size that looks harmless in the viewport. Vertex 0 of
+	# the fixture is the (+x, -y, +z) corner, so this is the outward direction.
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "pull")
+	vs.set_selection([brush])
+	var before := vs.get_brush_vertices(brush)[0]
+	vs.select_vertex("pull", 0, false)
+
+	assert_true(vs.move_vertices(Vector3(8, -8, 8)), "an outward pull stays a solid")
+	assert_almost_eq(_worst_bow(brush), 0.0, 0.001, "every face is a plane again")
+	assert_eq(brush.faces.size(), 9, "the three bent quads became six triangles")
+	var found := false
+	for vertex in vs.get_brush_vertices(brush):
+		if vertex.is_equal_approx(before + Vector3(8, -8, 8)):
+			found = true
+	assert_true(found, "the corner is where it was dragged to")
+
+
+func test_a_split_face_keeps_the_material_of_the_face_it_came_from():
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "mat")
+	for face in brush.faces:
+		face.material_idx = 3
+	vs.set_selection([brush])
+	vs.select_vertex("mat", 0, false)
+	assert_true(vs.move_vertices(Vector3(8, -8, 8)))
+	assert_eq(brush.faces.size(), 9, "the fixture really did split")
+	for face in brush.faces:
+		assert_eq(face.material_idx, 3, "a triangle carries its quad's material")
+
+
+func test_a_corner_pushed_inward_is_still_refused():
+	# The other direction. A dent is only visible once the bent quad is two
+	# triangles, and then it is a non-convex brush, which is refused.
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "dent")
+	vs.set_selection([brush])
+	var before := vs.get_brush_vertices(brush).duplicate()
+	vs.select_vertex("dent", 0, false)
+
+	assert_false(vs.move_vertices(Vector3(-8, 8, -8)), "a dent is not a convex solid")
+	assert_eq(brush.faces.size(), 6, "the refusal put the quads back")
 	var after := vs.get_brush_vertices(brush)
-	assert_eq(after.size(), before.size(), "the refusal put every vertex back")
+	assert_eq(after.size(), before.size(), "and every vertex")
 	for i in before.size():
 		assert_true(after[i].is_equal_approx(before[i]), "vertex %d is where it started" % i)
-	assert_almost_eq(_worst_bow(brush), 0.0, 0.001, "every face is still a plane")
 
 
-func test_a_small_bow_is_refused_too():
-	# The same defect at a size that looks harmless in the viewport. A four unit
-	# bow on a 64 unit brush still exports as a plane that does not contain its
-	# own corners.
-	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "small")
+func test_a_bent_displacement_face_is_refused_rather_than_split():
+	# A displacement is defined over four corners. Splitting the quad would
+	# throw it away, so this is the one bent face that has to be a refusal.
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "disp")
+	var face := _side_face(brush, Vector3.RIGHT)
+	face.displacement = HFDisplacementData.new()
 	vs.set_selection([brush])
-	vs.select_vertex("small", 0, false)
-	assert_false(vs.move_vertices(Vector3(4, 0, 0)), "four units off plane is still off plane")
-	assert_almost_eq(_worst_bow(brush), 0.0, 0.001, "every face is still a plane")
+	var verts := vs.get_brush_vertices(brush)
+	var corner := -1
+	for i in verts.size():
+		if verts[i].is_equal_approx(face.local_verts[0]):
+			corner = i
+	assert_gt(corner, -1, "the fixture found the corner to move")
+
+	vs.select_vertex("disp", corner, false)
+	assert_false(vs.move_vertices(Vector3(8, 0, 0)), "a displacement cannot be split")
+	assert_eq(brush.faces.size(), 6, "and nothing was split")
+	assert_almost_eq(_worst_bow(brush), 0.0, 0.001, "the face is back on its plane")
+
+
+func test_a_bent_displacement_face_is_a_failure_even_where_a_split_is_allowed():
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "disp2")
+	var face := _side_face(brush, Vector3.RIGHT)
+	face.displacement = HFDisplacementData.new()
+	var verts := face.local_verts
+	verts[0] = verts[0] + Vector3(8, 0, 0)
+	face.local_verts = verts
+	face.ensure_geometry()
+
+	assert_string_contains(vs.check_solid(brush, true), "displacement")
+	assert_eq(vs.planarize_faces(brush), 0, "a displacement quad is never split")
+
+
+func test_a_drag_bends_while_it_runs_and_is_split_when_it_ends():
+	# The split happens on commit, not per update: `_write_drag_geometry()`
+	# pairs faces with their starting vertices by position in the array, so the
+	# array has to keep its shape until the drag is over.
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "dragsplit")
+	vs.set_selection([brush])
+	var corner: Vector3 = vs.get_brush_vertices(brush)[0]
+	vs.select_vertex("dragsplit", 0, false)
+	vs.begin_drag(brush.to_global(corner))
+
+	assert_true(vs.update_drag_absolute(Vector3(8, -8, 8)), "the drag runs")
+	assert_eq(brush.faces.size(), 6, "nothing is split mid-drag")
+	assert_gt(_worst_bow(brush), 1.0, "the preview really is bent")
+
+	assert_false(vs.end_drag().is_empty(), "a committed drag keeps its undo data")
+	assert_eq(brush.faces.size(), 9, "the commit split the three bent quads")
+	assert_almost_eq(_worst_bow(brush), 0.0, 0.001, "every face is a plane again")
+
+
+func test_a_drag_that_ends_in_a_dent_is_put_back():
+	var brush := _make_box_brush(Vector3.ZERO, Vector3(64, 64, 64), "dragdent")
+	vs.set_selection([brush])
+	var before := vs.get_brush_vertices(brush).duplicate()
+	vs.select_vertex("dragdent", 0, false)
+	vs.begin_drag(brush.to_global(before[0]))
+
+	vs.update_drag_absolute(Vector3(-8, 8, -8))
+	assert_true(vs.end_drag().is_empty(), "a refused drag leaves no undo data")
+	assert_eq(brush.faces.size(), 6, "the quads went back")
+	var after := vs.get_brush_vertices(brush)
+	assert_eq(after.size(), before.size(), "and every vertex")
+	for i in before.size():
+		assert_true(after[i].is_equal_approx(before[i]), "vertex %d is where it started" % i)
 
 
 func test_the_validator_sees_a_bent_face_on_its_own():

--- a/tools/vibe/scenarios/vertex.gd
+++ b/tools/vibe/scenarios/vertex.gd
@@ -22,7 +22,8 @@ func summary() -> String:
 
 
 func run() -> void:
-	await _a_move_that_breaks_convexity_is_refused()
+	await _a_move_that_bends_a_face()
+	await _a_move_that_dents_the_solid()
 	await _a_non_finite_move()
 	await _merging_every_vertex_of_a_box()
 	await _splitting_an_edge()
@@ -78,37 +79,46 @@ func _any_non_finite(brush: Node3D) -> bool:
 	return false
 
 
-## Dragging one corner of a box far enough past the opposite face makes the
-## solid non-convex, and bends the three faces that meet at that corner on the
-## way. `validate_convexity()` is meant to catch both and put the brush back the
-## way it was.
-func _a_move_that_breaks_convexity_is_refused() -> void:
+## Dragging one corner of a box bends the faces that meet at it, because a quad
+## with one corner moved is no longer a plane. Whichever way it goes, the brush
+## the mapper is left with has to be a convex solid made of planes: pulled away
+## from the solid the bent faces are cut into triangles and the move stands,
+## pushed into it there is no split that stays convex and the move goes back.
+func _a_move_that_bends_a_face() -> void:
 	var root: Node3D = await fresh_root()
 	var b := box(root, Vector3(64, 64, 64))
 	var vs = root.vertex_system
 	var before := _volume(b)
+	var faces_before: int = b.faces.size()
 
 	vs.select_vertex(_bid(b), 0)
 	var ok: bool = vs.move_vertices(Vector3(0, -256, 0))
 	var after := _volume(b)
-	note(
-		"pulling one corner 256 through the brush",
-		"accepted: %s, volume %.0f -> %.0f" % [ok, before, after]
-	)
 	var bow := _worst_non_planarity(b)
+	note(
+		"pulling one corner 256 away from the solid",
+		(
+			"accepted: %s, volume %.0f -> %.0f, faces %d -> %d"
+			% [ok, before, after, faces_before, b.faces.size()]
+		)
+	)
 	note("worst face non-planarity after the move", "%.2f units" % bow)
-	if ok:
+	if bow > 0.02:
 		flag(
-			"a vertex move that warps a brush's faces out of plane is accepted",
+			"a vertex move left a face bent",
 			(
-				"one corner of a 64 box pulled 256 units: volume %.0f -> %.0f, worst face sits %.1f units off its own plane, validate_convexity() said yes"
-				% [before, after, bow]
+				"one corner of a 64 box pulled 256 units: accepted %s, worst face sits %.1f units off its own plane"
+				% [ok, bow]
 			)
 		)
-	elif bow > 0.02:
+	elif ok and b.faces.size() <= faces_before:
 		flag(
-			"a refused vertex move left a face bent",
-			"worst face sits %.2f units off its own plane" % bow
+			"a bent face was accepted without being split",
+			"faces %d -> %d" % [faces_before, b.faces.size()]
+		)
+	elif ok:
+		note(
+			"split and kept", "faces %d -> %d, volume %.0f" % [faces_before, b.faces.size(), after]
 		)
 	elif absf(after - before) > 0.5:
 		flag(
@@ -117,6 +127,34 @@ func _a_move_that_breaks_convexity_is_refused() -> void:
 		)
 	else:
 		note("refused and restored", "volume back to %.0f" % after)
+
+
+## The other direction. A corner pushed into the solid dents it, and no
+## triangulation of the bent faces gets that back to convex.
+func _a_move_that_dents_the_solid() -> void:
+	var root: Node3D = await fresh_root()
+	var b := box(root, Vector3(64, 64, 64))
+	var vs = root.vertex_system
+	var before := _volume(b)
+	var faces_before: int = b.faces.size()
+
+	# Vertex 0 of a box is the (+x, -y, +z) corner, so this heads for the middle.
+	vs.select_vertex(_bid(b), 0)
+	var ok: bool = vs.move_vertices(Vector3(-16, 16, -16))
+	var after := _volume(b)
+	note(
+		"pushing one corner 16 into the solid",
+		"accepted: %s, volume %.0f -> %.0f" % [ok, before, after]
+	)
+	if ok:
+		flag("a dent was accepted", "volume %.0f -> %.0f" % [before, after])
+	elif absf(after - before) > 0.5 or b.faces.size() != faces_before:
+		flag(
+			"a refused vertex move did not restore the brush",
+			"volume %.0f -> %.0f, faces %d -> %d" % [before, after, faces_before, b.faces.size()]
+		)
+	else:
+		note("refused and restored", "volume back to %.0f, faces %d" % [after, faces_before])
 
 
 ## The recurring seam. Every comparison against NaN is false, so a check written


### PR DESCRIPTION
Follow-up to #364, which took the reject option. This takes the other one the issue named.

A brush face is a plane and every face of a box is a quad, so moving one of its four corners bends it. Refusing that is correct but means no single corner of a box can be dragged at all. On commit each bent face is now cut into triangles along the same fan `FaceData.triangulate()` already uses for the bake, so the committed surface is the one that was on screen during the drag. Each triangle keeps its quad's material and projection.

What is still refused:

- a corner pushed into the solid. No triangulation of a bent face makes a concave solid convex, and with the quad in two pieces the dent is finally something the convexity check can see. That refusal now lands on release rather than mid-drag.
- a bent face carrying a displacement. The displacement is defined over four corners and a split would throw it away.

The split runs on commit only. Mid-drag the face array has to keep the shape `_capture_drag_geometry()` recorded, because `_write_drag_geometry()` pairs faces with their starting vertices by position in the array.

The face count goes up under the mapper. That is the part of this the issue said had to be decided rather than fall out of a missing check.

Hand-placed UVs on a split face go back to the face projection, because four of them do not describe three vertices.

Changelog and the vertex editing section of the smoke checklist updated. The vibe vertex scenario covers both directions now.