### PR TITLE
Keep the rest of a material when a face is painted over it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,24 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **Painting a face threw away everything about its material but three scalars,
+  and replaced a ShaderMaterial outright** (#412, #413). The editor preview and
+  the bake both built the painted material as a bare `StandardMaterial3D`
+  carrying copies of `roughness`, `metallic` and `albedo_color`. So a painted
+  face lost its normal map, its roughness and metallic maps, its emission and
+  its UV transform. On a tiled wall the UV scale going back to 1 is the visible
+  one - the texture on the painted face is suddenly four times the size of the
+  one beside it - and the normal map vanishing is the one people spend an
+  afternoon on before finding it. The composite only ever needed to replace the
+  albedo, so it now duplicates the base and sets `albedo_texture` on the copy,
+  which keeps everything else including slots added to `StandardMaterial3D` in a
+  future Godot version. A `ShaderMaterial` failed the `is StandardMaterial3D`
+  test, so the new material was built with nothing on it but the composited
+  albedo and the shader was silently gone from that surface. It is now refused
+  rather than substituted, the way `HFMaterialAtlas.build_atlas()` already puts
+  one in `fallback_keys` rather than pretending it can pack it: the face keeps
+  its shader, the paint is not drawn, and a warning says so once. Both call
+  sites now share one composite on `FaceData` rather than keeping a copy each.
 - **A level with more texture than the atlas holds took the atlas down** (#416).
   `_shelf_pack()` reports failure by returning zeros, and `build_atlas()` read
   `width`, `height` and `placements` without looking at `success`. So the

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,634 tests across 191 test scripts (3,627 passing plus seven intentional no-assert safety tests; 18,332 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,641 tests across 192 test scripts (3,634 passing plus seven intentional no-assert safety tests; 18,356 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,634 tests** across **191 scripts** (**3,627 passing** plus seven intentional no-assert safety tests; **18,332 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,641 tests** across **192 scripts** (**3,634 passing** plus seven intentional no-assert safety tests; **18,356 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3627%20passing-brightgreen" alt="3627 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3634%20passing-brightgreen" alt="3634 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,634 tests across 191 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,641 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/baker.gd
+++ b/addons/hammerforge/baker.gd
@@ -508,17 +508,7 @@ func _resolve_face_material(
 		base = fallback
 	var painted = face.get_painted_albedo()
 	if painted:
-		var tex = ImageTexture.create_from_image(painted)
-		if not tex:
-			return base
-		var mat = StandardMaterial3D.new()
-		if base is StandardMaterial3D:
-			var base_std := base as StandardMaterial3D
-			mat.roughness = base_std.roughness
-			mat.metallic = base_std.metallic
-			mat.albedo_color = base_std.albedo_color
-		mat.albedo_texture = tex
-		return mat
+		return FaceData.composite_painted_material(base, painted)
 	return base
 
 

--- a/addons/hammerforge/brush_instance.gd
+++ b/addons/hammerforge/brush_instance.gd
@@ -912,15 +912,9 @@ func _material_for_face(
 	if include_paint:
 		var painted = face.get_painted_albedo()
 		if painted:
-			var tex = ImageTexture.create_from_image(painted)
-			var mat = StandardMaterial3D.new()
-			if base_mat is StandardMaterial3D:
-				var base_std := base_mat as StandardMaterial3D
-				mat.roughness = base_std.roughness
-				mat.metallic = base_std.metallic
-				mat.albedo_color = base_std.albedo_color
-			mat.albedo_texture = tex
-			return mat
+			var mat := FaceData.composite_painted_material(base_mat, painted)
+			if mat:
+				return mat
 	if base_mat:
 		return base_mat
 	return _make_default_material()

--- a/addons/hammerforge/face_data.gd
+++ b/addons/hammerforge/face_data.gd
@@ -628,6 +628,64 @@ func _compute_normal() -> void:
 		normal = Vector3.UP
 
 
+## The material a painted face renders with: the base with the composited albedo
+## on it, and everything else about it kept.
+##
+## This used to build a bare `StandardMaterial3D` and copy three scalars across -
+## `roughness`, `metallic` and `albedo_color` - so painting a face threw away its
+## normal map, its roughness and metallic maps, its emission and its UV
+## transform. On a tiled wall the UV scale going back to 1 is the visible one:
+## the texture on the painted face is suddenly four times the size of the one
+## beside it. Duplicating the base keeps all of it, including slots added to
+## `StandardMaterial3D` in a future Godot version.
+##
+## A `ShaderMaterial` is refused rather than substituted. There is no way to
+## reproduce one with an albedo texture on it, and building a plain
+## `StandardMaterial3D` instead left one baked surface flat beside its
+## neighbours with the shader silently gone. `HFMaterialAtlas.build_atlas()`
+## already treats a ShaderMaterial this way, putting it in `fallback_keys` rather
+## than pretending it can pack it. The base comes back unpainted, with a warning.
+static func composite_painted_material(base: Material, painted: Image) -> Material:
+	if painted == null:
+		return base
+	var tex := ImageTexture.create_from_image(painted)
+	if tex == null:
+		return base
+	if base is ShaderMaterial:
+		_warn_once_about_shader_paint(base)
+		return base
+	var mat: StandardMaterial3D
+	if base is StandardMaterial3D:
+		mat = (base as StandardMaterial3D).duplicate() as StandardMaterial3D
+	else:
+		# No palette material, or one this cannot read. The composite is the
+		# whole surface.
+		mat = StandardMaterial3D.new()
+	mat.albedo_texture = tex
+	return mat
+
+
+## Once per material, not once per face per rebuild. `rebuild_preview()` runs on
+## every paint sample.
+static var _shader_paint_warned: Dictionary = {}
+
+
+static func _warn_once_about_shader_paint(base: Material) -> void:
+	var id := base.get_instance_id()
+	if _shader_paint_warned.has(id):
+		return
+	_shader_paint_warned[id] = true
+	(
+		HFLog
+		. warn(
+			(
+				"HammerForge: a face painted over a ShaderMaterial keeps the shader and drops the paint."
+				+ " A shader cannot be composited over."
+			)
+		)
+	)
+
+
 func _blend_color(base: Color, tex: Color, weight: float, mode: int) -> Color:
 	match mode:
 		PaintBlend.MULTIPLY:

--- a/docs/HammerForge_Texture_Materials.md
+++ b/docs/HammerForge_Texture_Materials.md
@@ -114,6 +114,8 @@ Controls:
 Notes:
 - Weights are stored per face as images (default 256x256).
 - A face takes at most 8 paint layers. They are composited into one image at every texel on each preview rebuild and again at bake, so past a handful each extra layer costs preview time, save size and load time without looking different.
+- The painted composite replaces the material's albedo texture and nothing else. The face keeps its normal map, roughness and metallic maps, emission, UV scale and offset, and cull mode, in the preview and in the bake.
+- A face whose material is a `ShaderMaterial` cannot be painted over: there is no way to composite an albedo image into a shader, so the shader is kept, the paint is not drawn, and a warning says so. The material atlas treats a `ShaderMaterial` the same way.
 - Surface paint updates the DraftBrush preview immediately.
 - Surface paint does not modify floor paint layers.
 - If paint affects floors, set `Paint Target = Surface` in the Paint tab → Surface Paint section.

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,634 tests across 191 scripts**: **3,627 passing tests**, seven intentional no-assert safety tests, and **18,332 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,641 tests across 192 scripts**: **3,634 passing tests**, seven intentional no-assert safety tests, and **18,356 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_painted_face_material.gd
+++ b/tests/test_painted_face_material.gd
@@ -1,0 +1,130 @@
+extends GutTest
+## What a painted face renders with.
+##
+## Painting a face composites its paint layers over the palette material's albedo
+## image. The composite used to be built on a bare `StandardMaterial3D` carrying
+## three copied scalars, so everything else about the material was thrown away,
+## and a `ShaderMaterial` was silently replaced by a plain one.
+
+const FaceData = preload("res://addons/hammerforge/face_data.gd")
+
+
+func _painted_image() -> Image:
+	var img := Image.create(8, 8, false, Image.FORMAT_RGBA8)
+	img.fill(Color(1.0, 0.0, 0.0, 1.0))
+	return img
+
+
+func _texture(color: Color) -> ImageTexture:
+	var img := Image.create(4, 4, false, Image.FORMAT_RGBA8)
+	img.fill(color)
+	return ImageTexture.create_from_image(img)
+
+
+func _full_material() -> StandardMaterial3D:
+	var mat := StandardMaterial3D.new()
+	mat.albedo_color = Color(0.4, 0.5, 0.6, 1.0)
+	mat.albedo_texture = _texture(Color.BLUE)
+	mat.normal_enabled = true
+	mat.normal_texture = _texture(Color(0.5, 0.5, 1.0, 1.0))
+	mat.normal_scale = 0.75
+	mat.roughness = 0.3
+	mat.roughness_texture = _texture(Color.GRAY)
+	mat.metallic = 0.9
+	mat.metallic_texture = _texture(Color.DARK_GRAY)
+	mat.emission_enabled = true
+	mat.emission = Color(0.1, 0.2, 0.3)
+	mat.uv1_scale = Vector3(4.0, 4.0, 1.0)
+	mat.uv1_offset = Vector3(0.25, 0.5, 0.0)
+	mat.cull_mode = BaseMaterial3D.CULL_DISABLED
+	return mat
+
+
+func test_a_painted_face_keeps_everything_but_the_albedo_texture():
+	var base := _full_material()
+	var painted = FaceData.composite_painted_material(base, _painted_image())
+	assert_true(painted is StandardMaterial3D, "The composite is a standard material")
+	var std: StandardMaterial3D = painted
+	assert_ne(std, base, "and not the palette material itself")
+	assert_ne(std.albedo_texture, base.albedo_texture, "The albedo is the composited image")
+	assert_eq(std.normal_texture, base.normal_texture, "The normal map survives")
+	assert_almost_eq(std.normal_scale, 0.75, 0.001, "and its scale")
+	assert_eq(std.roughness_texture, base.roughness_texture, "The roughness map survives")
+	assert_eq(std.metallic_texture, base.metallic_texture, "and the metallic map")
+	assert_eq(std.emission, base.emission, "The emission survives")
+	assert_eq(std.uv1_scale, Vector3(4.0, 4.0, 1.0), "and the UV scale, which is the visible one")
+	assert_eq(std.uv1_offset, Vector3(0.25, 0.5, 0.0), "and the UV offset")
+	assert_eq(std.cull_mode, BaseMaterial3D.CULL_DISABLED, "and the cull mode")
+	assert_almost_eq(std.roughness, 0.3, 0.001, "The three that were kept before are still kept")
+	assert_almost_eq(std.metallic, 0.9, 0.001)
+	assert_eq(std.albedo_color, base.albedo_color)
+
+
+func test_painting_does_not_write_back_into_the_palette_material():
+	var base := _full_material()
+	var before := base.albedo_texture
+	FaceData.composite_painted_material(base, _painted_image())
+	assert_eq(base.albedo_texture, before, "The palette material is untouched")
+
+
+func test_a_shader_material_is_kept_rather_than_replaced():
+	# The atlas already refuses a ShaderMaterial rather than pretending it can
+	# pack one. Building a plain StandardMaterial3D here left one baked surface
+	# flat beside its neighbours with the shader gone and nothing said.
+	var shader := ShaderMaterial.new()
+	shader.shader = Shader.new()
+	var painted = FaceData.composite_painted_material(shader, _painted_image())
+	assert_eq(painted, shader, "The shader material comes back as it was")
+
+
+func test_a_face_with_no_palette_material_still_gets_the_paint():
+	var painted = FaceData.composite_painted_material(null, _painted_image())
+	assert_true(painted is StandardMaterial3D, "The composite is the whole surface")
+	assert_not_null(painted.albedo_texture, "and carries the painted albedo")
+
+
+func test_no_painted_image_means_no_composite():
+	var base := _full_material()
+	assert_eq(
+		FaceData.composite_painted_material(base, null),
+		base,
+		"An unpainted face keeps its material"
+	)
+
+
+func _painted_face() -> FaceData:
+	var face := FaceData.new()
+	face.local_verts = PackedVector3Array(
+		[Vector3(-1, 0, -1), Vector3(-1, 0, 1), Vector3(1, 0, 1), Vector3(1, 0, -1)]
+	)
+	face.ensure_geometry()
+	var layer := FaceData.PaintLayer.new()
+	layer.texture = _texture(Color.RED)
+	layer.ensure_weight_image(Vector2i(16, 16))
+	layer.weight_image.fill(Color(1, 1, 1, 1))
+	face.paint_layers = [layer]
+	return face
+
+
+func test_the_bake_resolves_a_painted_face_the_same_way():
+	# The composite the bake writes is the one people spend an afternoon on
+	# before finding this: the normal map going missing, and the UV scale going
+	# back to 1 so the painted face's texture is four times the size of the one
+	# beside it.
+	var baker = preload("res://addons/hammerforge/baker.gd").new()
+	add_child_autoqfree(baker)
+	var base := _full_material()
+	var resolved = baker._resolve_face_material(_painted_face(), null, base, null)
+	assert_true(resolved is StandardMaterial3D, "A painted face bakes to a standard material")
+	assert_eq(resolved.normal_texture, base.normal_texture, "with its normal map")
+	assert_eq(resolved.uv1_scale, base.uv1_scale, "and its UV scale")
+	assert_ne(resolved.albedo_texture, base.albedo_texture, "and the painted albedo on it")
+
+
+func test_the_bake_keeps_a_shader_material_on_a_painted_face():
+	var baker = preload("res://addons/hammerforge/baker.gd").new()
+	add_child_autoqfree(baker)
+	var shader := ShaderMaterial.new()
+	shader.shader = Shader.new()
+	var resolved = baker._resolve_face_material(_painted_face(), null, shader, null)
+	assert_eq(resolved, shader, "The shader survives the bake rather than being substituted")


### PR DESCRIPTION
Fixes #412. Fixes #413.

One composite, written out twice - `brush_instance._material_for_face()` for the preview and `baker._resolve_face_material()` for the bake - and wrong the same way in both.

**It kept three scalars and dropped the rest.** The painted material was a bare `StandardMaterial3D` with `roughness`, `metallic` and `albedo_color` copied onto it. So a painted face lost `normal_texture`, `normal_scale`, `roughness_texture`, `metallic_texture`, `emission`, `uv1_scale`, `uv1_offset` and `cull_mode`. On a tiled wall the UV scale going back to 1 is the one you see first: the painted face's texture is four times the size of the one next to it.

The composite only ever needed to replace the albedo, so it duplicates the base and sets `albedo_texture` on the copy. That keeps everything, including slots added to `StandardMaterial3D` in a future Godot version, and it does not write back into the palette material.

**A ShaderMaterial was replaced rather than refused.** It fails the `is StandardMaterial3D` test, so the new material was built with nothing on it but the composited albedo and the shader was gone from that surface with nothing said. It is now kept and the paint is not drawn, which is what `HFMaterialAtlas.build_atlas()` already does by putting a `ShaderMaterial` in `fallback_keys` rather than pretending it can pack it. The warning fires once per material, not once per face per rebuild, because `rebuild_preview()` runs on every paint sample.

Both call sites now share `FaceData.composite_painted_material()`.

Tests: every slot of a fully-populated material survives the composite, the palette material is not written into, a shader material comes back as it was, a face with no palette material still gets the paint, and an unpainted face keeps its material. Two more drive `baker._resolve_face_material()` itself, because the bake is the path the issue was found through.

Changelog and the surface paint notes in the texture and materials doc updated.
