### PR TITLE
Say which materials a palette load could not find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,22 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **A palette of materials that could not be found was reported as success, and
+  as an empty palette** (#414, #415). `load_library()` keeps a slot and drops the
+  material when a path no longer resolves, which is right - `FaceData`
+  `material_idx` indexes that array and compacting it would repaint the level -
+  but it said nothing about it and returned `true`. Loading a library of three
+  paths that had moved gave a palette of three nulls, no warning, no count and
+  no list. Each missing path is now named on load with a count after it, and
+  `get_missing_library_paths()` and `get_missing_count()` report the same thing
+  to a caller. The status board counted only the slots that resolved, so a
+  palette of unresolved entries was indistinguishable from no palette at all and
+  the board said "Material palette / Empty / Everything bakes with the default
+  grey. Fine for greyboxing." It is not fine: those slots are the ones every face
+  indexes, and `validation_system.validate()` on the same level reports an issue
+  for each of them. The board carries both numbers now - "3 slots, 0 loaded" at
+  PROBLEM with the load action offered, and "4 of 6 loaded" at WARN when some
+  came back.
 - **Painting a face threw away everything about its material but three scalars,
   and replaced a ShaderMaterial outright** (#412, #413). The editor preview and
   the bake both built the painted material as a bare `StandardMaterial3D`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,641 tests across 192 test scripts (3,634 passing plus seven intentional no-assert safety tests; 18,356 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,646 tests across 192 test scripts (3,639 passing plus seven intentional no-assert safety tests; 18,372 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,641 tests** across **192 scripts** (**3,634 passing** plus seven intentional no-assert safety tests; **18,356 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,646 tests** across **192 scripts** (**3,639 passing** plus seven intentional no-assert safety tests; **18,372 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3634%20passing-brightgreen" alt="3634 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3639%20passing-brightgreen" alt="3639 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,641 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,646 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/hf_status_board.gd
+++ b/addons/hammerforge/hf_status_board.gd
@@ -108,7 +108,11 @@ static func collect_context(
 			for mat in materials:
 				if mat != null:
 					loaded += 1
+			# Two numbers, not one. A palette of slots that did not resolve is
+			# not an empty palette: those slots are what every face indexes, and
+			# the validator reports each of them.
 			ctx["material_count"] = loaded
+			ctx["material_slot_count"] = materials.size()
 
 	var spawn_system = level_root.get("spawn_system")
 	if spawn_system and spawn_system.has_method("get_all_spawns"):
@@ -147,6 +151,7 @@ static func _empty_context() -> Dictionary:
 		"recommended_chunk_size": 0.0,
 		"chunk_size": 0.0,
 		"material_count": 0,
+		"material_slot_count": 0,
 		"bake_use_face_materials": false,
 		"spawn_count": 0,
 		"auto_spawn_player": false,
@@ -404,13 +409,41 @@ static func _check_materials(ctx: Dictionary) -> Dictionary:
 	var help := (
 		"The material palette every brush face indexes into. An empty palette is\n"
 		+ "fine for greyboxing and fatal for a face-material bake, which has no\n"
-		+ "palette entry to resolve each face against."
+		+ "palette entry to resolve each face against. A palette with slots that\n"
+		+ "did not resolve is a different thing: those slots are what the faces\n"
+		+ "index, and every one of them is an issue the validator reports."
 	)
 	if not ctx.get("has_root", false):
 		return _row(
 			"materials", "Material palette", Severity.UNKNOWN, "-", "No level loaded.", help
 		)
 	var count := int(ctx.get("material_count", 0))
+	var slots := int(ctx.get("material_slot_count", 0))
+	if count == 0 and slots > 0:
+		# Slots that did not resolve. The board used to call this "Empty" and say
+		# it was fine for greyboxing, while `validation_system.validate()` on the
+		# same level reported a null palette entry for every one of them.
+		return _row(
+			"materials",
+			"Material palette",
+			Severity.PROBLEM,
+			"%d slot%s, 0 loaded" % [slots, "" if slots == 1 else "s"],
+			"No material in the palette could be found. Every face indexes one of these slots.",
+			help,
+			"load_palette",
+			"Load Palette"
+		)
+	if count > 0 and count < slots:
+		return _row(
+			"materials",
+			"Material palette",
+			Severity.WARN,
+			"%d of %d loaded" % [count, slots],
+			"Some materials in the palette could not be found. Faces indexing them bake grey.",
+			help,
+			"load_palette",
+			"Load Palette"
+		)
 	if count == 0 and bool(ctx.get("bake_use_face_materials", false)):
 		return _row(
 			"materials",

--- a/addons/hammerforge/material_manager.gd
+++ b/addons/hammerforge/material_manager.gd
@@ -7,6 +7,11 @@ class_name MaterialManager
 ## Path to the last saved/loaded material library (for auto-reload).
 var _library_path := ""
 
+## Paths from the last `load_library()` that did not resolve, in slot order.
+## Their slots are still in `materials`, holding null, because `FaceData`
+## `material_idx` indexes this array and compacting it would repaint the level.
+var _missing_paths: Array[String] = []
+
 
 func get_material(index: int) -> Material:
 	if index >= 0 and index < materials.size():
@@ -82,19 +87,56 @@ func load_library(path: String) -> bool:
 		return false
 	var mat_paths: Array = parsed.get("materials", [])
 	materials.clear()
+	_missing_paths.clear()
 	for mat_path in mat_paths:
 		var p := str(mat_path)
 		if p == "" or not ResourceLoader.exists(p):
 			# Preserve slot with null placeholder so indices stay stable.
 			materials.append(null)
+			_missing_paths.append(p)
 			continue
 		var res = ResourceLoader.load(p)
 		if res is Material:
 			materials.append(res)
 		else:
 			materials.append(null)
+			_missing_paths.append(p)
 	_library_path = path
+	if not _missing_paths.is_empty():
+		# Preserving the slots is right; saying nothing about them is not. The
+		# level's own validator reports one issue per null entry, but only if
+		# somebody runs it, and the natural moment to say so is the load.
+		for missing in _missing_paths:
+			HFLog.warn(
+				(
+					"%s: material '%s' could not be found. Its palette slot is empty."
+					% [path, missing if missing != "" else "<blank path>"]
+				)
+			)
+		HFLog.warn(
+			(
+				"%s: %d of %d materials in this library could not be found."
+				% [path, _missing_paths.size(), materials.size()]
+			)
+		)
 	return true
+
+
+## Paths from the last `load_library()` that did not resolve. Empty when every
+## material was found, and after a load that failed before it read any.
+func get_missing_library_paths() -> Array[String]:
+	return _missing_paths.duplicate()
+
+
+## How many palette slots hold no material. The status board reports this beside
+## the loaded count, because a palette of unresolved slots is not an empty
+## palette: those slots are the ones every face indexes.
+func get_missing_count() -> int:
+	var missing := 0
+	for mat in materials:
+		if mat == null:
+			missing += 1
+	return missing
 
 
 ## Returns the path of the last saved/loaded library, or empty string.

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -33,7 +33,7 @@ Eight checks, each a red / amber / green lamp with what was measured, what it me
 | **Geometry budget** | 50 brushes + entities or fewer | Above 50; bakes get slower | Above 100; dragging starts to stutter |
 | **Bake** | Baked meshes match the drafts | Never baked, or brushes edited since — *Bake Now* | — |
 | **Level check** | Scanned, no faults | 1–5 issues — *Check + Fix* | 6 or more |
-| **Material palette** | Materials loaded | Empty (fine for greyboxing) — *Load Palette* | Empty **and** face-material bake is on |
+| **Material palette** | Every slot loaded | Empty (fine for greyboxing), or some slots did not resolve — *Load Palette* | No slot resolved, or empty **and** face-material bake is on |
 | **Player spawn** | At least one spawn point | None, but auto-spawn is on — *Add Spawn Point* | None and auto-spawn is off |
 | **Autosave** | On, and a snapshot exists | Off, or nothing written yet — *Turn On* | — |
 | **Session log** | No warnings | Warnings this session — *Open Log* | Errors this session |

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,641 tests across 192 scripts**: **3,634 passing tests**, seven intentional no-assert safety tests, and **18,356 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,646 tests across 192 scripts**: **3,639 passing tests**, seven intentional no-assert safety tests, and **18,372 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_material_palette_integrity.gd
+++ b/tests/test_material_palette_integrity.gd
@@ -231,3 +231,59 @@ func test_a_negative_uv_scale_is_allowed_because_it_mirrors():
 	var brush := _make_brush("b1")
 	root.set_face_uv_params("b1", 0, Vector2(-1, 1), Vector2.ZERO, 0.0)
 	assert_almost_eq(brush.faces[0].uv_scale.x, -1.0, 0.0001)
+
+
+# --- what a library load says about what it dropped ------------------------
+
+
+func _write_library(path: String, paths: Array) -> void:
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	file.store_string(JSON.stringify({"materials": paths}))
+	file.close()
+
+
+func _library_path() -> String:
+	return "user://hf_missing_material_library_test.hfmaterials"
+
+
+func test_a_library_of_paths_that_moved_names_every_one_of_them():
+	# Preserving the slots is right: `material_idx` indexes this array and
+	# compacting it would repaint the level. Saying nothing about them is what
+	# was wrong - the load reported success and the user heard nothing, while
+	# the validator on the same level reported an issue per slot.
+	var path := _library_path()
+	_write_library(path, ["res://gone_a.tres", "res://gone_b.tres", "res://gone_c.tres"])
+	assert_true(root.material_manager.load_library(path), "The library file itself loads")
+	assert_eq(root.material_manager.materials.size(), 3, "The slots are kept")
+	assert_eq(root.material_manager.get_missing_count(), 3, "and all three are empty")
+	var missing := root.material_manager.get_missing_library_paths()
+	assert_eq(missing.size(), 3, "The load says which paths it could not find")
+	assert_true(missing.has("res://gone_b.tres"), "naming each one: %s" % str(missing))
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+
+
+func test_a_library_that_resolves_reports_nothing_missing():
+	var path := _library_path()
+	var mat_path := "user://hf_present_material_test.tres"
+	ResourceSaver.save(_make_material("Present"), mat_path)
+	_write_library(path, [mat_path])
+	assert_true(root.material_manager.load_library(path))
+	assert_eq(root.material_manager.get_missing_count(), 0, "Nothing is missing")
+	assert_eq(root.material_manager.get_missing_library_paths().size(), 0, "so there is no list")
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(mat_path))
+
+
+func test_a_later_clean_load_clears_the_missing_list():
+	var path := _library_path()
+	_write_library(path, ["res://gone_a.tres"])
+	root.material_manager.load_library(path)
+	assert_eq(root.material_manager.get_missing_library_paths().size(), 1)
+	_write_library(path, [])
+	root.material_manager.load_library(path)
+	assert_eq(
+		root.material_manager.get_missing_library_paths().size(),
+		0,
+		"The second load does not report the first load's misses"
+	)
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(path))

--- a/tests/test_status_board.gd
+++ b/tests/test_status_board.gd
@@ -25,6 +25,7 @@ func _healthy_context() -> Dictionary:
 		"recommended_chunk_size": 0.0,
 		"chunk_size": 32.0,
 		"material_count": 6,
+		"material_slot_count": 6,
 		"bake_use_face_materials": false,
 		"spawn_count": 1,
 		"auto_spawn_player": true,
@@ -217,14 +218,39 @@ func test_many_validation_issues_are_red():
 func test_empty_palette_is_amber_while_greyboxing():
 	var ctx := _healthy_context()
 	ctx["material_count"] = 0
+	ctx["material_slot_count"] = 0
 	assert_eq(_severity_of(ctx, "materials"), WARN)
 
 
 func test_empty_palette_is_red_when_face_materials_bake_is_on():
 	var ctx := _healthy_context()
 	ctx["material_count"] = 0
+	ctx["material_slot_count"] = 0
 	ctx["bake_use_face_materials"] = true
 	assert_eq(_severity_of(ctx, "materials"), PROBLEM, "That combination cannot bake correctly")
+
+
+func test_a_palette_of_slots_that_did_not_resolve_is_red():
+	# Not the same thing as an empty palette. Those slots are what every face
+	# indexes, and `validation_system.validate()` reports one issue per slot on
+	# the same level. The board used to call this "Empty" and say it was fine.
+	var ctx := _healthy_context()
+	ctx["material_count"] = 0
+	ctx["material_slot_count"] = 3
+	var row := _find(HFStatusBoardType.evaluate(ctx), "materials")
+	assert_eq(int(row["severity"]), PROBLEM, "A palette nothing resolved in is a problem")
+	assert_string_contains(str(row["value"]), "3 slots", "and the row says how many: %s" % row)
+	assert_string_contains(str(row["value"]), "0 loaded", "and how many came back")
+	assert_eq(str(row.get("action_id", "")), "load_palette", "with the load action offered")
+
+
+func test_a_partly_resolved_palette_is_amber():
+	var ctx := _healthy_context()
+	ctx["material_count"] = 4
+	ctx["material_slot_count"] = 6
+	var row := _find(HFStatusBoardType.evaluate(ctx), "materials")
+	assert_eq(int(row["severity"]), WARN, "Some faces bake grey")
+	assert_string_contains(str(row["value"]), "4 of 6", "and the row says which: %s" % row)
 
 
 func test_loaded_palette_is_green():


### PR DESCRIPTION
Fixes #414. Fixes #415.

Two halves of one thing: a palette whose materials could not be found looked like a success at the load and like an empty palette on the board.

**The load said nothing.** `load_library()` keeps the slot and drops the material when a path no longer resolves. Preserving the slot is right - `FaceData.material_idx` indexes that array and compacting it would repaint the level - but the function returned `true` with no warning, no count and no list. Each missing path is now named on load with a count after it, and the same is available to a caller through `get_missing_library_paths()` and `get_missing_count()`. The list is cleared at the start of each load, so a later clean load does not report the earlier one's misses.

**The board called it empty.** `collect_context()` counted only the slots that resolved, so three nulls and no palette at all were the same number, and `_check_materials()` reported "Material palette / Empty / Everything bakes with the default grey. Fine for greyboxing." It is not fine: those slots are what every face indexes, and `validation_system.validate()` on the same level reports `Dependency: Material palette entry N is null` for each one.

The context carries `material_slot_count` beside `material_count` now, and the row reads:

- no slots at all: unchanged. Amber while greyboxing, red when the face-material bake is on.
- slots but none resolved: red, "3 slots, 0 loaded", with the load action offered.
- some resolved: amber, "4 of 6 loaded". Faces indexing the rest bake grey.

Tests: a library of three paths that moved keeps three slots, reports three missing and names them; a library that resolves reports nothing; a later clean load clears the list; and the two new board rows assert the severity and what the row says. The board tests fail without the fix and the palette ones need the new API.

Changelog and the status board table in the user guide updated.
