### PR TITLE
Make a placed decal part of the level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,19 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **A decal was not part of the level** (#403, #404). `_place_decal()` added a
+  `Decal` node under the `LevelRoot` and nothing else knew about it.
+  `capture_state()` had no decal key, and a `.hflevel` is what `capture_state()`
+  returns, so a decal was gone after a save and reload - of the format the
+  editor treats as authoritative and the one autosave writes. Placing one also
+  registered no undo action, so Ctrl+Z undid whatever the user did before the
+  decal and left the decal in place, with no delete gesture to remove it. Decals
+  now live under a `Decals` container on the `LevelRoot`, are captured and
+  restored with the rest of the level state, and a placement is wrapped in the
+  same state capture and restore pair the polygon and path tools use. Each decal
+  also gets a name of its own: they were all called `HFDecal`, so the second one
+  in a level came back as `@Decal@15`. The ghost under the cursor stays out of
+  the container and out of the level, as before.
 - **The extrude tool's ghost was a brush in the level, in the wrong place, and
   its ids were not unique** (#400, #401, #402). The preview was a real
   `DraftBrush` parented into `draft_brushes_node`, the container

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,610 tests across 190 test scripts (3,603 passing plus seven intentional no-assert safety tests; 18,240 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,616 tests across 191 test scripts (3,609 passing plus seven intentional no-assert safety tests; 18,262 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,610 tests** across **190 scripts** (**3,603 passing** plus seven intentional no-assert safety tests; **18,240 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,616 tests** across **191 scripts** (**3,609 passing** plus seven intentional no-assert safety tests; **18,262 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3603%20passing-brightgreen" alt="3603 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3609%20passing-brightgreen" alt="3609 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,610 tests across 190 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,616 tests across 191 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/hf_decal_tool.gd
+++ b/addons/hammerforge/hf_decal_tool.gd
@@ -142,8 +142,20 @@ func _place_decal(position: Vector3, normal: Vector3) -> void:
 	var fade: float = get_setting("fade")
 	var tex_path: String = get_setting("texture")
 
+	var container: Node3D = root.get("decals_node")
+	if not container:
+		return
+
+	# Capture before the decal exists, so undo has somewhere to go back to. The
+	# polygon and path tools wrap creation the same way.
+	var pre_state: Dictionary = {}
+	if root.get("state_system") and root.state_system.has_method("capture_state"):
+		pre_state = root.state_system.capture_state(true)
+
 	var decal := Decal.new()
-	decal.name = "HFDecal"
+	# A name Godot does not have to invent a replacement for. Every decal used to
+	# be called "HFDecal", so the second one in a level came out as "@Decal@15".
+	decal.name = "HFDecal_%d" % (container.get_child_count() + 1)
 	decal.set_meta("hf_decal", true)
 
 	# Decal projects along its local -Y axis. We need to orient -Y toward the
@@ -156,12 +168,21 @@ func _place_decal(position: Vector3, normal: Vector3) -> void:
 		if tex is Texture2D:
 			decal.texture_albedo = tex
 
-	root.add_child(decal)
+	container.add_child(decal)
 	decal.owner = root.owner if root.owner else root
 
 	# Position and orient
 	decal.global_position = position + normal * 0.01  # slight offset to avoid z-fight
 	_orient_decal(decal, normal)
+
+	if undo_redo and not pre_state.is_empty():
+		var post_state: Dictionary = root.state_system.capture_state(true)
+		undo_redo.create_action("Place Decal", 0, null, false)
+		undo_redo.add_do_method(root.state_system, "restore_state", post_state)
+		undo_redo.add_undo_method(root.state_system, "restore_state", pre_state)
+		undo_redo.commit_action(false)
+	if history_callback.is_valid():
+		history_callback.call("Place Decal")
 
 
 func _orient_decal(decal: Decal, normal: Vector3) -> void:

--- a/addons/hammerforge/hf_validation.gd
+++ b/addons/hammerforge/hf_validation.gd
@@ -102,6 +102,7 @@ static func level_state_problem(state: Dictionary) -> String:
 		"hollows",
 		"paint_layers",
 		"paint_connectors",
+		"decals",
 	]
 	const DICTIONARY_KEYS := [
 		"face_selection",

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -320,6 +320,7 @@ var draft_brushes_node: Node3D
 var pending_node: Node3D
 var committed_node: Node3D
 var entities_node: Node3D
+var decals_node: Node3D
 var brush_manager: BrushManager
 var material_manager: MaterialManager
 var baker: Baker
@@ -669,6 +670,7 @@ func _ready():
 	_setup_pending_container()
 	_setup_committed()
 	_setup_entities_container()
+	_setup_decals_container()
 	_setup_manager()
 	_setup_material_manager()
 	_setup_baker()
@@ -2856,6 +2858,15 @@ func _setup_entities_container() -> void:
 		entities_node.name = "Entities"
 		add_child(entities_node)
 		_assign_owner(entities_node)
+
+
+func _setup_decals_container() -> void:
+	decals_node = get_node_or_null("Decals") as Node3D
+	if not decals_node:
+		decals_node = Node3D.new()
+		decals_node.name = "Decals"
+		add_child(decals_node)
+		_assign_owner(decals_node)
 
 
 func _setup_manager() -> void:

--- a/addons/hammerforge/systems/hf_state_system.gd
+++ b/addons/hammerforge/systems/hf_state_system.gd
@@ -139,7 +139,57 @@ func capture_state(include_transient: bool = true) -> Dictionary:
 	state["generators"] = root.generator_system.capture() if root.generator_system else []
 	if root.prefab_system:
 		state["prefab_instances"] = root.prefab_system.capture_state()
+	state["decals"] = capture_decals()
 	return state
+
+
+## Decals placed with the decal tool. They are part of the level: without this a
+## decal was scene decoration that a `.hflevel` save dropped, which is the format
+## the editor treats as authoritative and the one autosave writes.
+func capture_decals() -> Array:
+	var out: Array = []
+	if not root.decals_node:
+		return out
+	for child in root.decals_node.get_children():
+		if not (child is Decal):
+			continue
+		var decal := child as Decal
+		var entry: Dictionary = {
+			"transform": decal.transform,
+			"size": decal.size,
+		}
+		if decal.texture_albedo and decal.texture_albedo.resource_path != "":
+			entry["texture"] = decal.texture_albedo.resource_path
+		out.append(entry)
+	return out
+
+
+## One unreadable entry costs that entry, not the load, the same way a brush
+## entry does.
+func restore_decals(entries: Array) -> void:
+	if not root.decals_node:
+		return
+	for child in root.decals_node.get_children():
+		root.decals_node.remove_child(child)
+		child.queue_free()
+	for entry in entries:
+		if not (entry is Dictionary):
+			continue
+		var decal := Decal.new()
+		decal.set_meta("hf_decal", true)
+		var size = entry.get("size", Vector3(2.0, 4.0, 2.0))
+		if size is Vector3:
+			decal.size = size
+		var tex_path: String = str(entry.get("texture", ""))
+		if tex_path != "" and ResourceLoader.exists(tex_path):
+			var tex = load(tex_path)
+			if tex is Texture2D:
+				decal.texture_albedo = tex
+		root.decals_node.add_child(decal)
+		root._assign_owner(decal)
+		var xform = entry.get("transform", Transform3D())
+		if xform is Transform3D:
+			decal.transform = xform
 
 
 ## One brush out of a state entry, or null when the entry is not one.
@@ -262,6 +312,7 @@ func restore_state(state: Dictionary) -> void:
 		root._last_bake_preview_mode = 0
 	if root.prefab_system and state.has("prefab_instances"):
 		root.prefab_system.restore_state(state["prefab_instances"])
+	restore_decals(state.get("decals", []))
 	if skipped > 0:
 		HFLog.warn("HFStateSystem: skipped %d entry this level could not use" % skipped)
 		if root.has_signal("user_message"):

--- a/docs/HammerForge_Data_Portability.md
+++ b/docs/HammerForge_Data_Portability.md
@@ -9,7 +9,7 @@ Last updated: September 2, 2026
 This document describes how to move data in and out of HammerForge safely.
 
 ## Source of Truth: `.hflevel`
-- `.hflevel` files are the canonical save format for brushes, paint layers, materials, entities, and settings.
+- `.hflevel` files are the canonical save format for brushes, paint layers, materials, entities, decals, and settings.
 - When region streaming is enabled, per-region paint data is stored in a sibling `<level>.hfregions/` folder as one `.hfr` file per region.
 - A region is written before its chunks are streamed out of memory. If that write fails the region stays loaded and you are told, so unsaved paint is not dropped by moving the cursor.
 - A region is only listed in the `.hflevel` index once its `.hfr` file exists on disk.

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -1143,7 +1143,7 @@ All keyboard shortcuts are data-driven and can be customized. The default bindin
 | Move to Floor | Ctrl+Shift+F | Snap to nearest surface below |
 | Move to Ceiling | Ctrl+Shift+C | Snap to nearest surface above |
 | Measure | M | Multi-ruler tool (persistent rulers, angles, snap ref) |
-| Decal | N | Place decal on surface with live preview |
+| Decal | N | Place decal on surface with live preview. Decals live under the LevelRoot's `Decals` node, save with the level and undo like any other placement |
 | Polygon | P | Draw convex polygon, extrude to brush |
 | Path | ; | Place waypoints, extrude corridor brushes |
 | Edge sub-mode | E | Toggle vertex/edge sub-mode (in vertex mode) |

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,610 tests across 190 scripts**: **3,603 passing tests**, seven intentional no-assert safety tests, and **18,240 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,616 tests across 191 scripts**: **3,609 passing tests**, seven intentional no-assert safety tests, and **18,262 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_decals_are_part_of_the_level.gd
+++ b/tests/test_decals_are_part_of_the_level.gd
@@ -1,0 +1,104 @@
+extends GutTest
+## Decals placed with the decal tool belong to the level.
+##
+## They used to be scene decoration: nothing in `capture_state()` knew about
+## them, so a `.hflevel` save dropped them, and placing one registered no undo
+## action, so Ctrl+Z undid whatever the user did before the decal and left the
+## decal where it was.
+
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+const HFDecalTool = preload("res://addons/hammerforge/hf_decal_tool.gd")
+const HFLevelIO = preload("res://addons/hammerforge/hflevel_io.gd")
+
+var root: LevelRoot
+var tool
+
+
+func before_each() -> void:
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.commit_freeze = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	tool = HFDecalTool.new()
+	tool.root = root
+
+
+func after_each() -> void:
+	tool = null
+	root = null
+
+
+func test_a_placed_decal_is_in_the_level_state() -> void:
+	tool._place_decal(Vector3(16, 0, 32), Vector3.UP)
+	var state: Dictionary = root.capture_state(true)
+	assert_true(state.has("decals"), "The level state has a decals key")
+	assert_eq(state["decals"].size(), 1, "and the decal is in it")
+	var entry: Dictionary = state["decals"][0]
+	assert_almost_eq(entry["transform"].origin.x, 16.0, 0.01, "with where it was put")
+	assert_almost_eq(entry["transform"].origin.z, 32.0, 0.01)
+
+
+func test_a_decal_survives_a_capture_and_restore() -> void:
+	tool._place_decal(Vector3(64, 8, -12), Vector3.UP)
+	var state: Dictionary = root.capture_state(true)
+	root.state_system.restore_decals([])
+	assert_eq(root.decals_node.get_child_count(), 0, "Cleared")
+	root.state_system.restore_state(state)
+	assert_eq(root.decals_node.get_child_count(), 1, "The decal comes back")
+	var decal: Decal = root.decals_node.get_child(0) as Decal
+	assert_not_null(decal)
+	assert_almost_eq(decal.global_position.x, 64.0, 0.01, "in the same place")
+	assert_almost_eq(decal.global_position.z, -12.0, 0.01)
+
+
+func test_a_decal_survives_the_hflevel_encoding() -> void:
+	# A `.hflevel` is `capture_full_state()` put through `HFLevelIO`, so this is
+	# the round trip the file makes. The decal used to be absent from the capture
+	# and so was simply not in the file.
+	tool._place_decal(Vector3(24, 0, 0), Vector3.UP)
+	var bundle: Dictionary = root.capture_full_state()
+	var written = HFLevelIO.decode_variant(
+		JSON.parse_string(JSON.stringify(HFLevelIO.encode_variant(bundle)))
+	)
+	assert_true(written is Dictionary, "The bundle survives the file encoding")
+	root.state_system.restore_decals([])
+	assert_eq(root.decals_node.get_child_count(), 0, "Cleared before the load")
+	root.state_system.restore_full_state(written)
+	assert_eq(root.decals_node.get_child_count(), 1, "The decal came back with the level")
+	var decal: Decal = root.decals_node.get_child(0) as Decal
+	assert_almost_eq(decal.global_position.x, 24.0, 0.01, "in the same place")
+
+
+func test_restoring_the_state_from_before_the_decal_removes_it() -> void:
+	# This is what Ctrl+Z does. Without the decal in the state there was nothing
+	# for undo to go back to, so it undid the action before instead.
+	var before: Dictionary = root.capture_state(true)
+	tool._place_decal(Vector3.ZERO, Vector3.UP)
+	var after: Dictionary = root.capture_state(true)
+	assert_eq(root.decals_node.get_child_count(), 1, "The decal is placed")
+	root.state_system.restore_state(before)
+	assert_eq(root.decals_node.get_child_count(), 0, "Undo takes it away")
+	root.state_system.restore_state(after)
+	assert_eq(root.decals_node.get_child_count(), 1, "and redo puts it back")
+
+
+func test_a_second_decal_gets_a_name_of_its_own() -> void:
+	tool._place_decal(Vector3.ZERO, Vector3.UP)
+	tool._place_decal(Vector3(32, 0, 0), Vector3.UP)
+	var names: Array = []
+	for child in root.decals_node.get_children():
+		names.append(str(child.name))
+	assert_eq(names.size(), 2, "Two decals")
+	assert_false(
+		names.any(func(n: String) -> bool: return n.begins_with("@")),
+		"Neither is a name Godot had to invent: %s" % str(names)
+	)
+	assert_ne(names[0], names[1], "and they are not the same name")
+
+
+func test_the_ghost_under_the_cursor_is_not_one_of_them() -> void:
+	tool._update_preview(Vector3(8, 0, 8), Vector3.UP)
+	assert_not_null(tool._preview_decal, "There is a preview")
+	assert_eq(root.capture_state(true)["decals"].size(), 0, "and it is not part of the level")
+	tool._remove_preview()


### PR DESCRIPTION
Fixes #403. Fixes #404.

One root cause: the decal tool added a node and nothing else in the editor knew about it. That is why a decal did not survive a save and why undo could not remove it.

- `LevelRoot` gets a `Decals` container, built beside `DraftBrushes`, `PendingCuts`, `CommittedCuts` and `Entities`.
- `capture_state()` gains a `decals` key and `restore_state()` restores it, so a decal travels with the level, through a `.hflevel` round trip and through a state restore. Each entry is the decal's local transform, its size and its albedo texture path. An entry that cannot be read costs that entry, not the load, the same way a brush entry does. `decals` is registered as an array key in the state validator.
- `_place_decal()` wraps the placement in the capture and restore pair `HFPolygonTool._finalize_brush()` and `HFPathTool._build_path()` use, so Ctrl+Z takes the decal away instead of undoing the action before it.
- Each decal gets a name of its own. They were all called `HFDecal`, so Godot renamed the second one to `@Decal@15`.

The ghost under the cursor stays out of the container and out of the level, and there is a test holding it there.

A level saved before this change has no `decals` key, and decals placed under the root by the old tool are not in the new container, so they stay where they are as scene decoration rather than being removed.

Tests: the decal is in the state, survives a capture and restore, survives the `HFLevelIO` encoding a `.hflevel` puts the state through, is removed by restoring the state from before it and put back by the one after, two decals get distinct names, and the preview is not one of them. All six fail without the fix.

Changelog, the user guide tool table and the data portability doc updated.