### PR TITLE
Report a shortcut that shares a chord with another action in the same mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,20 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **A shortcut rebound onto a chord another action already uses was accepted in
+  silence** (#410). Nothing compared a new binding against the others, so
+  `matches()` answered true for both, and `plugin_input_router` tests actions one
+  at a time and returns on the first hit - so the earlier check won and the other
+  action became unreachable with no message anywhere. Rebinding Hollow to Ctrl+G
+  got you Group, forever, with no way to find out why. A plain "this chord is
+  taken" check would be wrong, because the defaults share six chords on purpose:
+  `E` is Extrude, Erase and Edge Mode, `R` is Rotate and Ramp, and `X`, `Y` and
+  `Z` are axis locks and paint mirrors. The router gates each family on its mode,
+  so none of those pairs can both fire. The check is mode-aware to match: two
+  actions clash only when they share a chord and can fire at the same time.
+  `set_binding()` reports one, loading a hand-edited keymap reports each pair
+  once naming the file, and the shortcut dialog marks the binding in amber with a
+  tooltip saying what else uses it - which is before the fact rather than after.
 - **Toggling the measure tool's align off forgot which ruler was the reference**
   (#405, #411). `_toggle_align()` called `_remove_snap_reference()`, which sets
   `_snap_ref_index` to -1, so the branch below it that reuses the chosen ruler

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,653 tests across 192 test scripts (3,646 passing plus seven intentional no-assert safety tests; 18,395 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,659 tests across 192 test scripts (3,652 passing plus seven intentional no-assert safety tests; 18,459 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,653 tests** across **192 scripts** (**3,646 passing** plus seven intentional no-assert safety tests; **18,395 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,659 tests** across **192 scripts** (**3,652 passing** plus seven intentional no-assert safety tests; **18,459 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3646%20passing-brightgreen" alt="3646 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3652%20passing-brightgreen" alt="3652 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,653 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,659 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/hf_keymap.gd
+++ b/addons/hammerforge/hf_keymap.gd
@@ -58,7 +58,37 @@ static func _validated(data: Dictionary, defaults: Dictionary, path: String) -> 
 	for action in defaults:
 		if not out.has(action):
 			out[action] = defaults[action]
+	_warn_about_conflicts(out, path)
 	return out
+
+
+## One line per pair of actions that can fire in the same mode on one chord.
+## A hand-edited file is where these arrive, so the load is where to say so.
+static func _warn_about_conflicts(bindings: Dictionary, path: String) -> void:
+	var reported: Dictionary = {}
+	for action in bindings:
+		var first := str(action)
+		for other in bindings:
+			var second := str(other)
+			if first == second:
+				continue
+			if action_mode(first) != action_mode(second):
+				continue
+			if not _same_chord(bindings[first], bindings[second]):
+				continue
+			var pair_key: String = first + "|" + second if first < second else second + "|" + first
+			if reported.has(pair_key):
+				continue
+			reported[pair_key] = true
+			HFLog.warn(
+				(
+					(
+						"%s: '%s' and '%s' share a shortcut and both fire in the same mode."
+						% [path, get_action_label(first), get_action_label(second)]
+					)
+					+ " Only one of them will work."
+				)
+			)
 
 
 static func _default_bindings() -> Dictionary:
@@ -177,6 +207,12 @@ func save(path: String) -> void:
 
 
 ## Update a single binding.
+##
+## A chord another action in the same mode already uses is still written - it is
+## what the caller asked for - but it is no longer silent. `plugin_input_router`
+## tests actions one at a time and returns on the first hit, so the one it
+## happens to check first wins and the other becomes unreachable with nothing
+## said anywhere.
 func set_binding(
 	action: String,
 	keycode: int,
@@ -195,6 +231,74 @@ func set_binding(
 	if meta:
 		b["meta"] = true
 	_bindings[action] = b
+	var clashes := conflicts_for(action)
+	if not clashes.is_empty():
+		(
+			HFLog
+			. warn(
+				(
+					"Keymap: '%s' is now %s, which %s already uses. Only one of them will fire."
+					% [
+						get_action_label(action),
+						get_display_string(action),
+						_label_list(clashes),
+					]
+				)
+			)
+		)
+
+
+## Actions that would fire on the same chord as `action`, in the same mode.
+##
+## The defaults share six chords on purpose - E is extrude, erase and edge mode;
+## R is rotate and ramp; X, Y and Z are axis locks and paint mirrors - and the
+## input router gates each family on its mode, so none of those pairs can both
+## fire. So the question is not whether a chord is taken, it is whether it is
+## taken by something that can fire at the same time.
+func conflicts_for(action: String) -> PackedStringArray:
+	var out := PackedStringArray()
+	var binding: Dictionary = _bindings.get(action, {})
+	if binding.is_empty():
+		return out
+	var mode := action_mode(action)
+	for other in _bindings:
+		var other_action := str(other)
+		if other_action == action:
+			continue
+		if action_mode(other_action) != mode:
+			continue
+		if _same_chord(binding, _bindings[other]):
+			out.append(other_action)
+	return out
+
+
+## Which mode an action can fire in. `plugin_input_router` dispatches the paint
+## family only while paint mode is on and the vertex family only while vertex
+## mode is on, and everything else only while neither is.
+static func action_mode(action: String) -> String:
+	if action.begins_with("paint_") and action != "toggle_paint_mode":
+		return "paint"
+	if action.begins_with("vertex_") and action != "vertex_edit":
+		return "vertex"
+	return "general"
+
+
+static func _same_chord(a, b) -> bool:
+	if not (a is Dictionary and b is Dictionary):
+		return false
+	if int(a.get("keycode", 0)) != int(b.get("keycode", -1)):
+		return false
+	for modifier in ["ctrl", "shift", "alt", "meta"]:
+		if bool(a.get(modifier, false)) != bool(b.get(modifier, false)):
+			return false
+	return true
+
+
+func _label_list(actions: PackedStringArray) -> String:
+	var labels := PackedStringArray()
+	for action in actions:
+		labels.append("'%s'" % get_action_label(action))
+	return ", ".join(labels)
 
 
 ## Get all action names.

--- a/addons/hammerforge/ui/hf_shortcut_dialog.gd
+++ b/addons/hammerforge/ui/hf_shortcut_dialog.gd
@@ -90,6 +90,18 @@ func populate(keymap) -> void:
 			item.set_meta("action", action)
 			item.set_meta("label_lower", label.to_lower())
 			item.set_meta("binding_lower", binding.to_lower())
+			# A chord two actions in the same mode share: the input router
+			# returns on the first hit, so one of them never fires. Say so here
+			# rather than leaving the user to find out by pressing it.
+			var clashes: PackedStringArray = keymap.conflicts_for(action)
+			if not clashes.is_empty():
+				var others := PackedStringArray()
+				for clash in clashes:
+					others.append(HFKeymapType.get_action_label(clash))
+				item.set_custom_color(1, Color(1.0, 0.6, 0.35, 1.0))
+				item.set_tooltip_text(
+					1, "Also used by %s. Only one of them fires." % ", ".join(others)
+				)
 
 
 func _on_search_text_changed(filter_text: String) -> void:

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -1170,7 +1170,9 @@ All keyboard shortcuts are data-driven and can be customized. The default bindin
 
 **Rebinding:** Edit `user://hammerforge_keymap.json` (created on first run). Each entry maps an action name to `{"keycode": KEY_*, "ctrl": bool, "shift": bool, "alt": bool}`. Restart the plugin after editing. The JSON file is the interface; there is no rebinding UI.
 
-An entry that is not a binding, one with no usable `keycode`, or a key that is not a HammerForge action is reported once on load, naming the file and the key, and the default is used for it. Before, a typo in this file turned every keystroke in the viewport into an error that named `hf_keymap.gd` rather than the file you got wrong.
+An entry that is not a binding, one with no usable `keycode`, or a key that is not a HammerForge action is reported once on load, naming the file and the key, and the default is used for it.
+
+Two actions that can fire in the same mode on the same chord are reported on load as well, naming both, because the input router tests actions one at a time and stops on the first hit -- so one of the two never fires. The shortcut dialog marks such a binding in amber and its tooltip says what else uses it. Sharing a chord across modes is fine and the defaults do it six times: `E` is Extrude, Erase and Edge Mode, `R` is Rotate and Ramp, and `X`, `Y` and `Z` are axis locks and paint mirrors. The paint family only fires while paint mode is on and the vertex family only while vertex mode is on, so those pairs never both answer. Before, a typo in this file turned every keystroke in the viewport into an error that named `hf_keymap.gd` rather than the file you got wrong.
 
 **Toolbar labels** and **tooltips** update automatically from the keymap, so custom bindings are always reflected in the UI. Press the **?** button on the toolbar to open a searchable shortcut dialog showing all current keybindings grouped by category (Tools, Editing, Selection, Paint, Axis Lock).
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,653 tests across 192 scripts**: **3,646 passing tests**, seven intentional no-assert safety tests, and **18,395 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,659 tests across 192 scripts**: **3,652 passing tests**, seven intentional no-assert safety tests, and **18,459 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_keymap.gd
+++ b/tests/test_keymap.gd
@@ -181,3 +181,54 @@ func test_data_roundtrip_via_json():
 
 	var ev = _make_key(KEY_W, true)
 	assert_true(loaded.matches("tool_draw", ev), "Loaded keymap should match saved binding")
+
+
+# -- chords two actions can both answer ----------------------------------------
+
+
+func test_the_shipped_defaults_have_no_conflicts():
+	# Six chords are shared on purpose - E is extrude, erase and edge mode; R is
+	# rotate and ramp; X, Y and Z are axis locks and paint mirrors - and the
+	# input router gates each family on its mode, so none of those can both fire.
+	for action in keymap.get_actions():
+		assert_eq(
+			Array(keymap.conflicts_for(action)),
+			[],
+			"'%s' should not clash with anything that fires in the same mode" % action
+		)
+
+
+func test_e_is_shared_across_three_modes_without_clashing():
+	assert_eq(HFKeymapType.action_mode("tool_extrude"), "general")
+	assert_eq(HFKeymapType.action_mode("paint_erase"), "paint")
+	assert_eq(HFKeymapType.action_mode("vertex_edge_mode"), "vertex")
+	assert_eq(Array(keymap.conflicts_for("paint_erase")), [], "Paint E only fires in paint mode")
+
+
+func test_rebinding_onto_a_chord_that_fires_in_the_same_mode_is_reported():
+	# Hollow onto Ctrl+G, which Group already uses. Both are general actions, so
+	# the input router's first hit wins and the other becomes unreachable.
+	keymap.set_binding("hollow", KEY_G, true)
+	var clashes := keymap.conflicts_for("hollow")
+	assert_eq(Array(clashes), ["group"], "The clash is named: %s" % str(clashes))
+	assert_eq(Array(keymap.conflicts_for("group")), ["hollow"], "and it is reported both ways")
+
+
+func test_rebinding_onto_a_chord_used_only_in_another_mode_is_not_a_conflict():
+	keymap.set_binding("hollow", KEY_B)
+	assert_eq(
+		Array(keymap.conflicts_for("hollow")),
+		[],
+		"Paint Brush is B, but it only fires while paint mode is on"
+	)
+
+
+func test_a_modifier_makes_it_a_different_chord():
+	keymap.set_binding("hollow", KEY_G, true, true)
+	assert_eq(Array(keymap.conflicts_for("hollow")), [], "Ctrl+Shift+G is not Ctrl+G")
+
+
+func test_toggle_paint_mode_is_a_general_action():
+	# It turns paint mode on, so it cannot be gated behind paint mode.
+	assert_eq(HFKeymapType.action_mode("toggle_paint_mode"), "general")
+	assert_eq(HFKeymapType.action_mode("vertex_edit"), "general", "and so is the vertex toggle")


### PR DESCRIPTION
Fixes #410.

Nothing compared a new binding against the others, so `matches()` answered true for both. `plugin_input_router` tests actions one at a time and returns `STOP` on the first hit, so the earlier check won and the other action became unreachable with nothing said anywhere. Rebind Hollow to Ctrl+G and you get Group, forever.

A plain "this chord is taken" check would be wrong, and the issue said why: the defaults share six chords on purpose. `E` is `tool_extrude`, `paint_erase` and `vertex_edge_mode`; `R` is `rotate_ccw` and `paint_ramp`; `X`, `Y` and `Z` are axis locks and paint mirrors. The router dispatches the paint family only while paint mode is on, the vertex family only while vertex mode is on, and the rest only while neither is, and there are comments in both files saying so.

So the check is mode-aware. `HFKeymap.action_mode()` names the mode an action can fire in from its family, and `conflicts_for()` returns the actions that share a chord *and* the mode. On the shipped defaults it returns nothing for every action, and there is a test holding it there.

Where it is said:

- `set_binding()` still writes the binding - it is what the caller asked for - and warns naming both actions and the chord.
- `load_or_default()` reports each clashing pair once, naming the file. A hand-edited `hammerforge_keymap.json` is where these actually arrive, since there is no rebinding UI.
- The shortcut dialog colours the binding amber and its tooltip says what else uses it. That is the "show it in the rebind UI rather than after the fact" part, as far as a read-only dialog can carry it.

`toggle_paint_mode` and `vertex_edit` are general rather than paint and vertex: they are what turns those modes on, so they cannot be gated behind them.

Tests: the defaults have no conflicts, E across three modes does not clash, Hollow onto Ctrl+G is reported both ways, Hollow onto B is not a conflict because Paint Brush only fires in paint mode, a modifier makes it a different chord, and the two mode toggles are general.

Changelog and the rebinding section of the user guide updated.
