### PR TITLE
Keep the chosen ruler when align is toggled off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,22 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **Toggling the measure tool's align off forgot which ruler was the reference**
+  (#405, #411). `_toggle_align()` called `_remove_snap_reference()`, which sets
+  `_snap_ref_index` to -1, so the branch below it that reuses the chosen ruler
+  could never run: pressing A again fell through to the last branch and silently
+  took the newest ruler instead. Nothing said the reference had changed; the snap
+  line just moved, and everything snapping to it went somewhere else. Align off
+  now clears the snap line and keeps the choice, which is what the HUD line and
+  that unreachable branch both say was intended; leaving the tool still forgets
+  it. The snap system itself also accepted a line with no direction:
+  `Vector3.ZERO.normalized()` is `Vector3.ZERO`, so every point inside the
+  threshold projected onto the line's origin. A ruler with both ends on one point
+  draws exactly that, and the rule lived in the one caller that checked rather
+  than in the system that depends on it. `set_custom_snap_line()` refuses a
+  direction that is not one, keeping any line already set, and `snap_threshold`
+  refuses a value of zero or less rather than turning every geometry candidate
+  off in silence.
 - **A palette of materials that could not be found was reported as success, and
   as an empty palette** (#414, #415). `load_library()` keeps a slot and drops the
   material when a path no longer resolves, which is right - `FaceData`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,646 tests across 192 test scripts (3,639 passing plus seven intentional no-assert safety tests; 18,372 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,653 tests across 192 test scripts (3,646 passing plus seven intentional no-assert safety tests; 18,395 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,646 tests** across **192 scripts** (**3,639 passing** plus seven intentional no-assert safety tests; **18,372 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,653 tests** across **192 scripts** (**3,646 passing** plus seven intentional no-assert safety tests; **18,395 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3639%20passing-brightgreen" alt="3639 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3646%20passing-brightgreen" alt="3646 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,646 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,653 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/hf_measure_tool.gd
+++ b/addons/hammerforge/hf_measure_tool.gd
@@ -208,9 +208,14 @@ func _clear_all() -> void:
 	_clear_visuals()
 
 
+## Turning align off keeps the chosen ruler, so turning it back on uses the same
+## one. It used to call `_remove_snap_reference()`, which sets `_snap_ref_index`
+## to -1, so the second branch below could never run: the next press fell through
+## to the third and silently picked the newest ruler instead. The HUD line and
+## that unreachable branch both say the choice was meant to survive the toggle.
 func _toggle_align() -> void:
 	if _align_active:
-		_remove_snap_reference()
+		_clear_snap_line()
 		_align_active = false
 	elif _snap_ref_index >= 0:
 		_align_active = true
@@ -233,15 +238,20 @@ func _apply_snap_reference() -> void:
 	if not root or not root.get("snap_system"):
 		return
 	var m: Dictionary = _measurements[_snap_ref_index]
-	var direction: Vector3 = (m["b"] - m["a"]).normalized()
-	if direction.length_squared() < 0.001:
-		return
-	root.snap_system.set_custom_snap_line(m["a"], direction)
+	# A ruler with both ends on the same point has no direction. The snap system
+	# refuses one now, so this passes the raw delta and lets it decide.
+	root.snap_system.set_custom_snap_line(m["a"], m["b"] - m["a"])
 
 
+## Forget the reference entirely. For leaving the tool, not for toggling align.
 func _remove_snap_reference() -> void:
 	_snap_ref_index = -1
 	_align_active = false
+	_clear_snap_line()
+
+
+## Stop snapping to the line without forgetting which ruler drew it.
+func _clear_snap_line() -> void:
 	if root and root.get("snap_system") and root.snap_system.has_method("clear_custom_snap_line"):
 		root.snap_system.clear_custom_snap_line()
 

--- a/addons/hammerforge/hf_snap_system.gd
+++ b/addons/hammerforge/hf_snap_system.gd
@@ -36,7 +36,26 @@ const VERTEX_KEY_SCALE := 1000.0
 
 var root: Node3D
 var enabled_modes: int = SnapMode.GRID
-var snap_threshold: float = 2.0
+## How far a candidate may be from the point and still be snapped to.
+##
+## A value of zero or less turns every geometry candidate off, so it is refused
+## rather than quietly disabling snapping. The backing variable is separate
+## because a setter that assigns to its own property re-enters itself.
+var _snap_threshold: float = 2.0
+
+var snap_threshold: float:
+	get:
+		return _snap_threshold
+	set(value):
+		if not is_finite(value) or value <= 0.0:
+			HFLog.warn(
+				(
+					"HFSnapSystem: a snap threshold of %s would turn every candidate off. Kept %s."
+					% [str(value), str(_snap_threshold)]
+				)
+			)
+			return
+		_snap_threshold = value
 var _custom_snap_origin: Vector3 = Vector3.ZERO
 var _custom_snap_dir: Vector3 = Vector3.ZERO
 var _has_custom_snap := false
@@ -122,10 +141,23 @@ func snap_point(point: Vector3, grid_snap: float, exclude_ids: Array = []) -> Ve
 	return best
 
 
-func set_custom_snap_line(origin: Vector3, direction: Vector3) -> void:
+## Point every snap within `snap_threshold` of the line at the nearest point on
+## it. Returns false and changes nothing when the direction is not a direction.
+##
+## `Vector3.ZERO.normalized()` is `Vector3.ZERO`, so a zero direction made
+## `_project_onto_line()` return `line_origin + Vector3.ZERO * t` - the origin -
+## for every input, and everything inside the threshold landed on one point. A
+## ruler with both ends in the same place is a real thing a user can draw, and
+## the only caller today checks the length before calling. The rule belongs here,
+## with the code that depends on it.
+func set_custom_snap_line(origin: Vector3, direction: Vector3) -> bool:
+	if not direction.is_finite() or direction.length_squared() < 0.000001:
+		HFLog.warn("HFSnapSystem: a snap line needs a direction. %s is not one." % str(direction))
+		return false
 	_custom_snap_origin = origin
 	_custom_snap_dir = direction.normalized()
 	_has_custom_snap = true
+	return true
 
 
 func clear_custom_snap_line() -> void:

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -190,7 +190,7 @@ Press **M** to activate the Measure tool. It supports persistent multi-ruler mea
 - **Shift+Click** chains a new ruler from the last ruler's endpoint. Consecutive chained rulers that share a vertex display the **angle** between them in degrees.
 - Up to **20 rulers** can be active simultaneously, each drawn in a cycling color palette.
 - **Ctrl+Click** near a ruler to set it as a **snap reference line**. The snap system will project nearby points onto that line.
-- Press **A** to toggle align mode on/off.
+- Press **A** to toggle align mode on/off. Turning it off keeps the ruler you chose, so turning it back on snaps to the same line. With no reference chosen, **A** uses the newest ruler. A ruler with both ends on the same point has no direction and sets no snap line.
 - Press **Delete/Backspace** to remove the last ruler.
 - Press **Escape** to clear all rulers.
 - The HUD shows ruler count, distance of the last ruler, and alignment status.

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,646 tests across 192 scripts**: **3,639 passing tests**, seven intentional no-assert safety tests, and **18,372 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,653 tests across 192 scripts**: **3,646 passing tests**, seven intentional no-assert safety tests, and **18,395 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_measure_tool.gd
+++ b/tests/test_measure_tool.gd
@@ -271,3 +271,82 @@ func test_hud_lines_with_measurement():
 	var joined := "\n".join(lines)
 	assert_true(joined.contains("10.0"), "Should show distance")
 	assert_true(joined.contains("Rulers: 1"), "Should show ruler count")
+
+
+# --- the align toggle keeps the ruler you chose -----------------------------
+
+
+class AlignRoot:
+	extends Node3D
+
+	var snap_system = null
+
+	func _init() -> void:
+		snap_system = load("res://addons/hammerforge/hf_snap_system.gd").new(self)
+
+
+func _two_rulers(measure_tool) -> void:
+	measure_tool._measurements = [
+		{"a": Vector3.ZERO, "b": Vector3(64, 0, 0)},
+		{"a": Vector3(0, 0, 64), "b": Vector3(0, 0, 128)},
+	]
+
+
+func test_turning_align_off_and_on_keeps_the_same_ruler():
+	# Turning it off used to clear the chosen index, so turning it back on fell
+	# through to the newest ruler and everything snapping to the line moved.
+	var align_root := AlignRoot.new()
+	add_child_autoqfree(align_root)
+	tool.root = align_root
+	_two_rulers(tool)
+	tool._snap_ref_index = 0
+	tool._align_active = true
+	tool._apply_snap_reference()
+	assert_eq(align_root.snap_system._custom_snap_dir, Vector3(1, 0, 0), "Ruler 1 is the reference")
+
+	tool._toggle_align()
+	assert_false(tool._align_active, "Align is off")
+	assert_eq(tool._snap_ref_index, 0, "and the chosen ruler is remembered")
+	assert_false(align_root.snap_system._has_custom_snap, "but nothing snaps to it")
+
+	tool._toggle_align()
+	assert_true(tool._align_active, "Align is back on")
+	assert_eq(tool._snap_ref_index, 0, "with the ruler that was chosen")
+	assert_eq(
+		align_root.snap_system._custom_snap_dir, Vector3(1, 0, 0), "and the same line to snap to"
+	)
+
+
+func test_align_with_no_reference_chosen_still_takes_the_newest_ruler():
+	var align_root := AlignRoot.new()
+	add_child_autoqfree(align_root)
+	tool.root = align_root
+	_two_rulers(tool)
+	tool._toggle_align()
+	assert_true(tool._align_active)
+	assert_eq(tool._snap_ref_index, 1, "The newest one, as before, when nothing was chosen")
+
+
+func test_leaving_the_tool_forgets_the_reference():
+	var align_root := AlignRoot.new()
+	add_child_autoqfree(align_root)
+	tool.root = align_root
+	_two_rulers(tool)
+	tool._snap_ref_index = 0
+	tool._align_active = true
+	tool._apply_snap_reference()
+	tool._remove_snap_reference()
+	assert_eq(tool._snap_ref_index, -1, "Leaving is not toggling")
+	assert_false(tool._align_active)
+	assert_false(align_root.snap_system._has_custom_snap)
+
+
+func test_a_ruler_with_both_ends_on_one_point_sets_no_snap_line():
+	var align_root := AlignRoot.new()
+	add_child_autoqfree(align_root)
+	tool.root = align_root
+	tool._measurements = [{"a": Vector3(10, 20, 30), "b": Vector3(10, 20, 30)}]
+	tool._snap_ref_index = 0
+	tool._align_active = true
+	tool._apply_snap_reference()
+	assert_false(align_root.snap_system._has_custom_snap, "There is no line through one point")

--- a/tests/test_snap_system_custom.gd
+++ b/tests/test_snap_system_custom.gd
@@ -60,3 +60,36 @@ func test_snap_point_uses_custom_line():
 	# Custom line projects to (3, 0, 0)
 	assert_almost_eq(result.y, 0.0, 0.01, "Should snap Y to the line")
 	assert_almost_eq(result.x, 3.0, 0.01, "X should stay projected")
+
+
+# --- a line that is not a line, and a threshold that is not one -------------
+
+
+func test_a_snap_line_with_no_direction_is_refused():
+	# `Vector3.ZERO.normalized()` is `Vector3.ZERO`, so the projection returned
+	# the origin for every input and everything inside the threshold landed on
+	# one point. A ruler with both ends in the same place draws one of these.
+	assert_false(
+		snap.set_custom_snap_line(Vector3(10, 20, 30), Vector3.ZERO), "A zero direction is refused"
+	)
+	assert_false(snap._has_custom_snap, "and no custom line is set")
+	snap.snap_threshold = 100.0
+	assert_eq(snap.snap_point(Vector3.ZERO, 0.0, []), Vector3.ZERO, "so nothing collapses onto it")
+
+
+func test_a_snap_line_that_was_set_is_not_lost_to_a_bad_one():
+	assert_true(snap.set_custom_snap_line(Vector3.ZERO, Vector3(1, 0, 0)))
+	assert_false(snap.set_custom_snap_line(Vector3(10, 20, 30), Vector3.ZERO))
+	assert_eq(snap._custom_snap_dir, Vector3(1, 0, 0), "The good line is still the one in use")
+	assert_eq(snap._custom_snap_origin, Vector3.ZERO)
+
+
+func test_a_snap_threshold_of_zero_or_less_is_refused():
+	# It turns every geometry candidate off, which used to happen in silence.
+	snap.snap_threshold = 4.0
+	snap.snap_threshold = -10.0
+	assert_almost_eq(snap.snap_threshold, 4.0, 0.001, "A negative threshold is not taken")
+	snap.snap_threshold = 0.0
+	assert_almost_eq(snap.snap_threshold, 4.0, 0.001, "and neither is zero")
+	snap.snap_threshold = 6.0
+	assert_almost_eq(snap.snap_threshold, 6.0, 0.001, "A usable one still is")


### PR DESCRIPTION
Fixes #405. Fixes #411.

The measure tool's align reference and the snap line it sets.

**The toggle forgot the ruler.** `_toggle_align()` turned align off by calling `_remove_snap_reference()`, which sets `_snap_ref_index` to -1. So the `elif _snap_ref_index >= 0` branch below it could never run, and the next press fell through to the last branch and took `_measurements.size() - 1` - the newest ruler. Nothing said the reference had changed. The snap line just moved, and everything snapping to it went somewhere else.

Align off now clears the snap line and keeps the choice. `_remove_snap_reference()` still forgets it entirely and is what `deactivate()` calls, because leaving the tool is not the same as toggling. `_remove_last_ruler()` already drops the reference when the ruler it points at is the one going, and only the last ruler can be removed, so a kept index stays valid.

**The snap system trusted its caller.** `Vector3.ZERO.normalized()` is `Vector3.ZERO`, so `_project_onto_line()` returned `line_origin + Vector3.ZERO * t` - the origin - for every input, and everything inside `snap_threshold` landed on that one point. `set_custom_snap_line()` refuses a direction that is not one and keeps any line already set. `_apply_snap_reference()` now passes the raw delta and lets the snap system decide, rather than keeping the length check in the caller.

`snap_threshold` refuses a value of zero or less too, which used to turn every geometry candidate off without saying so. It is a property over a separate backing variable, because a setter that assigns to its own property re-enters itself.

Tests: off and on again keeps ruler 1 and the line it set; align with nothing chosen still takes the newest ruler; leaving the tool still forgets; a ruler with both ends on one point sets no line; a zero direction is refused and does not lose the line already set; and a threshold of zero or less is refused while a usable one is taken.

Changelog and the Measure Tool section of the user guide updated.
