### PR TITLE
Stop an I/O input from calling engine methods, and survive malformed output metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,26 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **An entity I/O input named after a Node method called it, and one malformed
+  entity took its whole subtree out of the wiring** (#406, #407).
+  `_deliver_to_target()` resolved an input name by calling a method of that name,
+  and `has_method()` answers for everything `Object` and `Node` implement. The
+  snake_case fallback made the collision easy to hit from ordinary PascalCase
+  naming: an input called `QueueFree` deleted the target, `Free` would have
+  deleted it mid-frame, and `Hide`, `SetScript` and `ReplaceBy` are each one typo
+  away. The input name is free text from a dock field with nothing between it
+  and there, so a name that collided with the engine was destructive while a
+  plain typo was silent. Only methods the target's own script defines are called
+  now; an engine method, or a name starting with an underscore, falls through to
+  `_on_io_input` and the user signal with a warning naming both. Separately,
+  `_collect_connections()` read `entity_io_outputs` into a typed local, so one
+  entity whose metadata was not an Array - a hand-edited scene, an older format -
+  was a runtime error that unwound the function including the recursion at the
+  bottom of it, and everything nested under that entity dropped out of the
+  wiring. This is the shipped game, not the editor: the level loads, the error
+  goes to a log nobody reads, and a door somewhere never opens. The value is
+  type-checked, the bad entity is skipped with a warning naming it, and its
+  children are scanned as usual.
 - **A decal was not part of the level** (#403, #404). `_place_decal()` added a
   `Decal` node under the `LevelRoot` and nothing else knew about it.
   `capture_state()` had no decal key, and a `.hflevel` is what `capture_state()`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,616 tests across 191 test scripts (3,609 passing plus seven intentional no-assert safety tests; 18,262 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,622 tests across 191 test scripts (3,615 passing plus seven intentional no-assert safety tests; 18,277 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,616 tests** across **191 scripts** (**3,609 passing** plus seven intentional no-assert safety tests; **18,262 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,622 tests** across **191 scripts** (**3,615 passing** plus seven intentional no-assert safety tests; **18,277 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3609%20passing-brightgreen" alt="3609 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3615%20passing-brightgreen" alt="3615 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,616 tests across 191 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,622 tests across 191 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/hf_io_runtime.gd
+++ b/addons/hammerforge/hf_io_runtime.gd
@@ -257,11 +257,41 @@ func _deliver(
 		_deliver_to_target(target, input_name, parameter)
 
 
+## Whether an input name may be delivered by calling a method of that name.
+##
+## `has_method()` answers for everything `Object` and `Node` implement, and the
+## snake_case fallback makes the collision easy to hit from ordinary PascalCase
+## naming: an input called `QueueFree` deleted the target, `Free` would have
+## deleted it mid-frame, and `SetScript`, `Hide` and `ReplaceBy` are all one
+## typo away. The input name is free text from a dock field with nothing between
+## it and here, so a name that collides with the engine was destructive while a
+## plain typo was silent.
+##
+## Only methods the target's own script defines are called. An engine method, or
+## anything starting with an underscore, falls through to `_on_io_input` and then
+## to the user signal, which is where a game that means to hide a node on an
+## input can handle it deliberately.
+func _is_callable_input(target: Node, method_name: String) -> bool:
+	if method_name.begins_with("_"):
+		return false
+	# Default third argument: ancestors count. `queue_free` is on `Node`, and the
+	# target is a `Node3D` or further down.
+	if ClassDB.class_has_method(target.get_class(), method_name):
+		push_warning(
+			(
+				"HFIORuntime: input '%s' on '%s' names an engine method - not calling it."
+				% [method_name, target.name]
+			)
+		)
+		return false
+	return true
+
+
 ## Deliver an input to a single target node.
 func _deliver_to_target(target: Node, input_name: String, parameter: String) -> void:
 	# 1) Try calling the input method directly on the target (e.g. "Open", "TurnOn").
 	var method_name: String = input_name
-	if target.has_method(method_name):
+	if target.has_method(method_name) and _is_callable_input(target, method_name):
 		if parameter != "":
 			target.call(method_name, parameter)
 		else:
@@ -270,7 +300,11 @@ func _deliver_to_target(target: Node, input_name: String, parameter: String) -> 
 
 	# 2) Try snake_case variant (e.g. "TurnOn" -> "turn_on").
 	var snake_name: String = _to_snake_case(method_name)
-	if snake_name != method_name and target.has_method(snake_name):
+	if (
+		snake_name != method_name
+		and target.has_method(snake_name)
+		and _is_callable_input(target, snake_name)
+	):
 		if parameter != "":
 			target.call(snake_name, parameter)
 		else:
@@ -346,7 +380,23 @@ func _collect_connections(node: Node) -> void:
 		for child in node.get_children():
 			_collect_connections(child)
 		return
-	var outputs: Array = node.get_meta("entity_io_outputs", [])
+	# Not a typed local. A value of another type here - a String from a
+	# hand-edited scene, an older metadata format, a Dictionary someone wrote by
+	# hand - used to be a runtime error on this line, and GDScript unwinds the
+	# whole function, including the recursion at the bottom. One bad entity took
+	# every entity under it out of the wiring, in the shipped game, with nothing
+	# but a line in a log nobody reads.
+	var raw_outputs = node.get_meta("entity_io_outputs", [])
+	var outputs: Array = []
+	if raw_outputs is Array:
+		outputs = raw_outputs
+	elif raw_outputs != null:
+		push_warning(
+			(
+				"HFIORuntime: '%s' has entity_io_outputs of type %s, not a list - skipping it."
+				% [node.name, type_string(typeof(raw_outputs))]
+			)
+		)
 	if not outputs.is_empty():
 		var id: int = node.get_instance_id()
 		var source_name: String = node.name

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -698,6 +698,8 @@ Entity I/O connections are automatically translated into live Godot signals when
 3. Generic handler (`_on_io_input(input_name, parameter)`)
 4. User signal (`io_Open` emitted on the target)
 
+Only methods the target's own script defines are called at steps 1 and 2. An input whose name resolves to an engine method -- `QueueFree`, `Free`, `Hide`, `SetScript` and anything else on `Node` or `Object`, before or after the snake-case conversion -- is not called, and falls through to the generic handler and the user signal instead, with a warning naming the input and the target. Handle those deliberately in `_on_io_input` if your game wants them.
+
 **Firing outputs from game scripts**:
 ```gdscript
 # From any entity script at runtime:

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,616 tests across 191 scripts**: **3,609 passing tests**, seven intentional no-assert safety tests, and **18,262 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,622 tests across 191 scripts**: **3,615 passing tests**, seven intentional no-assert safety tests, and **18,277 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_io_runtime.gd
+++ b/tests/test_io_runtime.gd
@@ -779,3 +779,84 @@ func test_fire_ignores_empty_entity_name_meta():
 
 	dispatcher.fire("", "OnPressed")
 	assert_eq(door.received_calls.size(), 0, "An empty alias must not become a lookup key")
+
+
+# ===========================================================================
+# Names that collide with the engine, and metadata that is not a list
+# ===========================================================================
+
+
+func test_an_input_named_after_an_engine_method_does_not_call_it():
+	# `has_method()` answers for everything Node implements, and the snake_case
+	# fallback turns ordinary PascalCase naming into a collision: an input called
+	# QueueFree used to delete the target.
+	var button := _make_entity(scene_root, "Button1")
+	var door := _make_target_entity(scene_root, "Door1")
+	_add_connection(button, "OnTrigger", "Door1", "QueueFree")
+	_wire_dispatcher()
+	dispatcher.fire("Button1", "OnTrigger")
+	assert_true(is_instance_valid(door), "The target is still there")
+	assert_false(door.is_queued_for_deletion(), "and is not on its way out")
+	assert_eq(door.received_calls.size(), 1, "The input went to the generic handler instead")
+	assert_eq(door.received_calls[0]["method"], "_on_io_input")
+	assert_eq(door.received_calls[0]["input"], "QueueFree")
+
+
+func test_an_input_named_hide_is_left_to_the_target_to_handle():
+	var button := _make_entity(scene_root, "Button1")
+	var door := _make_target_entity(scene_root, "Door1")
+	_add_connection(button, "OnTrigger", "Door1", "Hide")
+	_wire_dispatcher()
+	dispatcher.fire("Button1", "OnTrigger")
+	assert_true(door.visible, "The engine method was not called behind the game's back")
+	assert_eq(door.received_calls[0]["method"], "_on_io_input", "It went to the handler")
+
+
+func test_an_input_the_target_script_defines_is_still_called():
+	# The guard must not cost the ordinary case.
+	var button := _make_entity(scene_root, "Button1")
+	var door := _make_target_entity(scene_root, "Door1")
+	_add_connection(button, "OnPressed", "Door1", "Open")
+	_wire_dispatcher()
+	dispatcher.fire("Button1", "OnPressed")
+	assert_eq(door.received_calls.size(), 1)
+	assert_eq(door.received_calls[0]["method"], "Open", "A script method still answers")
+
+
+func test_an_input_starting_with_an_underscore_is_not_called():
+	var button := _make_entity(scene_root, "Button1")
+	var door := _make_target_entity(scene_root, "Door1")
+	_add_connection(button, "OnTrigger", "Door1", "_ready")
+	_wire_dispatcher()
+	dispatcher.fire("Button1", "OnTrigger")
+	assert_eq(door.received_calls[0]["method"], "_on_io_input", "Engine callbacks are not inputs")
+
+
+func test_malformed_outputs_metadata_costs_only_that_entity():
+	# The typed local used to make this a runtime error that unwound the whole
+	# scan, including the recursion into the children, so everything nested under
+	# the bad entity dropped out of the wiring.
+	var broken := _make_entity(scene_root, "BrokenButton")
+	broken.set_meta("entity_io_outputs", "not a list")
+	var nested := _make_entity(broken, "NestedButton")
+	var good := _make_entity(scene_root, "GoodButton")
+	var door := _make_target_entity(scene_root, "Door1")
+	_add_connection(nested, "OnPressed", "Door1", "Open")
+	_add_connection(good, "OnPressed", "Door1", "Open")
+	_wire_dispatcher()
+	assert_true(
+		dispatcher._source_name_to_ids.has("NestedButton"),
+		"The entity under the bad one is still wired"
+	)
+	assert_true(dispatcher._source_name_to_ids.has("GoodButton"), "and so is its sibling")
+	assert_false(dispatcher._source_name_to_ids.has("BrokenButton"), "The bad one is skipped")
+	dispatcher.fire("NestedButton", "OnPressed")
+	assert_eq(door.received_calls.size(), 1, "and the nested connection fires")
+
+
+func test_malformed_outputs_metadata_does_not_stop_the_entity_cache():
+	var broken := _make_entity(scene_root, "BrokenButton")
+	broken.set_meta("entity_io_outputs", {"output_name": "OnPressed"})
+	var nested := _make_entity(broken, "NestedDoor")
+	_wire_dispatcher()
+	assert_true(dispatcher._entity_cache.has("NestedDoor"), "Nested entities are still found")


### PR DESCRIPTION
Fixes #406. Fixes #407.

Both in `hf_io_runtime.gd`, both about trusting what arrives.

**An input named after a Node method called it.** `_deliver_to_target()` resolves an input name by calling a method of that name, and `has_method()` answers for everything `Object` and `Node` implement. The snake_case fallback is what makes the collision easy to reach from ordinary PascalCase naming: `QueueFree` to `queue_free`, `Free` to `free`, `Hide` to `hide`, `SetScript` to `set_script`. An input called `QueueFree` deleted the target. The input name is free text from a dock field with nothing between it and there, so a name that collided with the engine was destructive while a typo was silent.

Steps 1 and 2 now only call a method the target's own script defines. The test is `ClassDB.class_has_method(target.get_class(), name)`, with inheritance, which is true for an engine method and false for a script one; names starting with an underscore are refused too, so an input cannot call `_ready`. Anything refused falls through to `_on_io_input` and then the user signal, which is where a game that means to hide a node on an input handles it deliberately. A warning names the input and the target rather than leaving it silent.

Entity definitions do not declare their inputs, so there is no per-class allowlist to check against. This is the structural rule the issue named as the fallback.

**One malformed entity took its subtree with it.** `_collect_connections()` read the metadata into `var outputs: Array`, so a value of another type was a runtime error on that line, and GDScript unwinds the whole function including the recursion at the bottom. Siblings survived, everything nested under the bad entity did not. The value is type-checked, the entity is skipped with a warning naming it, and the children are scanned as usual. `_cache_entities()` was already fine because it reads a String meta with `str()`.

Tests: QueueFree does not delete the target and reaches the generic handler, Hide does not hide it, an underscore name is refused, a script-defined `Open` is still called, and a broken entity's nested child still fires its connection. Four fail without the fix.

Changelog and the I/O runtime section of the user guide updated.