### PR TITLE
Validate the preferences file and write it atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,25 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **User preferences trusted the file completely and were not written
+  atomically** (#408, #409). `load_prefs()` assigned the parsed JSON straight to
+  `data`, and every accessor then reads its container into a typed local, so one
+  value of the wrong type was not a wrong preference - it was an error on every
+  call that touched it. A `collapsed_sections` of `"all"` broke every section
+  read, `add_recent_file()` aborted before its write so the path was dropped
+  without a word, and `dismiss_hint()` could not record a dismissal so the hint
+  came back forever. The loaded file is now held to a schema: a value that
+  cannot be used is replaced by the default and reported once naming the file
+  and the key, the way `HFKeymap._validated()` does for the keymap, and a key
+  this version does not know is kept rather than thrown away. A number outside
+  its usable range is clamped, on load and in `set_pref()`, so an autosave
+  interval of -1 or a grid snap of 0 cannot reach the disk. `save()` also opened
+  the destination with `FileAccess.WRITE`, which truncates first, so an editor
+  that went down mid-write left a file that would not parse - and a file that
+  would not parse was silently replaced by the defaults and overwritten by the
+  next save, taking the evidence with it. The write goes beside the file and is
+  moved into place, and a file that cannot be read is kept as
+  `hammerforge_prefs.json.unreadable` with a warning that says why.
 - **An entity I/O input named after a Node method called it, and one malformed
   entity took its whole subtree out of the wiring** (#406, #407).
   `_deliver_to_target()` resolved an input name by calling a method of that name,

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,622 tests across 191 test scripts (3,615 passing plus seven intentional no-assert safety tests; 18,277 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,631 tests across 191 test scripts (3,624 passing plus seven intentional no-assert safety tests; 18,301 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,622 tests** across **191 scripts** (**3,615 passing** plus seven intentional no-assert safety tests; **18,277 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,631 tests** across **191 scripts** (**3,624 passing** plus seven intentional no-assert safety tests; **18,301 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3615%20passing-brightgreen" alt="3615 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3624%20passing-brightgreen" alt="3624 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,622 tests across 191 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,631 tests across 191 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/hf_user_prefs.gd
+++ b/addons/hammerforge/hf_user_prefs.gd
@@ -21,12 +21,107 @@ static func load_prefs() -> HFUserPrefs:
 		var file = FileAccess.open(PREFS_PATH, FileAccess.READ)
 		if file:
 			var text = file.get_as_text()
-			var parsed = JSON.parse_string(text)
-			if parsed is Dictionary:
-				prefs.data = parsed
+			file.close()
+			# The instance parser rather than `JSON.parse_string()`, because it
+			# reports why the file would not read instead of pushing an engine
+			# error and returning null.
+			var parser := JSON.new()
+			var parse_err := parser.parse(text)
+			if parse_err == OK and parser.data is Dictionary:
+				prefs.data = _validated(parser.data)
 				return prefs
+			# The file is there and cannot be read. It used to be replaced by the
+			# defaults in silence and overwritten by the next save, so the user
+			# lost their grid size, recent files, collapsed sections and dismissed
+			# hints and was told nothing. Keep it and say so.
+			var reason := (
+				parser.get_error_message() if parse_err != OK else "it is not a set of values"
+			)
+			_move_aside(PREFS_PATH, reason)
 	prefs.data = _defaults()
 	return prefs
+
+
+## The unreadable file, kept beside the one that replaces it.
+static func _move_aside(path: String, reason: String) -> void:
+	var kept := path + ".unreadable"
+	var abs_path := ProjectSettings.globalize_path(path)
+	var abs_kept := ProjectSettings.globalize_path(kept)
+	if FileAccess.file_exists(kept):
+		DirAccess.remove_absolute(abs_kept)
+	if DirAccess.rename_absolute(abs_path, abs_kept) == OK:
+		HFLog.warn(
+			(
+				"%s could not be read (%s). It is kept as %s and the defaults are in use."
+				% [path, reason, kept]
+			)
+		)
+	else:
+		HFLog.warn("%s could not be read (%s). The defaults are in use." % [path, reason])
+
+
+## What each preference has to be to be usable, and what a number has to be
+## within. Every one of these has an accessor that reads it into a typed local,
+## so a value of the wrong type is not a wrong preference, it is an error on
+## every call that touches it: one bad `collapsed_sections` broke every section
+## read, and `add_recent_file()` aborted before its write so the path was
+## dropped in silence.
+const SCHEMA := {
+	"grid_snap": {"type": TYPE_FLOAT, "min": 0.001},
+	"autosave_interval": {"type": TYPE_INT, "min": 0},
+	"recent_files": {"type": TYPE_ARRAY},
+	"collapsed_sections": {"type": TYPE_DICTIONARY},
+	"last_tool_id": {"type": TYPE_INT},
+	"show_hud": {"type": TYPE_BOOL},
+	"show_welcome": {"type": TYPE_BOOL},
+	"power_user_overlays": {"type": TYPE_BOOL},
+	"hints_dismissed": {"type": TYPE_DICTIONARY},
+}
+
+
+## The loaded preferences with anything unusable dropped, reported once naming
+## the file and the key. `HFKeymap._validated()` does this for the keymap, for
+## the same reason.
+static func _validated(loaded: Dictionary) -> Dictionary:
+	var out := _defaults()
+	for key in loaded:
+		var pref_name := str(key)
+		var value = loaded[key]
+		if not SCHEMA.has(pref_name):
+			# Not ours to judge: a key from a newer version, or one a user added.
+			out[pref_name] = value
+			continue
+		out[pref_name] = _usable(pref_name, value, out[pref_name])
+	return out
+
+
+## One value, held to the schema or replaced by the fallback.
+static func _usable(pref_name: String, value: Variant, fallback: Variant) -> Variant:
+	var rule: Dictionary = SCHEMA[pref_name]
+	var wanted: int = rule["type"]
+	# JSON has one number type, so an int preference comes back as a float and a
+	# float one can come back as an int. Neither is the user getting it wrong.
+	if wanted == TYPE_FLOAT and value is int:
+		value = float(value)
+	elif wanted == TYPE_INT and value is float and value == floor(value):
+		value = int(value)
+	if typeof(value) != wanted:
+		HFLog.warn(
+			(
+				"%s: '%s' is a %s, not a %s. The default is used."
+				% [PREFS_PATH, pref_name, type_string(typeof(value)), type_string(wanted)]
+			)
+		)
+		return fallback
+	if rule.has("min") and value < rule["min"]:
+		HFLog.warn(
+			(
+				"%s: '%s' is %s, below the smallest usable value %s."
+				% [PREFS_PATH, pref_name, str(value), str(rule["min"])]
+			)
+		)
+		return rule["min"]
+	return value
 
 
 static func _defaults() -> Dictionary:
@@ -44,12 +139,18 @@ static func _defaults() -> Dictionary:
 
 
 ## Save preferences to disk.
+##
+## Written beside the destination and moved into place, so an editor that goes
+## down mid-write leaves the old preferences rather than half of the new ones.
+## `FileAccess.WRITE` truncates first, which is how the file got into a state
+## that would not parse.
 func save() -> void:
 	if not persistence_enabled:
 		return
-	var file = FileAccess.open(PREFS_PATH, FileAccess.WRITE)
-	if file:
-		file.store_string(JSON.stringify(data, "\t"))
+	var payload := JSON.stringify(data, "\t").to_utf8_buffer()
+	var err := HFLevelIO.write_bytes_atomic(PREFS_PATH, payload)
+	if err != OK:
+		HFLog.warn("%s could not be written (error %d). Preferences not saved." % [PREFS_PATH, err])
 
 
 ## Get a preference value with fallback to built-in default.
@@ -62,8 +163,12 @@ func get_pref(key: String, fallback: Variant = null) -> Variant:
 	return fallback
 
 
-## Set a preference value.
+## Set a preference value. A value the schema knows is held to it here too, so a
+## caller cannot write an autosave interval of -1 or a grid snap of 0 to disk.
 func set_pref(key: String, value: Variant) -> void:
+	if SCHEMA.has(key):
+		data[key] = _usable(key, value, get_pref(key))
+		return
 	data[key] = value
 
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,622 tests across 191 scripts**: **3,615 passing tests**, seven intentional no-assert safety tests, and **18,277 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,631 tests across 191 scripts**: **3,624 passing tests**, seven intentional no-assert safety tests, and **18,301 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_user_prefs.gd
+++ b/tests/test_user_prefs.gd
@@ -4,15 +4,38 @@ const HFUserPrefsType = preload("res://addons/hammerforge/hf_user_prefs.gd")
 
 var prefs: HFUserPrefsType
 
+## The file tests below write the real preferences path, which is a developer's
+## own file when the suite runs locally. It is moved aside for the run and put
+## back afterwards.
+const BACKUP_PATH := "user://hammerforge_prefs.json.test_backup"
+
 
 func before_each():
 	prefs = HFUserPrefsType.new()
 	prefs.persistence_enabled = false
 	prefs.data = HFUserPrefsType._defaults()
+	_move(HFUserPrefsType.PREFS_PATH, BACKUP_PATH)
 
 
 func after_each():
 	prefs = null
+	for leftover in [
+		HFUserPrefsType.PREFS_PATH,
+		HFUserPrefsType.PREFS_PATH + ".unreadable",
+		HFUserPrefsType.PREFS_PATH + ".writing",
+		HFUserPrefsType.PREFS_PATH + ".previous",
+	]:
+		if FileAccess.file_exists(leftover):
+			DirAccess.remove_absolute(ProjectSettings.globalize_path(leftover))
+	_move(BACKUP_PATH, HFUserPrefsType.PREFS_PATH)
+
+
+func _move(from_path: String, to_path: String) -> void:
+	if not FileAccess.file_exists(from_path):
+		return
+	DirAccess.rename_absolute(
+		ProjectSettings.globalize_path(from_path), ProjectSettings.globalize_path(to_path)
+	)
 
 
 # -- Tests ----------------------------------------------------------------------
@@ -158,3 +181,103 @@ func test_hint_dismissed_roundtrip():
 		loaded.is_hint_dismissed("paint_floor"), "paint_floor hint should survive roundtrip"
 	)
 	assert_false(loaded.is_hint_dismissed("draw_idle"), "draw_idle should still be undismissed")
+
+
+# -- What the file is allowed to contain ---------------------------------------
+
+
+func test_a_wrong_typed_value_falls_back_to_the_default():
+	# Each accessor reads its container into a typed local, so one wrong type is
+	# not a wrong preference, it is an error on every call that touches it.
+	var loaded = (
+		HFUserPrefsType
+		. _validated(
+			{
+				"collapsed_sections": "all",
+				"recent_files": "res://a.tscn",
+				"hints_dismissed": 3,
+			}
+		)
+	)
+	assert_eq(loaded["collapsed_sections"], {}, "A String is not a set of sections")
+	assert_eq(loaded["recent_files"], [], "nor a list of recent files")
+	assert_eq(loaded["hints_dismissed"], {}, "and a number is not a set of dismissals")
+
+
+func test_the_accessors_work_after_a_wrong_typed_file():
+	var broken = HFUserPrefsType.new()
+	broken.persistence_enabled = false
+	broken.data = HFUserPrefsType._validated(
+		{"collapsed_sections": "all", "recent_files": "res://a.tscn", "hints_dismissed": 3}
+	)
+	assert_null(broken.get_section_collapsed("Bake"), "A section reads without erroring")
+	broken.add_recent_file("res://kept.hflevel")
+	assert_eq(broken.get_recent_files(), ["res://kept.hflevel"], "A recent file is recorded")
+	broken.dismiss_hint("draw_idle")
+	assert_true(broken.is_hint_dismissed("draw_idle"), "and a dismissal sticks")
+
+
+func test_a_good_file_is_left_alone():
+	var loaded = HFUserPrefsType._validated(
+		{"grid_snap": 64.0, "show_hud": false, "recent_files": ["res://a.hflevel"]}
+	)
+	assert_eq(loaded["grid_snap"], 64.0)
+	assert_eq(loaded["show_hud"], false)
+	assert_eq(loaded["recent_files"], ["res://a.hflevel"])
+	assert_eq(loaded["autosave_interval"], 300, "and the keys it did not carry come from defaults")
+
+
+func test_json_numbers_are_not_treated_as_the_wrong_type():
+	# JSON has one number type, so an int preference comes back as a float.
+	var loaded = HFUserPrefsType._validated({"autosave_interval": 120.0, "grid_snap": 8})
+	assert_eq(loaded["autosave_interval"], 120, "120.0 is the interval the user set")
+	assert_eq(loaded["grid_snap"], 8.0, "and 8 is the grid snap they set")
+
+
+func test_a_key_this_version_does_not_know_is_kept():
+	var loaded = HFUserPrefsType._validated({"some_future_pref": "keep me"})
+	assert_eq(loaded["some_future_pref"], "keep me", "A newer version's key survives a load")
+
+
+func test_a_value_below_the_usable_range_is_clamped():
+	var loaded = HFUserPrefsType._validated({"autosave_interval": -1, "grid_snap": 0.0})
+	assert_eq(loaded["autosave_interval"], 0, "A negative interval is not an interval")
+	assert_almost_eq(loaded["grid_snap"], 0.001, 0.0001, "and a zero grid snap is not a snap")
+
+
+func test_set_pref_refuses_a_value_the_file_could_not_use():
+	prefs.set_pref("autosave_interval", -1)
+	assert_eq(prefs.get_pref("autosave_interval"), 0, "Clamped rather than written as -1")
+	prefs.set_pref("grid_snap", "big")
+	assert_eq(prefs.get_pref("grid_snap"), 16.0, "and a String leaves the grid snap alone")
+
+
+func test_a_file_that_will_not_parse_is_kept_rather_than_overwritten():
+	var path: String = HFUserPrefsType.PREFS_PATH
+	var kept := path + ".unreadable"
+	var damaged := '{"grid_snap": 64.0, "recent_files": ["res://a.tscn", "res://'
+	var file = FileAccess.open(path, FileAccess.WRITE)
+	assert_not_null(file, "The test can write the prefs file")
+	file.store_string(damaged)
+	file.close()
+
+	var loaded = HFUserPrefsType.load_prefs()
+	assert_eq(loaded.get_pref("grid_snap"), 16.0, "The defaults are in use")
+	assert_true(FileAccess.file_exists(kept), "and the damaged file is kept, not thrown away")
+	var recovered = FileAccess.open(kept, FileAccess.READ)
+	assert_eq(recovered.get_as_text(), damaged, "with what was in it")
+	recovered.close()
+
+
+func test_save_does_not_truncate_the_file_it_is_replacing():
+	# `FileAccess.WRITE` truncates first, so a crash mid-write left half a file.
+	# This writes beside the destination and moves it into place.
+	var path: String = HFUserPrefsType.PREFS_PATH
+	var writer = HFUserPrefsType.new()
+	writer.data = HFUserPrefsType._defaults()
+	writer.set_pref("grid_snap", 32.0)
+	writer.save()
+	assert_true(FileAccess.file_exists(path), "The file is written")
+	assert_false(FileAccess.file_exists(path + ".writing"), "and the temporary is not left behind")
+	var back = HFUserPrefsType.load_prefs()
+	assert_eq(back.get_pref("grid_snap"), 32.0, "and reads back")


### PR DESCRIPTION
Fixes #408. Fixes #409.

One file, two halves of the same story: nothing checked what came off disk, and the way it went onto disk is what put bad things there.

**Nothing was validated.** Every accessor reads its container into a typed local, so one value of the wrong type was not a wrong preference, it was an error on every call that touched it. A `collapsed_sections` of `"all"` broke every section read, `add_recent_file()` aborted before its write so the path was dropped without a word, `get_recent_files()` returned nothing, and `dismiss_hint()` could not record a dismissal so the hint came back forever.

The loaded file is now held to a `SCHEMA`, the way `HFKeymap._validated()` holds the keymap. A value that cannot be used is replaced by the default and reported once naming the file and the key. A key this version does not know is kept, so a newer version's preferences survive a load in an older one. JSON has one number type, so an int preference arriving as a float is coerced rather than rejected. A number below its usable range is clamped, on load and in `set_pref()`, so `autosave_interval` of -1 and `grid_snap` of 0 cannot reach the disk.

**The write was not atomic and the failure was silent.** `FileAccess.WRITE` truncates first, so an editor that went down between the truncate and the flush left half a file. `load_prefs()` then got `null`, fell through to the defaults and said nothing, and the next `save()` overwrote the damaged file, so the evidence went too. The write now goes through `HFLevelIO.write_bytes_atomic()`, the same beside-then-replace the level writer uses. A file that exists and cannot be read is kept as `hammerforge_prefs.json.unreadable` with a warning that says why: the loader uses the `JSON` instance parser rather than `JSON.parse_string()` so it has the reason to report rather than an engine error and a null.

Tests: wrong-typed values fall back and the accessors then work, a good file is left alone, JSON numbers are not treated as the wrong type, an unknown key is kept, out-of-range numbers are clamped on load and on set, a file that will not parse is kept rather than thrown away, and a save leaves no temporary behind and reads back.

The two file tests write the real preferences path, which is a developer's own file when the suite runs locally, so it is moved aside for the run and put back after.

Changelog updated. No doc describes the old behaviour; `tools/prepare_editor_smoke.gd` still runs, and its `tutorial_step` key passes through as an unknown key.