### PR TITLE
Refuse degenerate polygon input instead of building a brush from it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,19 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **The polygon tool built brushes out of degenerate input** (#398, #399). The
+  convexity gate skips any cross product under 0.001 before it looks at the
+  sign, so for points all on one line it never disagreed with itself and
+  reported a convex polygon. Three collinear clicks and Enter gave a five-faced
+  brush with an extent of zero that validated clean, saved, baked and sat in
+  front of every pick. The same blind spot let a vertex be placed on top of one
+  already there, which built side quads spanning no area that still took a
+  fallback normal, a UV projection, a snap target and a place in the bake. A
+  click within a hundredth of a unit of a vertex already placed is now rejected,
+  and a polygon that encloses no area is refused at the point it would extrude,
+  with a warning saying so. The convexity gate itself is unchanged: a run of
+  collinear points part-way through a polygon is a real shape, and it is the
+  finished polygon's area that decides.
 - **Every path tool brush was wound inside out** (#397). `_build_segment_brush()`
   and `_build_miter_brush()` wrote their rings the opposite way round from the
   clockwise-from-outside order every other brush in the editor uses, and nothing

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,601 tests across 189 test scripts (3,594 passing plus seven intentional no-assert safety tests; 18,202 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,605 tests across 189 test scripts (3,598 passing plus seven intentional no-assert safety tests; 18,213 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,601 tests** across **189 scripts** (**3,594 passing** plus seven intentional no-assert safety tests; **18,202 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,605 tests** across **189 scripts** (**3,598 passing** plus seven intentional no-assert safety tests; **18,213 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3594%20passing-brightgreen" alt="3594 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3598%20passing-brightgreen" alt="3598 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,601 tests across 189 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,605 tests across 189 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/hf_polygon_tool.gd
+++ b/addons/hammerforge/hf_polygon_tool.gd
@@ -23,6 +23,15 @@ var _immediate_mesh: ImmediateMesh = null
 var _material: StandardMaterial3D = null
 const HEIGHT_SENSITIVITY := 0.5
 
+## How close a click has to land to a vertex already placed to count as the same
+## vertex. Points arrive snapped, so anything short of the smallest grid step is
+## a repeat rather than a very short edge.
+const REPEAT_POINT_EPSILON := 0.01
+
+## Smallest XZ area a finished polygon may enclose. Below this the extrusion is a
+## sheet rather than a solid.
+const MIN_POLYGON_AREA := 0.01
+
 
 func tool_name() -> String:
 	return "Polygon"
@@ -185,6 +194,11 @@ func _handle_click(camera: Camera3D, mouse_pos: Vector2) -> int:
 				if hit.distance_to(first) <= threshold:
 					_begin_height_stage(mouse_pos, true)
 					return EditorPlugin.AFTER_GUI_INPUT_STOP
+			# Reject a point on top of one already placed. Two coincident
+			# vertices make a side quad with no area, and the convexity gate
+			# cannot see them because their cross products are all zero.
+			if _is_repeat_point(_polygon_points, hit):
+				return EditorPlugin.AFTER_GUI_INPUT_STOP
 			# Validate convexity
 			if not _validate_convex(_polygon_points, hit):
 				return EditorPlugin.AFTER_GUI_INPUT_STOP  # Reject concave point
@@ -233,13 +247,48 @@ func _handle_escape() -> int:
 # ---------------------------------------------------------------------------
 
 
-func _begin_height_stage(mouse_pos: Vector2, pointer_capture: bool = false) -> void:
+## Returns false and leaves the tool where it is when the polygon encloses
+## nothing. `_is_convex_xz()` cannot catch this: for points on one line every
+## cross product falls under its degenerate threshold, so it never disagrees with
+## itself and reports a convex polygon. Extruding one gives a brush with no
+## volume that still saves, bakes and sits in front of every pick.
+func _begin_height_stage(mouse_pos: Vector2, pointer_capture: bool = false) -> bool:
+	if _polygon_area_xz(_polygon_points) < MIN_POLYGON_AREA:
+		push_warning(
+			(
+				"HammerForge: polygon encloses no area (%d points on one line) - not extruding."
+				% _polygon_points.size()
+			)
+		)
+		return false
 	_phase = Phase.SETTING_HEIGHT
 	_height_pointer_capture = pointer_capture
 	_height_start_mouse = mouse_pos
 	_height = 32.0
 	_height_start_value = _height
 	_update_preview()
+	return true
+
+
+static func _is_repeat_point(existing: PackedVector3Array, new_pt: Vector3) -> bool:
+	for pt in existing:
+		if pt.distance_to(new_pt) < REPEAT_POINT_EPSILON:
+			return true
+	return false
+
+
+## Area the polygon encloses in XZ, by the shoelace sum. Zero when every point
+## is on one line, which is what the convexity gate reads as agreement.
+static func _polygon_area_xz(pts: PackedVector3Array) -> float:
+	var n := pts.size()
+	if n < 3:
+		return 0.0
+	var twice_area := 0.0
+	for i in range(n):
+		var a: Vector3 = pts[i]
+		var b: Vector3 = pts[(i + 1) % n]
+		twice_area += a.x * b.z - b.x * a.z
+	return absf(twice_area) * 0.5
 
 
 func _validate_convex(existing: PackedVector3Array, new_pt: Vector3) -> bool:

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -1337,8 +1337,8 @@ The polygon tool lets you draw arbitrary convex shapes and extrude them into bru
 1. Press **P** to activate the Polygon tool.
 2. Click in the viewport to place the first vertex on the nearest exact visible surface. If no geometry is hit, placement uses the plane the grid is drawn on. The point passes through the shared Grid, Vertex, Center, Edge, Perpendicular, and reference-line snap pipeline.
 3. Place more vertices. Each cursor ray starts on the horizontal plane established by the first point, then passes through the shared snap pipeline.
-4. Each new vertex is validated for convexity -- concave placements are rejected.
-5. Close the polygon by clicking near the first vertex (within the auto-close threshold) or pressing **Enter** (requires 3+ vertices).
+4. Each new vertex is validated for convexity -- concave placements are rejected. A click that lands on a vertex already placed is rejected too, because two vertices in one spot make a side face with no area.
+5. Close the polygon by clicking near the first vertex (within the auto-close threshold) or pressing **Enter** (requires 3+ vertices). A polygon whose points are all on one line encloses nothing, so it is refused with a warning rather than extruded into a brush with no volume.
 6. Move the mouse up/down to set the extrusion height, then click to confirm.
 7. The brush is created with full undo/redo support.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,601 tests across 189 scripts**: **3,594 passing tests**, seven intentional no-assert safety tests, and **18,202 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,605 tests across 189 scripts**: **3,598 passing tests**, seven intentional no-assert safety tests, and **18,213 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_polygon_tool.gd
+++ b/tests/test_polygon_tool.gd
@@ -114,9 +114,15 @@ func test_degenerate_two_points():
 	assert_true(HFPolygonTool._is_convex_xz(pts), "Two points should pass (degenerate)")
 
 
-func test_collinear_points():
+func test_collinear_points_pass_the_convexity_gate_but_not_the_area_gate():
+	# The convexity gate skips every cross product under its degenerate
+	# threshold, and for points on one line that is all of them, so it never
+	# disagrees with itself. That is why a polygon on one line has to be caught
+	# on the area it encloses instead: it used to extrude to a five-faced brush
+	# with an extent of zero that saved, baked and blocked every pick.
 	var pts = PackedVector3Array([Vector3(0, 0, 0), Vector3(2, 0, 0), Vector3(4, 0, 0)])
-	assert_true(HFPolygonTool._is_convex_xz(pts), "Collinear points should pass")
+	assert_true(HFPolygonTool._is_convex_xz(pts), "Convexity alone cannot see collinear points")
+	assert_almost_eq(HFPolygonTool._polygon_area_xz(pts), 0.0, 0.0001, "They enclose nothing")
 
 
 # ===========================================================================
@@ -319,3 +325,68 @@ func test_focus_loss_cancels_height_pointer_capture_but_keeps_polygon_editable()
 	assert_false(tool._height_pointer_capture)
 	assert_eq(tool._polygon_points.size(), 3)
 	assert_false(tool.cancel_pointer_capture(), "A settled polygon should not be cancelled twice")
+
+
+# ===========================================================================
+# Degenerate input
+# ===========================================================================
+
+
+func test_a_polygon_on_one_line_does_not_extrude():
+	var tool = HFPolygonTool.new()
+	var root := PlacementRoot.new()
+	tool.root = root
+	tool._polygon_points = PackedVector3Array(
+		[Vector3(-64, 0, 0), Vector3(0, 0, 0), Vector3(64, 0, 0)]
+	)
+	tool._phase = tool.Phase.PLACING_VERTS
+	assert_false(tool._begin_height_stage(Vector2.ZERO), "A polygon with no area is refused")
+	assert_eq(tool._phase, tool.Phase.PLACING_VERTS, "and the tool stays where it was")
+	root.free()
+
+
+func test_a_polygon_with_area_still_extrudes():
+	var tool = HFPolygonTool.new()
+	var root := PlacementRoot.new()
+	tool.root = root
+	tool._polygon_points = PackedVector3Array(
+		[Vector3(0, 0, 0), Vector3(64, 0, 0), Vector3(64, 0, 64), Vector3(0, 0, 64)]
+	)
+	tool._phase = tool.Phase.PLACING_VERTS
+	assert_true(tool._begin_height_stage(Vector2.ZERO), "A square is fine")
+	assert_eq(tool._phase, tool.Phase.SETTING_HEIGHT, "and the height stage opens")
+	root.free()
+
+
+func test_a_point_on_top_of_one_already_placed_is_rejected():
+	var existing = PackedVector3Array([Vector3(0, 0, 0), Vector3(64, 0, 0)])
+	assert_true(
+		HFPolygonTool._is_repeat_point(existing, Vector3(0, 0, 0)), "The same point is a repeat"
+	)
+	assert_true(
+		HFPolygonTool._is_repeat_point(existing, Vector3(64, 0, 0.001)),
+		"and so is one inside the epsilon"
+	)
+	assert_false(
+		HFPolygonTool._is_repeat_point(existing, Vector3(64, 0, 64)), "A new corner is not"
+	)
+
+
+func test_a_repeat_click_places_no_second_vertex():
+	# A repeated vertex used to build a side quad spanning no area, which still
+	# took a normal, a UV projection, a snap target and a place in the bake.
+	var tool = HFPolygonTool.new()
+	var root := PlacementRoot.new()
+	var camera := Camera3D.new()
+	tool.root = root
+	root.raycast_result = {"position": Vector3(0, 0, 0)}
+	tool._handle_click(camera, Vector2.ZERO)
+	assert_eq(tool._polygon_points.size(), 1, "First click places a vertex")
+	assert_eq(
+		tool._handle_click(camera, Vector2.ZERO),
+		EditorPlugin.AFTER_GUI_INPUT_STOP,
+		"The repeat is swallowed"
+	)
+	assert_eq(tool._polygon_points.size(), 1, "and places nothing")
+	root.free()
+	camera.free()


### PR DESCRIPTION
Fixes #398. Fixes #399.

One blind spot behind both. `_is_convex_xz()` skips any cross product under 0.001 before it looks at the sign, so when every cross product is degenerate the loop finishes without ever setting `sign` and the function reports a convex polygon.

- Three collinear clicks and Enter gave a brush with a local extent of (128, 32, 0): five faces enclosing nothing, which validated clean, saved, baked and sat in front of every pick.
- A vertex placed on top of one already there gave side quads spanning no area, which still took a fallback normal, a UV projection, a snap target and a place in the bake.

Two guards, at the two places the input arrives:

- a click within `REPEAT_POINT_EPSILON` of a vertex already placed is rejected, the same silent way a concave placement is. Auto-close is tested first, so closing on the first vertex still closes.
- `_begin_height_stage()` now returns false and stays put when the polygon encloses no area, with a warning saying so. That is the only way into the height stage, so it is the only gate `_finalize_brush()` can be reached through.

`_is_convex_xz()` is deliberately left alone. A run of collinear points part-way through a polygon is a real shape - clicking along a straight wall and then turning - so the finished polygon's area is what decides, not the running convexity check. The existing `test_collinear_points` asserted the old pass; it now says why convexity alone cannot see this and pairs it with the area gate.

Changelog and the polygon tool workflow in the user guide updated.