### PR TITLE
Keep the extrude ghost out of the level and mint its ids from the session scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,23 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **The extrude tool's ghost was a brush in the level, in the wrong place, and
+  its ids were not unique** (#400, #401, #402). The preview was a real
+  `DraftBrush` parented into `draft_brushes_node`, the container
+  `_iter_managed_brush_nodes()`, `_iter_pick_nodes()`, `capture_state()` and the
+  save all walk, so mid-drag the level had a brush in it that nobody made: an
+  undo snapshot or an autosave taken during the drag stored the ghost, and the
+  snap system offered its corners as targets. It now goes into a container of
+  its own the way every other preview in the editor does. It was also positioned
+  before it was added to the tree, and `global_position` is tree-relative, so the
+  engine returned an identity transform twice per preview update and the ghost
+  sat at the origin rather than on the face under the cursor - on a brush turned
+  45 degrees the green volume had nothing to do with what committing would
+  build. The transform is written after `add_child()` now. And the tool minted
+  its own brush ids from the direction and the millisecond clock, so two
+  extrusions committed in the same millisecond claimed the same id, ids collided
+  across sessions whenever the tick counts lined up, and `id_counter` never
+  advanced. Ids come from the brush system, like every other created brush's.
 - **The polygon tool built brushes out of degenerate input** (#398, #399). The
   convexity gate skips any cross product under 0.001 before it looks at the
   sign, so for points all on one line it never disagreed with itself and

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,605 tests across 189 test scripts (3,598 passing plus seven intentional no-assert safety tests; 18,213 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,610 tests across 190 test scripts (3,603 passing plus seven intentional no-assert safety tests; 18,240 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,605 tests** across **189 scripts** (**3,598 passing** plus seven intentional no-assert safety tests; **18,213 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,610 tests** across **190 scripts** (**3,603 passing** plus seven intentional no-assert safety tests; **18,240 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3598%20passing-brightgreen" alt="3598 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3603%20passing-brightgreen" alt="3603 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,605 tests across 189 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,610 tests across 190 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/hf_extrude_tool.gd
+++ b/addons/hammerforge/hf_extrude_tool.gd
@@ -24,6 +24,7 @@ var source_face_size: Vector3 = Vector3.ONE
 var _start_mouse_y: float = 0.0
 var _current_height: float = 0.0
 var _preview_brush: DraftBrush = null
+var _preview_container: Node3D = null
 var _snap: float = 1.0
 
 const HEIGHT_SENSITIVITY := 0.02  # world units per screen pixel
@@ -96,13 +97,13 @@ func end_extrude_info() -> Dictionary:
 		return {}
 
 	var info := _build_brush_info(_current_height)
-	_clear_preview()
+	_teardown_preview()
 	active = false
 	return info
 
 
 func cancel_extrude() -> void:
-	_clear_preview()
+	_teardown_preview()
 	active = false
 	_current_height = 0.0
 	source_brush = null
@@ -136,13 +137,6 @@ func _update_preview(height: float) -> void:
 	var preview_size := _compute_preview_size(height, extrude_axis)
 	_preview_brush.size = preview_size
 
-	# Position: offset from face center along extrude direction
-	var offset := extrude_axis * (height * 0.5)
-	_preview_brush.global_position = source_face_center + offset
-
-	# Align rotation to match source brush
-	_preview_brush.global_transform.basis = source_brush.global_transform.basis
-
 	# Semi-transparent preview material
 	var mat := StandardMaterial3D.new()
 	if direction == Direction.UP:
@@ -157,19 +151,56 @@ func _update_preview(height: float) -> void:
 	if source_brush.material_override:
 		_preview_brush.set_meta("source_material", source_brush.material_override)
 
-	if root.draft_brushes_node:
-		root.draft_brushes_node.add_child(_preview_brush)
-	else:
+	var container := _ensure_preview_container()
+	if not container:
 		_preview_brush.free()
 		_preview_brush = null
+		return
+	# In the tree first. `global_position` and `global_transform` are both
+	# tree-relative, and a node that is not in the tree yet answers them with an
+	# engine error and an identity transform, which left the ghost at the origin
+	# instead of on the face being extruded.
+	container.add_child(_preview_brush)
+	var offset := extrude_axis * (height * 0.5)
+	_preview_brush.global_position = source_face_center + offset
+	# Align rotation to match source brush
+	_preview_brush.global_transform.basis = source_brush.global_transform.basis
 
 
+## The ghost gets a container of its own, the way every other preview in the
+## editor does. It used to go into `draft_brushes_node`, which is what
+## `_iter_managed_brush_nodes()`, `_iter_pick_nodes()`, `capture_state()` and the
+## save all walk: mid-drag the level had a brush in it that nobody made, an
+## autosave stored it, and the snap system offered its corners.
+func _ensure_preview_container() -> Node3D:
+	if is_instance_valid(_preview_container):
+		return _preview_container
+	if not is_instance_valid(root):
+		return null
+	_preview_container = Node3D.new()
+	_preview_container.name = "ExtrudePreview"
+	root.add_child(_preview_container)
+	return _preview_container
+
+
+## The ghost only. The container stays up for the rest of the drag, because this
+## runs once per mouse move.
 func _clear_preview() -> void:
 	if _preview_brush and is_instance_valid(_preview_brush):
 		if _preview_brush.get_parent():
 			_preview_brush.get_parent().remove_child(_preview_brush)
 		_preview_brush.queue_free()
-		_preview_brush = null
+	_preview_brush = null
+
+
+## The ghost and its container, for the end of the extrusion either way.
+func _teardown_preview() -> void:
+	_clear_preview()
+	if is_instance_valid(_preview_container):
+		if _preview_container.get_parent():
+			_preview_container.get_parent().remove_child(_preview_container)
+		_preview_container.queue_free()
+	_preview_container = null
 
 
 # ---------------------------------------------------------------------------
@@ -190,15 +221,30 @@ func _build_brush_info(height: float) -> Dictionary:
 	info["size"] = preview_size
 	info["operation"] = CSGShape3D.OPERATION_UNION
 	info["transform"] = xform
-	info["brush_id"] = _generate_extrude_id()
+	var brush_id := _next_brush_id()
+	if brush_id != "":
+		info["brush_id"] = brush_id
 	if source_brush.material_override:
 		info["material"] = source_brush.material_override
 	return info
 
 
-func _generate_extrude_id() -> String:
-	var dir_str := "up" if direction == Direction.UP else "down"
-	return "extrude_%s_%d" % [dir_str, Time.get_ticks_msec()]
+## Ids come from the brush system, the way every other created brush's does.
+## This tool used to mint its own from the direction and the millisecond clock,
+## which is not unique: two extrusions committed in the same millisecond claimed
+## the same id, an id minted in one session collided with one from another
+## whenever the tick counts lined up, and `id_counter` never advanced, so the
+## counter and the ids in the level drifted apart after every extrusion.
+##
+## The id is minted here rather than left to `create_brush_from_info()` because
+## it has to stay the same across a redo, which calls that function again with
+## this same dictionary.
+func _next_brush_id() -> String:
+	if is_instance_valid(root) and root.get("brush_system"):
+		var brush_system = root.brush_system
+		if brush_system.has_method("next_brush_id"):
+			return str(brush_system.next_brush_id())
+	return ""
 
 
 # ---------------------------------------------------------------------------

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,605 tests across 189 scripts**: **3,598 passing tests**, seven intentional no-assert safety tests, and **18,213 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,610 tests across 190 scripts**: **3,603 passing tests**, seven intentional no-assert safety tests, and **18,240 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_extrude_tool_preview_and_ids.gd
+++ b/tests/test_extrude_tool_preview_and_ids.gd
@@ -1,0 +1,145 @@
+extends GutTest
+## The extrude ghost and the ids the tool mints.
+##
+## A preview is the one node the editor puts in the scene that is not part of the
+## level, so the contract is about what it must not do: never be counted as a
+## brush, never reach a state capture, never be offered as a snap target. And an
+## id has to come from the session scheme, or two brushes end up sharing one.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+const DraftBrush = preload("res://addons/hammerforge/brush_instance.gd")
+
+var root: LevelRoot
+var tool
+
+
+func before_each() -> void:
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.commit_freeze = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	tool = root.extrude_tool
+
+
+func after_each() -> void:
+	root = null
+	tool = null
+
+
+func _make_box(brush_id: String, position: Vector3, rotation_y: float = 0.0) -> DraftBrush:
+	var brush := (
+		(
+			root
+			. create_brush_from_info(
+				{
+					"shape": LevelRootType.BrushShape.BOX,
+					"size": Vector3(64, 64, 64),
+					"center": position,
+					"operation": CSGShape3D.OPERATION_UNION,
+					"brush_id": brush_id,
+				}
+			)
+		)
+		as DraftBrush
+	)
+	assert_not_null(brush)
+	if brush and rotation_y != 0.0:
+		brush.rotation.y = rotation_y
+	return brush
+
+
+## Put the tool into a live extrusion on the top face of the given brush without
+## going through the camera, which a headless test has none of.
+func _begin_on_top_face(brush: DraftBrush, height: float) -> void:
+	var face_idx := -1
+	for i in range(brush.faces.size()):
+		var face = brush.faces[i]
+		face.ensure_geometry()
+		if (brush.global_transform.basis * face.normal).normalized().dot(Vector3.UP) > 0.9:
+			face_idx = i
+			break
+	assert_true(face_idx >= 0, "The box has a top face")
+	var face = brush.faces[face_idx]
+	tool.source_brush = brush
+	tool.source_face_idx = face_idx
+	tool.source_face_normal = (brush.global_transform.basis * face.normal).normalized()
+	tool.source_face_center = tool._compute_face_center(brush, face)
+	tool.source_face_size = tool._compute_face_extents(face)
+	tool.direction = tool.Direction.UP
+	tool.active = true
+	tool._current_height = height
+	tool._update_preview(height)
+
+
+func test_the_ghost_is_not_a_brush_in_the_level() -> void:
+	var brush := _make_box("box_a", Vector3.ZERO)
+	var managed_before := root._iter_managed_brush_nodes().size()
+	var pick_before := root._iter_pick_nodes().size()
+	_begin_on_top_face(brush, 32.0)
+	assert_not_null(tool._preview_brush, "There is a ghost")
+	assert_eq(
+		root._iter_managed_brush_nodes().size(),
+		managed_before,
+		"The ghost is not one of the level's brushes"
+	)
+	assert_eq(root._iter_pick_nodes().size(), pick_before, "and it is not a pick or snap candidate")
+	var state: Dictionary = root.capture_state(true)
+	assert_eq(state["brushes"].size(), managed_before, "and a state capture does not store it")
+	tool.cancel_extrude()
+
+
+func test_the_ghost_leaves_nothing_behind() -> void:
+	var brush := _make_box("box_b", Vector3.ZERO)
+	_begin_on_top_face(brush, 32.0)
+	tool.cancel_extrude()
+	assert_null(tool._preview_brush, "The ghost is gone")
+	assert_null(root.get_node_or_null("ExtrudePreview"), "and so is its container")
+
+
+func test_the_ghost_sits_on_the_face_being_extruded() -> void:
+	# The transform used to be written before add_child, which both errors and
+	# leaves the ghost at the origin.
+	var brush := _make_box("box_c", Vector3(128, 0, 128), deg_to_rad(45.0))
+	_begin_on_top_face(brush, 32.0)
+	assert_not_null(tool._preview_brush)
+	var expected: Vector3 = tool.source_face_center + Vector3.UP * 16.0
+	assert_almost_eq(
+		tool._preview_brush.global_position.x, expected.x, 0.01, "Ghost is on the face, not at 0"
+	)
+	assert_almost_eq(tool._preview_brush.global_position.y, expected.y, 0.01)
+	assert_almost_eq(tool._preview_brush.global_position.z, expected.z, 0.01)
+	assert_almost_eq(
+		tool._preview_brush.global_transform.basis.get_euler().y,
+		brush.global_transform.basis.get_euler().y,
+		0.01,
+		"and turned the way the source brush is"
+	)
+	tool.cancel_extrude()
+
+
+func test_two_extrusions_in_one_frame_get_different_ids() -> void:
+	# Ids used to be minted from the direction and the millisecond clock, so two
+	# commits in the same millisecond claimed the same id.
+	var brush := _make_box("box_d", Vector3.ZERO)
+	_begin_on_top_face(brush, 32.0)
+	var first: String = str(tool._build_brush_info(32.0)["brush_id"])
+	var second: String = str(tool._build_brush_info(32.0)["brush_id"])
+	assert_ne(first, "", "An extrusion gets an id")
+	assert_ne(first, second, "and two of them do not share it")
+	tool.cancel_extrude()
+
+
+func test_an_extrusion_id_comes_from_the_session_scheme() -> void:
+	var brush := _make_box("box_e", Vector3.ZERO)
+	_begin_on_top_face(brush, 32.0)
+	var counter_before: int = root._brush_id_counter
+	var brush_id: String = str(tool._build_brush_info(32.0)["brush_id"])
+	assert_false(brush_id.begins_with("extrude_"), "Not a scheme of its own")
+	var parts := brush_id.split("_")
+	assert_eq(parts.size(), 2, "A session prefix and a counter: %s" % brush_id)
+	assert_true(parts[1].is_valid_int(), "and the counter is a number")
+	assert_eq(
+		root._brush_id_counter, counter_before + 1, "Minting one advances the level's id counter"
+	)
+	tool.cancel_extrude()


### PR DESCRIPTION
Fixes #400. Fixes #401. Fixes #402.

Three things wrong with the same preview-and-commit path.

**The ghost was a brush in the level.** It was a real `DraftBrush` parented into `draft_brushes_node`, which `_iter_managed_brush_nodes()`, `_iter_pick_nodes()`, `capture_state()` and the save all walk. Mid-drag the managed count went up, a state capture stored the ghost in `brushes`, and the snap system offered its corners. It now goes into an `ExtrudePreview` container of its own, the way clip, carve, hollow, array and structure previews do.

**The ghost was in the wrong place.** `global_position` and `global_transform` were written before `add_child()`, and both are tree-relative, so the engine printed `Condition "!is_inside_tree()" is true` twice per preview update and left the node at the origin. On a box turned 45 degrees about Y the green volume had nothing to do with the face under the cursor. The transform is written after the node is in the tree.

**The ids were not unique.** `extrude_up_<millisecond>` is uniquely determined by the direction and the millisecond, so two commits in one millisecond claimed the same id and ids collided across sessions. It also never advanced `id_counter`. The id now comes from `brush_system.next_brush_id()`, the same `<session>_<counter>` scheme every other created brush uses. It is minted in `_build_brush_info()` rather than left to `create_brush_from_info()` because a redo calls that function again with the same dictionary and the id has to survive it.

While in there: the container is built once per extrusion rather than once per mouse move. `_clear_preview()` drops the ghost, `_teardown_preview()` drops both and runs on commit and on cancel.

New test file covers all three: the ghost is not counted, picked or captured; it leaves nothing behind; it lands on the face of a rotated brush; two ids in one frame differ; an id parses as the session scheme and advances the counter. All five fail without the fix.

Changelog updated. No doc describes the old behaviour.