### PR TITLE
Nine vibe scenarios over the paint pipeline and the UI panels

### DIFF
--- a/tools/vibe/README.md
+++ b/tools/vibe/README.md
@@ -95,6 +95,15 @@ it from here.
 | `painted-faces` | what a painted face keeps of the material it was painted over |
 | `status-board` | what the status board says against what the level is, and a half-missing palette |
 | `atlas` | the material atlas packer at its size limits, and what a failed pack does to the caller |
+| `scatter` | what a scattered instance is oriented to, how many one click makes, and what the scene keeps |
+| `selection-filter` | which faces each bulk filter reaches, and which faces no filter reaches at all |
+| `timeline` | the glyph and colour an operation gets on the timeline, and whether Replay can be clicked |
+| `shortcut-surfaces` | whether the HUD, the coach marks and the tooltips still tell the truth after a rebind |
+| `connectors` | what the live connector path costs per stroke, and whether the paint grid follows the level |
+| `examples` | what loading an example does to the level already in the scene, and whether it can be undone |
+| `heightmap-io` | what a heightmap loses going through the `.hflevel`'s base64 PNG, in world units |
+| `regions` | what the region eviction loop frees against what it thinks it freed |
+| `quick-property` | whether the quick popup and the dock control behind it agree on range and step |
 
 ## Adding a scenario
 

--- a/tools/vibe/hf_vibe_runner.gd
+++ b/tools/vibe/hf_vibe_runner.gd
@@ -53,6 +53,15 @@ const SCENARIOS: Array[String] = [
 	"res://tools/vibe/scenarios/painted_faces.gd",
 	"res://tools/vibe/scenarios/status_board.gd",
 	"res://tools/vibe/scenarios/atlas.gd",
+	"res://tools/vibe/scenarios/scatter.gd",
+	"res://tools/vibe/scenarios/selection_filter.gd",
+	"res://tools/vibe/scenarios/timeline.gd",
+	"res://tools/vibe/scenarios/shortcut_surfaces.gd",
+	"res://tools/vibe/scenarios/connectors.gd",
+	"res://tools/vibe/scenarios/examples.gd",
+	"res://tools/vibe/scenarios/heightmap_io.gd",
+	"res://tools/vibe/scenarios/regions.gd",
+	"res://tools/vibe/scenarios/quick_property.gd",
 ]
 
 

--- a/tools/vibe/run_vibe.py
+++ b/tools/vibe/run_vibe.py
@@ -68,6 +68,15 @@ SCENARIOS = [
     "painted-faces",
     "status-board",
     "atlas",
+    "scatter",
+    "selection-filter",
+    "timeline",
+    "shortcut-surfaces",
+    "connectors",
+    "examples",
+    "heightmap-io",
+    "regions",
+    "quick-property",
 ]
 
 # Generous: chaos runs 300 operations and cost saves eight levels. A scenario

--- a/tools/vibe/scenarios/connectors.gd
+++ b/tools/vibe/scenarios/connectors.gd
@@ -1,0 +1,148 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## Auto-connectors and the paint grid they are laid out on.
+##
+## The connector generator runs twice per stroke in the editor -- once for the
+## live ghost and once at bake -- so what it costs per stroke matters as much as
+## what it produces. And everything it produces is addressed in grid cells, so
+## the grid's own agreement with the level it belongs to is the thing underneath
+## all of it.
+
+const AutoConnector = preload("res://addons/hammerforge/paint/hf_auto_connector.gd")
+
+
+func id() -> String:
+	return "connectors"
+
+
+func summary() -> String:
+	return "what the live connector path costs per stroke, and whether the paint grid follows the level"
+
+
+func run() -> void:
+	await _what_the_live_path_scans()
+	await _does_the_grid_follow_the_level()
+
+
+func _two_levels(root: Node3D, half: int) -> void:
+	var mgr = root.paint_layers
+	var lower = mgr.get_active_layer()
+	var upper = mgr.create_layer(&"upper", 32.0)
+	for y in range(-half, half):
+		for x in range(-half, 0):
+			lower.set_cell(Vector2i(x, y), true)
+		for x in range(0, half):
+			upper.set_cell(Vector2i(x, y), true)
+
+
+## The comment on defs_for_touched_cells says it does not scan. Time it.
+func _what_the_live_path_scans() -> void:
+	var root: Node3D = await fresh_root()
+	var gen = AutoConnector.new()
+
+	for half in [8, 32, 64]:
+		var probe_root: Node3D = await fresh_root("Level_%d" % int(half))
+		_two_levels(probe_root, int(half))
+		var painted: int = int(half) * int(half) * 2
+
+		var started := Time.get_ticks_usec()
+		var segments = gen.detect_boundaries(probe_root.paint_layers)
+		var scan_us := Time.get_ticks_usec() - started
+
+		# One cell touched, the way a single click reaches the live ghost path.
+		var touched := {Vector2i(-1, 0): true}
+		started = Time.get_ticks_usec()
+		var defs = gen.defs_for_touched_cells(probe_root.paint_layers, 0, touched)
+		var live_us := Time.get_ticks_usec() - started
+
+		note(
+			"%d painted cells" % painted,
+			(
+				"detect_boundaries %d segments in %d ms; defs_for_touched_cells for ONE cell %d ms, %d def(s)"
+				% [segments.size(), scan_us / 1000, live_us / 1000, defs.size()]
+			)
+		)
+		if live_us > scan_us * 0.5 and int(half) >= 64:
+			known(
+				441,
+				"the live connector path costs a full-level scan for every stroke",
+				(
+					"defs_for_touched_cells() is documented as 'the live-ghost path; it does "
+					+ "not scan or rebuild geometry', and its first statement is "
+					+ "detect_boundaries(layers), which walks every chunk of every layer. "
+					+ (
+						"With %d painted cells one touched cell took %d ms against %d ms for "
+						% [painted, live_us / 1000, scan_us / 1000]
+					)
+					+ "the full scan it claims to avoid -- the same work, then a filter. "
+					+ "HFPaintTool calls it on every committed stroke"
+				)
+			)
+	root.queue_free()
+
+
+## The grid each layer carries against the level root it belongs to.
+func _does_the_grid_follow_the_level() -> void:
+	var root: Node3D = await fresh_root()
+	var mgr = root.paint_layers
+	var layer = mgr.get_active_layer()
+	note("root position", root.global_position)
+	note("base grid origin", mgr.base_grid.origin)
+	note("layer grid origin", layer.grid.origin)
+
+	var cell := Vector2i(4, 4)
+	var before: Vector3 = layer.grid.uv_to_world(layer.grid.cell_center_uv(cell))
+	note("world position of cell (4,4)", before)
+
+	root.global_position = Vector3(1024, 0, 1024)
+	root._sync_paint_grid_from_root()
+	await frame()
+	note("after moving the root to (1024, 0, 1024)")
+	note("  base grid origin", mgr.base_grid.origin)
+	note("  layer grid origin", layer.grid.origin)
+	var after: Vector3 = layer.grid.uv_to_world(layer.grid.cell_center_uv(cell))
+	note("  world position of cell (4,4)", after)
+
+	if mgr.base_grid.origin != layer.grid.origin:
+		known(
+			442,
+			"moving the level root moves the paint grid but not the grid any layer is using",
+			(
+				"_sync_paint_grid_from_root() writes global_position into "
+				+ "paint_layers.base_grid, and create_layer() gave every layer its own "
+				+ (
+					"base_grid.duplicate(). So base_grid.origin is now %s while the live "
+					% str(mgr.base_grid.origin)
+				)
+				+ (
+					"layer's grid is still %s, and cell (4,4) still resolves to %s. "
+					% [str(layer.grid.origin), str(after)]
+				)
+				+ "_set_grid_snap() has the same shape and does remember to push cell_size "
+				+ "into every layer grid; origin and layer_y are not pushed anywhere. "
+				+ "Painted floors, heightmap sampling and the auto-connectors all read the "
+				+ "layer grid, so the whole floor-paint layer stays behind at the level's "
+				+ "old position"
+			)
+		)
+
+	# A new layer made after the move does pick the move up, so two layers in one
+	# level end up on two different grids.
+	var fresh = mgr.create_layer(&"after_move", 0.0)
+	note("layer created after the move: grid origin", fresh.grid.origin)
+	if fresh.grid.origin != layer.grid.origin:
+		known(
+			442,
+			"two paint layers in one level sit on two different grid origins",
+			(
+				(
+					"the layer made before the move has origin %s and the one made after has %s. "
+					% [str(layer.grid.origin), str(fresh.grid.origin)]
+				)
+				+ "HFAutoConnector.detect_boundaries() compares cells between layers by cell "
+				+ "coordinate and reads each layer's own grid for the height, so a boundary "
+				+ "between these two is computed from coordinates that do not mean the same "
+				+ "thing"
+			)
+		)

--- a/tools/vibe/scenarios/connectors.gd.uid
+++ b/tools/vibe/scenarios/connectors.gd.uid
@@ -1,0 +1,1 @@
+uid://bf16jpxw1obqv

--- a/tools/vibe/scenarios/draw_tools.gd
+++ b/tools/vibe/scenarios/draw_tools.gd
@@ -212,10 +212,19 @@ func _path_settings_out_of_range() -> void:
 	for b in negative:
 		var inward := HFVibe.inward_face_count(b)
 		note("  size", b.size)
+		note("  inward faces", "%d of %d" % [inward, b.get_faces().size()])
 		if inward > 0:
-			flag(
+			known(
+				450,
 				"path tool: a negative width inverts the corridor (%d inward faces)" % inward,
-				"schema says min 0.5; set_setting() does not clamp, size came out %s" % b.size
+				(
+					(
+						"schema says min 0.5 and set_setting() does not clamp. The size came out %s "
+						% b.size
+					)
+					+ "because _usable_size() takes absf() of the negative -- it corrects the size "
+					+ "and leaves the face ring the negative half-extent already reversed"
+				)
 			)
 
 	var zero := _path_brushes(

--- a/tools/vibe/scenarios/examples.gd
+++ b/tools/vibe/scenarios/examples.gd
@@ -1,0 +1,166 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## The Example Level library in the Manage tab.
+##
+## Its one action replaces the level in front of the mapper, which makes it the
+## most destructive button in the dock. What it does to work already in the
+## scene, and whether that is recoverable, is the whole scenario.
+
+const ExampleLibrary = preload("res://addons/hammerforge/ui/hf_example_library.gd")
+const DOCK_SOURCE := "res://addons/hammerforge/dock.gd"
+
+
+func id() -> String:
+	return "examples"
+
+
+func summary() -> String:
+	return "what loading an example does to the level already in the scene, and whether it can be undone"
+
+
+func run() -> void:
+	await _what_load_costs_the_open_level()
+	await _the_card_list_and_its_search()
+
+
+func _library() -> Control:
+	var lib = ExampleLibrary.new()
+	_tree.get_root().add_child(lib)
+	return lib
+
+
+func _dock_source() -> String:
+	var f := FileAccess.open(DOCK_SOURCE, FileAccess.READ)
+	return f.get_as_text() if f else ""
+
+
+func _function_body(source: String, header: String) -> String:
+	var start := source.find(header)
+	if start < 0:
+		return ""
+	var rest := source.substr(start)
+	var next := rest.find("\nfunc ", 1)
+	return rest.substr(0, next) if next > 0 else rest
+
+
+## A level with work in it, then the sequence the Load button runs.
+func _what_load_costs_the_open_level() -> void:
+	var root: Node3D = await fresh_root()
+	for i in range(6):
+		box(root, Vector3(64, 64, 64), Vector3(i * 128, 0, 0))
+	await frame()
+	var entity = DraftEntity.new()
+	entity.entity_type = "player_start"
+	entity.entity_class = "player_start"
+	root.add_entity(entity)
+	await frame()
+
+	var before := HFVibe.describe_level(root)
+	note(
+		"the mapper's level",
+		(
+			"%d brushes, %d entities"
+			% [before.get("brushes", []).size(), before.get("entities", []).size()]
+		)
+	)
+
+	var lib = _library()
+	await frame()
+	note("examples in the library", lib.get_example_count())
+	var data: Dictionary = lib.get_example_data("simple_room")
+	note("simple_room brushes", (data.get("brushes", []) as Array).size())
+
+	# Exactly what dock._load_example_data() does before it places anything.
+	root.clear_brushes()
+	if root.entity_system and root.entity_system.has_method("clear_entities"):
+		root.entity_system.clear_entities()
+	await frame()
+	var after := HFVibe.describe_level(root)
+	note(
+		"after the two clears the Load button runs",
+		(
+			"%d brushes, %d entities"
+			% [after.get("brushes", []).size(), after.get("entities", []).size()]
+		)
+	)
+
+	var source := _dock_source()
+	var load_body := _function_body(source, "func _load_example_data(")
+	var clear_body := _function_body(source, "func _on_clear(")
+	var load_is_undoable := (
+		load_body.contains("HFUndoHelper")
+		or load_body.contains("_commit_state_action")
+		or load_body.contains("create_action")
+	)
+	var clear_is_undoable := (
+		clear_body.contains("HFUndoHelper") or clear_body.contains("_commit_state_action")
+	)
+	note("_on_clear goes through undo", clear_is_undoable)
+	note("_load_example_data goes through undo", load_is_undoable)
+	var confirms := load_body.contains("ConfirmationDialog") or load_body.contains("confirm")
+	note("_load_example_data asks first", confirms)
+
+	if not load_is_undoable and not confirms:
+		known(
+			443,
+			"loading an example silently destroys the open level, with no confirmation and no undo",
+			(
+				"dock._load_example_data() calls level_root.clear_brushes() and "
+				+ "entity_system.clear_entities() directly before placing the example, and "
+				+ "the Load button on each card emits load_requested straight from "
+				+ "_on_load_pressed() with nothing in between. The Clear Brushes button next "
+				+ "to it in the same tab goes through _commit_state_action('Clear Brushes', "
+				+ (
+					"'clear_brushes') and is undoable; this path is not. A level of %d brushes "
+					% before.get("brushes", []).size()
+				)
+				+ (
+					"and %d entit(ies) went to %d and %d, and Ctrl+Z cannot bring it back"
+					% [
+						before.get("entities", []).size(),
+						after.get("brushes", []).size(),
+						after.get("entities", []).size(),
+					]
+				)
+			)
+		)
+	lib.queue_free()
+
+
+## The cards, and the search that indexes into them.
+func _the_card_list_and_its_search() -> void:
+	var lib = _library()
+	await frame()
+	var cards: int = lib._cards_container.get_child_count()
+	note("cards after the first build", cards)
+
+	# A second build in the same frame -- what a reload or a settings change does.
+	lib._load_examples()
+	var doubled: int = lib._cards_container.get_child_count()
+	note("cards after a rebuild in the same frame", doubled)
+	if doubled > cards:
+		known(
+			444,
+			"rebuilding the example list leaves the old cards in place",
+			(
+				"_rebuild_cards() calls child.queue_free() without remove_child(), so the old "
+				+ "cards stay in the container until the end of the frame and the new ones are "
+				+ (
+					"appended below them: %d cards became %d. _on_search_changed() then indexes "
+					% [cards, doubled]
+				)
+				+ "_examples[i] by the container's child order and stops at "
+				+ "i >= _examples.size(), so while the duplicates are alive the search shows "
+				+ "and hides the wrong cards"
+			)
+		)
+
+	lib._on_search_changed("arena")
+	var visible_titles: Array = []
+	for i in range(lib._cards_container.get_child_count()):
+		var card: Control = lib._cards_container.get_child(i)
+		if card.visible:
+			visible_titles.append(card.name)
+	note("cards visible for the search 'arena'", visible_titles)
+	lib.queue_free()

--- a/tools/vibe/scenarios/examples.gd.uid
+++ b/tools/vibe/scenarios/examples.gd.uid
@@ -1,0 +1,1 @@
+uid://dbyn0g2x5ykmo

--- a/tools/vibe/scenarios/heightmap_io.gd
+++ b/tools/vibe/scenarios/heightmap_io.gd
@@ -1,0 +1,153 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## The heightmap as it goes into a saved level and comes back out.
+##
+## A heightmap is a 32-bit float image and the `.hflevel` carries it as a
+## base64 PNG, so the interesting question is what survives that. The scenario
+## puts known float values in, takes them out again, and measures the difference
+## in the world units the mapper actually sees.
+
+const HeightmapIO = preload("res://addons/hammerforge/paint/hf_heightmap_io.gd")
+
+
+func id() -> String:
+	return "heightmap-io"
+
+
+func summary() -> String:
+	return "what a heightmap loses going through the .hflevel's base64 PNG, measured in world units"
+
+
+func run() -> void:
+	await _the_base64_round_trip()
+	await _through_a_real_level_save()
+
+
+func _ramp_image(size: int) -> Image:
+	var img := Image.create(size, size, false, Image.FORMAT_RF)
+	for y in range(size):
+		for x in range(size):
+			# A gentle ramp: the values a sculpted hillside actually holds.
+			img.set_pixel(x, y, Color(float(x) / float(size * 8), 0.0, 0.0, 1.0))
+	return img
+
+
+func _the_base64_round_trip() -> void:
+	var size := 64
+	var before := _ramp_image(size)
+	note("source format", before.get_format())
+	note("source value at (1,0)", before.get_pixel(1, 0).r)
+	note("source value at (2,0)", before.get_pixel(2, 0).r)
+
+	var encoded := HeightmapIO.encode_to_base64(before)
+	note("base64 length", encoded.length())
+	var after := HeightmapIO.decode_from_base64(encoded)
+	if after == null:
+		flag("a heightmap could not be decoded back out of its own encoding")
+		return
+	note("decoded format", after.get_format())
+
+	var worst := 0.0
+	var distinct_before: Dictionary = {}
+	var distinct_after: Dictionary = {}
+	for x in range(size):
+		var a := before.get_pixel(x, 0).r
+		var b := after.get_pixel(x, 0).r
+		distinct_before[snappedf(a, 0.0000001)] = true
+		distinct_after[snappedf(b, 0.0000001)] = true
+		worst = maxf(worst, absf(a - b))
+	note("distinct values along the ramp, before", distinct_before.size())
+	note("distinct values along the ramp, after", distinct_after.size())
+	note("worst error in normalised units", worst)
+
+	# What that is on the ground, at the default height scale.
+	var height_scale := 10.0
+	note("worst error at height_scale %s" % height_scale, worst * height_scale)
+
+	if distinct_after.size() < distinct_before.size():
+		known(
+			445,
+			"saving a level quantises the heightmap to 8 bits per sample",
+			(
+				"HFHeightmapIO.encode_to_base64() calls save_png_to_buffer() on a FORMAT_RF "
+				+ "image. PNG has no 32-bit float channel, so Godot writes it as 8-bit and "
+				+ (
+					"decode_from_base64() converts the 8-bit result back to RF. A %d-step ramp "
+					% distinct_before.size()
+				)
+				+ (
+					"came back with %d distinct values, worst error %s, which is %s world units "
+					% [distinct_after.size(), worst, worst * height_scale]
+				)
+				+ (
+					"at height_scale %s. Every sculpted slope reloads as a staircase, and the "
+					% height_scale
+				)
+				+ "damage compounds on each save/load because the quantised values are what "
+				+ "gets re-encoded"
+			)
+		)
+
+	# And what happens above 1.0, which an imported or sculpted map can hold.
+	var tall := Image.create(4, 4, false, Image.FORMAT_RF)
+	tall.set_pixel(0, 0, Color(4.5, 0, 0, 1))
+	tall.set_pixel(1, 0, Color(-2.0, 0, 0, 1))
+	var tall_back := HeightmapIO.decode_from_base64(HeightmapIO.encode_to_base64(tall))
+	if tall_back:
+		note("4.5 came back as", tall_back.get_pixel(0, 0).r)
+		note("-2.0 came back as", tall_back.get_pixel(1, 0).r)
+		if not is_equal_approx(tall_back.get_pixel(0, 0).r, 4.5):
+			known(
+				445,
+				"a heightmap sample outside 0..1 does not survive a save at all",
+				(
+					(
+						"4.5 came back as %s and -2.0 as %s. The 8-bit PNG round trip clamps as "
+						% [tall_back.get_pixel(0, 0).r, tall_back.get_pixel(1, 0).r]
+					)
+					+ "well as quantises, so anything a sculpt pushed above or below the unit "
+					+ "range is flattened to the limit on the next save"
+				)
+			)
+
+
+## The same trip through capture_state / restore_state on a real level.
+func _through_a_real_level_save() -> void:
+	var root: Node3D = await fresh_root()
+	var layer = root.paint_layers.get_active_layer()
+	layer.heightmap = _ramp_image(64)
+	layer.height_scale = 10.0
+	for y in range(4):
+		for x in range(8):
+			layer.set_cell(Vector2i(x, y), true)
+	await frame()
+
+	var before: Array = []
+	for x in range(8):
+		before.append(snappedf(layer.get_height_at(Vector2i(x, 0)), 0.00001))
+	note("world heights before the save", before)
+
+	var state: Dictionary = root.capture_state()
+	root.restore_state(state)
+	await frame()
+
+	var restored = root.paint_layers.get_active_layer()
+	var after: Array = []
+	for x in range(8):
+		after.append(snappedf(restored.get_height_at(Vector2i(x, 0)), 0.00001))
+	note("world heights after capture/restore", after)
+	if before != after:
+		known(
+			445,
+			"a capture_state / restore_state round trip moves the terrain",
+			(
+				(
+					"the same eight cells read %s before and %s after. The heightmap goes through "
+					% [str(before), str(after)]
+				)
+				+ "HFHeightmapIO.encode_to_base64() in HFStateSystem, which is the same 8-bit "
+				+ "PNG trip -- so this is not only the .hflevel on disk, it is every undo that "
+				+ "restores level state"
+			)
+		)

--- a/tools/vibe/scenarios/heightmap_io.gd.uid
+++ b/tools/vibe/scenarios/heightmap_io.gd.uid
@@ -1,0 +1,1 @@
+uid://bbipxp5kikkrh

--- a/tools/vibe/scenarios/quick_property.gd
+++ b/tools/vibe/scenarios/quick_property.gd
@@ -1,0 +1,163 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## The double-tap quick property popup against the controls it writes into.
+##
+## G G, B B and R R open a small numeric popup over the viewport and the value
+## typed there is pushed straight into a dock control. Three properties, six
+## controls, and nobody has checked that the pairs agree about what a legal
+## value is.
+
+const QuickProperty = preload("res://addons/hammerforge/ui/hf_quick_property.gd")
+
+
+func id() -> String:
+	return "quick-property"
+
+
+func summary() -> String:
+	return "whether the quick popup and the dock control behind it agree on range and step"
+
+
+func run() -> void:
+	await _the_ranges_on_both_sides()
+	await _what_a_committed_value_becomes()
+
+
+func _popup() -> Control:
+	var p = QuickProperty.new()
+	_tree.get_root().add_child(p)
+	return p
+
+
+func _spin_ranges(popup: Control, type: int, values: Array) -> Array:
+	popup.show_property(type, Vector2(10, 10), values)
+	await frame()
+	var out: Array = []
+	for spin in popup._spinboxes:
+		(
+			out
+			. append(
+				{
+					"min": spin.min_value,
+					"max": spin.max_value,
+					"step": spin.step,
+					"value": spin.value,
+				}
+			)
+		)
+	return out
+
+
+## A SpinBox built like the dock's, handed the popup's value.
+func _through(min_v: float, max_v: float, step: float, value: float) -> float:
+	var spin := SpinBox.new()
+	spin.min_value = min_v
+	spin.max_value = max_v
+	spin.step = step
+	spin.value = value
+	var out: float = spin.value
+	spin.free()
+	return out
+
+
+func _the_ranges_on_both_sides() -> void:
+	var popup = _popup()
+	await frame()
+
+	var grid: Array = await _spin_ranges(popup, QuickProperty.PropertyType.GRID_SNAP, [])
+	note("quick GRID_SNAP spin", grid[0])
+	note("dock GridSnap spin (dock.tscn)", {"min": 0.0, "max": 128.0, "step": 1.0})
+
+	var size: Array = await _spin_ranges(popup, QuickProperty.PropertyType.BRUSH_SIZE, [])
+	note("quick BRUSH_SIZE spin", size[0])
+	if not is_equal_approx(float(size[0]["value"]), 4.0):
+		known(
+			447,
+			"the brush size popup cannot express a whole number",
+			(
+				"min 0.1 with step 0.5 puts every legal value at .1 or .6, so a 4.0 brush opens "
+				+ "the popup reading %s" % size[0]["value"]
+			)
+		)
+	note("dock SizeX/Y/Z spin (dock.tscn)", {"min": 1.0, "max": 256.0, "step": 1.0})
+
+	var radius: Array = await _spin_ranges(popup, QuickProperty.PropertyType.PAINT_RADIUS, [])
+	note("quick PAINT_RADIUS spin", radius[0])
+	note(
+		"dock surface_paint_radius spin (paint_tab_builder)",
+		{"min": 0.01, "max": 0.5, "step": 0.01}
+	)
+	note("dock paint_radius spin (paint_tab_builder)", {"min": 1.0, "max": 16.0, "step": 1.0})
+	popup.queue_free()
+
+
+func _what_a_committed_value_becomes() -> void:
+	var popup = _popup()
+	await frame()
+
+	# PAINT_RADIUS. plugin_overlays.on_quick_property_committed() writes values[0]
+	# into dock.surface_paint_radius, which is _make_spin(0.01, 0.5, 0.01, 0.1).
+	var radius: Array = await _spin_ranges(popup, QuickProperty.PropertyType.PAINT_RADIUS, [])
+	var offered: float = radius[0]["value"]
+	var landed := _through(0.01, 0.5, 0.01, offered)
+	note("popup offers a radius of", offered)
+	note("surface_paint_radius takes it as", landed)
+	if not is_equal_approx(offered, landed):
+		known(
+			447,
+			"the quick radius popup's own default is ten times the control's maximum",
+			(
+				"show_property(PAINT_RADIUS) builds a spin of 0.1..512 defaulting to 5.0, and "
+				+ "on_quick_property_committed() writes it into dock.surface_paint_radius, "
+				+ "which is _make_spin(0.01, 0.5, 0.01, 0.1). Pressing Enter on the value the "
+				+ (
+					"popup itself put there turns %s into %s. The popup is documented as "
+					% [offered, landed]
+				)
+				+ "'R R (paint radius)' and the floor paint radius is a different control "
+				+ "again -- dock.paint_radius, 1..16 -- so whichever of the two was meant, "
+				+ "the popup's range matches neither"
+			)
+		)
+
+	# BRUSH_SIZE goes two places: unclamped into input_state.drag_size_default and
+	# clamped into the dock spins.
+	var root: Node3D = await fresh_root()
+	await frame()
+	var typed := Vector3(500.5, 500.5, 500.5)
+	root.input_state.drag_size_default = typed
+	var dock_shows := Vector3(
+		_through(1.0, 256.0, 1.0, typed.x),
+		_through(1.0, 256.0, 1.0, typed.y),
+		_through(1.0, 256.0, 1.0, typed.z)
+	)
+	note("popup allows a brush size up to", 1024.0)
+	note("typed size", typed)
+	note("what the dock spins show", dock_shows)
+	note("what input_state.drag_size_default holds", root.input_state.drag_size_default)
+	if root.input_state.drag_size_default != dock_shows:
+		known(
+			448,
+			"a brush size from the quick popup leaves the dock and the draw tool disagreeing",
+			(
+				"on_quick_property_committed() writes the raw values into "
+				+ "input_state.drag_size_default and the same values into dock.size_x/y/z, "
+				+ (
+					"which are 1..256 step 1 and clamp them. A typed %s leaves the dock reading "
+					% str(typed)
+				)
+				+ (
+					"%s while the next brush drawn is %s. The popup's own spin is 0.1..1024 "
+					% [str(dock_shows), str(root.input_state.drag_size_default)]
+				)
+				+ "step 0.5, so any value with a half unit in it or above 256 splits the two"
+			)
+		)
+
+	var brush = root.create_brush_from_info(
+		{"shape": 0, "size": root.input_state.drag_size_default}
+	)
+	await frame()
+	note("a brush drawn at that size measures", HFVibe.local_extent(brush))
+	popup.queue_free()

--- a/tools/vibe/scenarios/quick_property.gd.uid
+++ b/tools/vibe/scenarios/quick_property.gd.uid
@@ -1,0 +1,1 @@
+uid://c8pbmuwio1vy7

--- a/tools/vibe/scenarios/regions.gd
+++ b/tools/vibe/scenarios/regions.gd
@@ -1,0 +1,128 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## Terrain region streaming: the eviction loop and the bookkeeping under it.
+##
+## Streaming exists so a level bigger than memory can be edited, which makes the
+## eviction loop the one place where paint is deliberately thrown out of memory.
+## What it believes it freed, and what it actually freed, had better agree.
+
+
+func id() -> String:
+	return "regions"
+
+
+func summary() -> String:
+	return "what the region eviction loop frees against what it thinks it freed"
+
+
+func run() -> void:
+	await _eviction_when_the_write_fails()
+	await _what_mark_unloaded_forgets()
+
+
+## Spread one painted cell across `chunks` chunks so each region has real data.
+func _spread_paint(layer, chunks_per_side: int, chunk_size: int) -> int:
+	var made := 0
+	var half := chunks_per_side / 2
+	for cy in range(-half, half):
+		for cx in range(-half, half):
+			layer.set_cell(Vector2i(cx * chunk_size, cy * chunk_size), true)
+			made += 1
+	return made
+
+
+## A level that has never been saved has no region directory, so every region
+## write fails. What does the eviction loop do with that?
+func _eviction_when_the_write_fails() -> void:
+	var root: Node3D = await fresh_root()
+	var paint = root.paint_system
+	var layer = root.paint_layers.get_active_layer()
+	var chunk_size: int = root.paint_layers.chunk_size
+
+	paint.set_region_size_cells(256)
+	paint.set_region_streaming_radius(2)
+	note("region base path", "'%s'" % paint.region_manager.region_base_path)
+
+	var chunks := _spread_paint(layer, 40, chunk_size)
+	note("chunks painted", chunks)
+	await frame()
+
+	paint.set_region_streaming_enabled(true)
+	paint._ensure_regions_for_cell(Vector2i.ZERO)
+	await frame()
+	var loaded_before: int = paint.region_manager.loaded_regions.size()
+	var bytes_before: int = paint._total_loaded_bytes()
+	note("regions loaded", loaded_before)
+	note("bytes the paint system counts as loaded", bytes_before)
+
+	# A budget the level is well over, so the loop has work to do.
+	paint.region_memory_budget_mb = 1
+	note("budget bytes", 1024 * 1024)
+	paint._evict_for_budget(Vector2i.ZERO)
+	await frame()
+
+	var loaded_after: int = paint.region_manager.loaded_regions.size()
+	var bytes_after: int = paint._total_loaded_bytes()
+	note("regions loaded after the eviction pass", loaded_after)
+	note("bytes still loaded", bytes_after)
+
+	if bytes_after > 1024 * 1024 and loaded_after == loaded_before:
+		known(
+			446,
+			"the eviction loop counts memory it did not free and stops with the budget still blown",
+			(
+				"_unload_region() returns false when the region's paint could not be written "
+				+ "-- which is every region while the level has no save path -- and keeps the "
+				+ "region loaded, correctly. _evict_for_budget() ignores that return and "
+				+ "subtracts _estimate_region_bytes(rid) from its running total anyway, so it "
+				+ (
+					"decides the budget is met and breaks. %d regions and %d bytes went in, %d "
+					% [loaded_before, bytes_before, loaded_after]
+				)
+				+ (
+					"regions and %d bytes came out, against a budget of %d. The loop reports "
+					% [bytes_after, 1024 * 1024]
+				)
+				+ "nothing, and the budget control in the dock quietly does nothing on any "
+				+ "level that has not been saved yet"
+			)
+		)
+	root.queue_free()
+
+
+## What the region manager keeps after a region is marked unloaded.
+func _what_mark_unloaded_forgets() -> void:
+	var root: Node3D = await fresh_root()
+	var mgr = root.paint_system.region_manager
+	var rid := Vector2i(3, 4)
+	mgr.mark_loaded(rid)
+	mgr.mark_dirty(rid)
+	note(
+		"loaded / dirty / indexed",
+		[mgr.is_loaded(rid), mgr.dirty_regions.has(rid), mgr.region_index.has(rid)]
+	)
+	mgr.mark_unloaded(rid)
+	note(
+		"after mark_unloaded",
+		[mgr.is_loaded(rid), mgr.dirty_regions.has(rid), mgr.region_index.has(rid)]
+	)
+	if mgr.dirty_regions.has(rid):
+		note(
+			"a region stays in dirty_regions after it is unloaded",
+			(
+				"mark_unloaded() erases loaded_regions and last_access and leaves "
+				+ "dirty_regions alone. Not a defect on its own -- the unload path saves "
+				+ "first -- but it means dirty_regions grows without bound over a session "
+				+ "and can never be trusted as 'these regions are loaded and unsaved'"
+			)
+		)
+
+	# The radius control against what it loads.
+	for radius in [0, 2, 8]:
+		root.paint_system.set_region_streaming_radius(int(radius))
+		note(
+			"streaming radius %s" % radius,
+			"%d regions in the neighbourhood" % mgr.region_ids_in_radius(Vector2i.ZERO).size()
+		)
+	root.queue_free()

--- a/tools/vibe/scenarios/regions.gd.uid
+++ b/tools/vibe/scenarios/regions.gd.uid
@@ -1,0 +1,1 @@
+uid://mrot7ulhomg2

--- a/tools/vibe/scenarios/scatter.gd
+++ b/tools/vibe/scenarios/scatter.gd
@@ -1,0 +1,210 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## The scatter brush, the foliage populator and the paint layer list behind them.
+##
+## Scatter is the one part of the plugin that puts hundreds of nodes into the
+## scene from one click, so what it orients them to, how many it is willing to
+## make, and whether the scene keeps them afterwards are all worth measuring
+## rather than trusting.
+
+const ScatterBrush = preload("res://addons/hammerforge/paint/hf_scatter_brush.gd")
+const FoliagePopulator = preload("res://addons/hammerforge/paint/hf_foliage_populator.gd")
+
+
+func id() -> String:
+	return "scatter"
+
+
+func summary() -> String:
+	return "what a scattered instance is oriented to, how many one click makes, and what the scene keeps"
+
+
+func run() -> void:
+	await _which_way_is_up()
+	await _how_many_one_click_makes()
+	await _what_the_scene_keeps()
+	await _the_layer_list_under_it()
+
+
+func _flat_layer(root: Node3D):
+	var layer = root.paint_layers.get_active_layer()
+	for y in range(-8, 9):
+		for x in range(-8, 9):
+			layer.set_cell(Vector2i(x, y), true)
+	return layer
+
+
+func _settings(mesh_needed: bool = false):
+	var s = ScatterBrush.ScatterSettings.new()
+	s.seed = 12345
+	s.density = 0.1
+	s.radius = 4.0
+	if mesh_needed:
+		s.mesh = BoxMesh.new()
+	return s
+
+
+## A scattered tree on flat ground, asked to stand up.
+func _which_way_is_up() -> void:
+	var root: Node3D = await fresh_root()
+	var layer = _flat_layer(root)
+	var brush = ScatterBrush.new()
+
+	var s = _settings()
+	s.align_to_normal = false
+	s.random_rotation = false
+	var plain = brush.scatter_circle(Vector3.ZERO, layer, s)
+	note("flat ground, no align: instances", plain.transforms.size())
+	if not plain.transforms.is_empty():
+		note("  first basis y", plain.transforms[0].basis.y)
+
+	s.align_to_normal = true
+	var aligned = brush.scatter_circle(Vector3.ZERO, layer, s)
+	note("flat ground, align to normal: instances", aligned.transforms.size())
+	if aligned.transforms.is_empty():
+		note("  nothing placed, nothing to measure")
+		return
+	var up: Vector3 = aligned.transforms[0].basis.y.normalized()
+	note("  first basis y", up)
+	if up.y < 0.0:
+		known(
+			429,
+			"align to surface normal stands every scattered instance on its head",
+			(
+				"flat ground, so the surface normal is +Y; the instance basis y is %s. " % str(up)
+				+ "_compute_normal() crosses the X tangent into the Z tangent, which on a "
+				+ "height field points down -- tz.cross(tx) is the up-facing order"
+			)
+		)
+
+
+## The budget. One drag with the radius wound up.
+func _how_many_one_click_makes() -> void:
+	var root: Node3D = await fresh_root()
+	var layer = root.paint_layers.get_active_layer()
+	var brush = ScatterBrush.new()
+	var s = _settings()
+	s.min_height = -100000.0
+	s.max_height = 100000.0
+	s.max_slope = 90.0
+
+	for radius in [10.0, 100.0, 300.0]:
+		s.radius = radius
+		s.density = 1.0
+		var started := Time.get_ticks_msec()
+		var result = brush.scatter_circle(Vector3.ZERO, layer, s)
+		var took := Time.get_ticks_msec() - started
+		note(
+			"radius %s density 1.0" % radius,
+			(
+				"%d candidates, %d placed, %d ms"
+				% [result.total_candidates, result.transforms.size(), took]
+			)
+		)
+		if result.transforms.size() > 100000:
+			known(
+				430,
+				"one scatter stroke lays out more instances than any cap allows",
+				(
+					(
+						"radius %s at density 1.0 produced %d transforms in %d ms with no refusal. "
+						% [radius, result.transforms.size(), took]
+					)
+					+ "HFDuplicator refuses past MAX_COPY_BRUSHES (256); scatter has no equivalent"
+				)
+			)
+			break
+
+
+## What the scene has after a commit, and what an undo could take back.
+func _what_the_scene_keeps() -> void:
+	var root: Node3D = await fresh_root()
+	var layer = _flat_layer(root)
+	var brush = ScatterBrush.new()
+	var s = _settings(true)
+	var result = brush.scatter_circle(Vector3.ZERO, layer, s)
+	note("instances to commit", result.transforms.size())
+
+	var before := root.get_child_count()
+	var mmi = brush.commit(result.transforms, s, root)
+	await frame()
+	note("committed node", mmi.name if mmi else "<null>")
+	note("root children before/after", "%d -> %d" % [before, root.get_child_count()])
+	if mmi:
+		note("committed node owner", mmi.owner)
+		if mmi.owner == null:
+			known(
+				431,
+				"a committed scatter is not owned, so saving the scene drops every instance",
+				(
+					"HFScatterBrush.commit() calls parent.add_child(mmi) and never sets "
+					+ "mmi.owner. A node without an owner is not written into the .tscn, so "
+					+ "the scatter is there until the scene is closed and gone after"
+				)
+			)
+
+	var populator = FoliagePopulator.new()
+	var fs = FoliagePopulator.FoliageSettings.new()
+	fs.mesh = BoxMesh.new()
+	fs.seed = 7
+	var foliage = populator.populate(layer, fs, root)
+	note("foliage node", foliage.name if foliage else "<null>")
+	if foliage:
+		note("foliage owner", foliage.owner)
+
+	var described := HFVibe.describe_level(root)
+	note("brush count after two commits", described.get("brushes", []).size())
+
+
+## The layer list the scatter target is chosen from.
+func _the_layer_list_under_it() -> void:
+	var root: Node3D = await fresh_root()
+	var mgr = root.paint_layers
+	mgr.create_layer(&"upper", 32.0)
+	mgr.create_layer(&"roof", 64.0)
+	var ids: Array = []
+	for l in mgr.layers:
+		ids.append(str(l.layer_id))
+	note("layer ids", ids)
+
+	mgr.set_active_layer(1)
+	var active_before: StringName = mgr.get_active_layer().layer_id
+	note("active layer before remove", str(active_before))
+	mgr.remove_layer(0)
+	var active_after: StringName = mgr.get_active_layer().layer_id
+	note("active layer after removing layer 0", str(active_after))
+	if active_after != active_before:
+		known(
+			432,
+			"deleting a paint layer moves the selection to a different layer",
+			(
+				(
+					"active was '%s'; after removing the layer above it in the list the active "
+					% str(active_before)
+				)
+				+ (
+					"layer is '%s'. remove_layer() clamps active_layer_index instead of "
+					% str(active_after)
+				)
+				+ "decrementing it when the removed index is below the active one, so the "
+				+ "next stroke lands on a layer the mapper did not choose"
+			)
+		)
+
+	var dup = mgr.create_layer(&"roof", 96.0)
+	var roof_count := 0
+	for l in mgr.layers:
+		if l.layer_id == &"roof":
+			roof_count += 1
+	note("layers named 'roof'", roof_count)
+	note("duplicate layer node name", dup.name)
+	if roof_count > 1:
+		known(
+			433,
+			"two paint layers can share one layer_id",
+			(
+				"create_layer() does not check the id is free; the node name collides too, so the second layer is named '%s'"
+				% dup.name
+			)
+		)

--- a/tools/vibe/scenarios/scatter.gd.uid
+++ b/tools/vibe/scenarios/scatter.gd.uid
@@ -1,0 +1,1 @@
+uid://cq5mtepsb3k31

--- a/tools/vibe/scenarios/selection_filter.gd
+++ b/tools/vibe/scenarios/selection_filter.gd
@@ -1,0 +1,208 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## The Selection Filters popover: walls/floors/ceilings, same material, similar,
+## detail/structural.
+##
+## Every one of these is a bulk selection a mapper then acts on -- paints,
+## deletes, moves. What matters is not that a filter selects something but that
+## the set it selects is the set the button names, and that a face it should not
+## reach is not in it.
+
+const SelectionFilter = preload("res://addons/hammerforge/ui/hf_selection_filter.gd")
+
+
+func id() -> String:
+	return "selection-filter"
+
+
+func summary() -> String:
+	return "which faces each bulk filter reaches, and which faces no filter reaches at all"
+
+
+func run() -> void:
+	await _the_faces_between_the_three_buttons()
+	await _what_a_hidden_brush_contributes()
+	await _detail_against_structural()
+	await _a_filter_that_matches_nothing()
+
+
+class Capture:
+	extends RefCounted
+	var nodes: Array = []
+	var faces: Dictionary = {}
+	var emitted := false
+
+	func take(p_nodes: Array, p_faces: Dictionary) -> void:
+		nodes = p_nodes
+		faces = p_faces
+		emitted = true
+
+
+func _filter_for(root: Node3D, selection: Array = []):
+	var f = SelectionFilter.new()
+	f._root = root
+	f._hf_selection = selection
+	return f
+
+
+func _run_filter(root: Node3D, method: String, selection: Array = []) -> Capture:
+	var f = _filter_for(root, selection)
+	var cap := Capture.new()
+	f.filter_applied.connect(cap.take)
+	f.call(method)
+	f.free()
+	return cap
+
+
+func _face_total(cap: Capture) -> int:
+	var total := 0
+	for key in cap.faces.keys():
+		total += (cap.faces[key] as Array).size()
+	return total
+
+
+## A ramp. Walls, floors and ceilings between them should name every face.
+func _the_faces_between_the_three_buttons() -> void:
+	var root: Node3D = await fresh_root()
+	var b := box(root, Vector3(64, 16, 64))
+	await frame()
+	# 50 degrees off level: steeper than a floor, shallower than a wall.
+	b.rotation = Vector3(deg_to_rad(50.0), 0.0, 0.0)
+	await frame()
+
+	var faces: Array = b.get_faces()
+	note("ramp faces", faces.size())
+	var basis: Basis = b.global_transform.basis
+	var ys: Array = []
+	for f in faces:
+		ys.append(snappedf((basis * f.normal).normalized().y, 0.001))
+	note("world normal y per face", ys)
+
+	var walls := _run_filter(root, "_filter_walls")
+	var floors := _run_filter(root, "_filter_floors")
+	var ceilings := _run_filter(root, "_filter_ceilings")
+	note(
+		"walls / floors / ceilings",
+		"%d / %d / %d" % [_face_total(walls), _face_total(floors), _face_total(ceilings)]
+	)
+
+	var reached: Dictionary = {}
+	for cap in [walls, floors, ceilings]:
+		for key in cap.faces.keys():
+			for i in cap.faces[key]:
+				reached[int(i)] = true
+	var missed: Array = []
+	for i in range(faces.size()):
+		if not reached.has(i):
+			missed.append([i, ys[i]])
+	note("faces no filter reaches", missed)
+	if not missed.is_empty():
+		known(
+			434,
+			"the three normal filters between them do not cover every face",
+			(
+				(
+					"a brush pitched 50 degrees has %d face(s) that Walls, Floors and Ceilings "
+					% missed.size()
+				)
+				+ "all skip: %s (index, world normal y). " % str(missed)
+				+ "Walls is |n.y| < 0.3, Floors is n.y > 0.7, Ceilings is n.y < -0.7, so "
+				+ "everything between 0.3 and 0.7 off level belongs to no button -- exactly "
+				+ "the ramps and chamfers a mapper reaches for the filter to catch"
+			)
+		)
+
+
+## A brush hidden by a visgroup, and what a filter does with it.
+func _what_a_hidden_brush_contributes() -> void:
+	var root: Node3D = await fresh_root()
+	var visible_brush := box(root, Vector3(64, 64, 64))
+	var hidden_brush := box(root, Vector3(64, 64, 64), Vector3(256, 0, 0))
+	await frame()
+	hidden_brush.visible = false
+	await frame()
+	note("brushes", "1 visible, 1 hidden")
+
+	var floors := _run_filter(root, "_filter_floors")
+	note("floor faces selected", _face_total(floors))
+	var keys: Array = floors.faces.keys()
+	note("brushes contributing faces", keys.size())
+	if keys.size() > 1:
+		known(
+			435,
+			"a bulk filter selects faces on brushes that are hidden",
+			(
+				"one of the two brushes has visible = false, and Floors still returned faces "
+				+ (
+					"from both (%d keys). _get_all_brushes() walks _iter_pick_nodes() and never "
+					% keys.size()
+				)
+				+ "looks at visibility, so a paint or a material assignment made straight "
+				+ "after the filter lands on geometry the mapper cannot see"
+			)
+		)
+	note("visible brush still selected", floors.faces.has(HFBrushSystem.face_key(visible_brush)))
+
+
+## Detail, structural, and the brushes that are neither.
+func _detail_against_structural() -> void:
+	var root: Node3D = await fresh_root()
+	var plain := box(root, Vector3(64, 64, 64))
+	var detail := box(root, Vector3(64, 64, 64), Vector3(128, 0, 0))
+	var door := box(root, Vector3(64, 64, 64), Vector3(256, 0, 0))
+	await frame()
+	detail.set_meta("brush_entity_class", "func_detail")
+	door.set_meta("brush_entity_class", "func_door")
+	await frame()
+
+	var as_detail := _run_filter(root, "_filter_detail")
+	var as_structural := _run_filter(root, "_filter_structural")
+	note("detail filter picked", as_detail.nodes.size())
+	note("structural filter picked", as_structural.nodes.size())
+
+	var picked: Dictionary = {}
+	for n in as_detail.nodes:
+		picked[n] = true
+	for n in as_structural.nodes:
+		picked[n] = true
+	note("door brush in either set", picked.has(door))
+	if not picked.has(door):
+		note(
+			"a brush entity that is not func_detail belongs to neither filter",
+			"Structural is cls == '' or 'worldspawn'; a func_door brush answers to neither button"
+		)
+
+
+## What happens when a filter matches nothing.
+func _a_filter_that_matches_nothing() -> void:
+	var root: Node3D = await fresh_root()
+	box(root, Vector3(64, 64, 64))
+	await frame()
+
+	var empty := _run_filter(root, "_filter_detail")
+	note("detail filter on a level with no detail brushes: emitted", empty.emitted)
+	note("  nodes", empty.nodes.size())
+	note("  faces", empty.faces.size())
+	if empty.emitted and empty.nodes.is_empty() and empty.faces.is_empty():
+		known(
+			436,
+			"a filter that matches nothing reports nothing and leaves the old selection standing",
+			(
+				"_filter_detail() emits filter_applied([], {}) when no brush matches. "
+				+ "HFPluginSelectionCommands.on_filter_applied() only acts when one of the two "
+				+ "is non-empty -- with both empty it returns without clearing the selection "
+				+ "and without a toast, so the popover closes and the button looks broken. "
+				+ "The other filters differ again: _filter_same_material() with no face "
+				+ "selected returns before emitting and does not even close the popover"
+			)
+		)
+
+	var f = _filter_for(root, [])
+	var cap := Capture.new()
+	f.filter_applied.connect(cap.take)
+	f.visible = true
+	f._filter_same_material()
+	note("same-material with no face selected: emitted", cap.emitted)
+	note("  popover still open", f.visible)
+	f.free()

--- a/tools/vibe/scenarios/selection_filter.gd.uid
+++ b/tools/vibe/scenarios/selection_filter.gd.uid
@@ -1,0 +1,1 @@
+uid://du0aqdqhqjw65

--- a/tools/vibe/scenarios/shortcut_surfaces.gd
+++ b/tools/vibe/scenarios/shortcut_surfaces.gd
@@ -1,0 +1,149 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## Every surface that tells a mapper which key does what, checked against the
+## keymap that actually decides it.
+##
+## The keymap is rebindable -- `HFKeymap.set_binding()` writes it and the
+## shortcut dialog offers it -- so a surface that spells a chord into a string
+## literal is a claim that stops being true the moment someone uses that dialog.
+
+## The HUD is scene-backed -- its @onready node paths only resolve from the
+## packed scene, so instantiating the bare script logs "Node not found".
+const ShortcutHudScene = preload("res://addons/hammerforge/shortcut_hud.tscn")
+const CoachMarks = preload("res://addons/hammerforge/ui/hf_coach_marks.gd")
+const TooltipText = preload("res://addons/hammerforge/ui/hf_tooltip_text.gd")
+
+const KEYMAP_PATH := "user://vibe_keymap_surfaces.json"
+
+
+func id() -> String:
+	return "shortcut-surfaces"
+
+
+func summary() -> String:
+	return "whether the HUD, the coach marks and the tooltips still tell the truth after a rebind"
+
+
+func run() -> void:
+	await _who_reads_the_keymap_and_who_does_not()
+	await _duplicate_labels_in_the_rebind_list()
+
+
+func _hud() -> Control:
+	var hud = ShortcutHudScene.instantiate()
+	_tree.get_root().add_child(hud)
+	return hud
+
+
+func _select_mode_text(hud: Control) -> String:
+	return hud._build_shortcuts_text({"tool": 1, "mode": 0})
+
+
+func _coach_steps(guide: String) -> Array:
+	var guides: Dictionary = CoachMarks.GUIDES
+	return guides.get(guide, {}).get("steps", [])
+
+
+func _who_reads_the_keymap_and_who_does_not() -> void:
+	var keymap := HFKeymap.load_or_default(KEYMAP_PATH)
+	note("default Hollow binding", keymap.get_display_string("hollow"))
+
+	var hud = _hud()
+	await frame()
+	var before := _select_mode_text(hud)
+	note("HUD select-mode line", before.split("\n")[7] if before.split("\n").size() > 7 else before)
+
+	# The rebind a mapper makes when Ctrl+H is taken by something else.
+	keymap.set_binding("hollow", KEY_H, true, false, true)
+	note("Hollow after rebind", keymap.get_display_string("hollow"))
+
+	var after := _select_mode_text(hud)
+	note("HUD select-mode text unchanged", before == after)
+	var lying: Array = []
+	if after.contains("Ctrl+H"):
+		lying.append("viewport HUD: '%s'" % _line_containing(after, "Ctrl+H"))
+	var hollow_steps := _coach_steps("hollow")
+	for step in hollow_steps:
+		if str(step).contains("Ctrl+H"):
+			lying.append("coach mark: '%s'" % str(step))
+	var hollow_tip := str(TooltipText.TEXTS.get("hollow_btn", ""))
+	note("hollow_btn tooltip", hollow_tip)
+	if hollow_tip.contains("Ctrl+H"):
+		lying.append("dock tooltip: '%s'" % hollow_tip)
+
+	note("surfaces still naming the old chord", lying)
+	if not lying.is_empty():
+		known(
+			439,
+			"a rebound shortcut is still advertised under its old chord in three places",
+			(
+				"Hollow was rebound to %s; " % keymap.get_display_string("hollow")
+				+ "%d surface(s) still say Ctrl+H: %s. " % [lying.size(), str(lying)]
+				+ "HFKeymap.get_display_string() exists and is what dock.gd, "
+				+ "hf_hotkey_palette.gd and hf_shortcut_dialog.gd use, so the same editor "
+				+ "shows the new chord in the palette and the old one in the HUD"
+			)
+		)
+
+	var hard_coded := _count_hard_coded_chords()
+	note("chord literals in shortcut_hud.gd", hard_coded["hud"])
+	note("chord literals in hf_coach_marks.gd", hard_coded["coach"])
+	note("chord literals in hf_tooltip_text.gd", hard_coded["tooltips"])
+
+	hud.queue_free()
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(KEYMAP_PATH))
+
+
+func _line_containing(text: String, needle: String) -> String:
+	for line in text.split("\n"):
+		if line.contains(needle):
+			return line
+	return ""
+
+
+func _count_hard_coded_chords() -> Dictionary:
+	var out := {"hud": 0, "coach": 0, "tooltips": 0}
+	var files := {
+		"hud": "res://addons/hammerforge/shortcut_hud.gd",
+		"coach": "res://addons/hammerforge/ui/hf_coach_marks.gd",
+		"tooltips": "res://addons/hammerforge/ui/hf_tooltip_text.gd",
+	}
+	var regex := RegEx.new()
+	regex.compile("(Ctrl|Shift|Alt)[+][A-Za-z]")
+	for key in files:
+		var f := FileAccess.open(files[key], FileAccess.READ)
+		if f:
+			out[key] = regex.search_all(f.get_as_text()).size()
+	return out
+
+
+## Two actions with the same label in the rebind list.
+func _duplicate_labels_in_the_rebind_list() -> void:
+	var keymap := HFKeymap.load_or_default(KEYMAP_PATH)
+	var by_label: Dictionary = {}
+	for action in keymap.get_actions():
+		var label := HFKeymap.get_action_label(action)
+		var seen: Array = by_label.get(label, [])
+		seen.append("%s (%s)" % [action, keymap.get_display_string(action)])
+		by_label[label] = seen
+	var collisions: Array = []
+	for label in by_label:
+		if (by_label[label] as Array).size() > 1:
+			collisions.append("%s: %s" % [label, str(by_label[label])])
+	note("labels shared by more than one action", collisions)
+	if not collisions.is_empty():
+		known(
+			440,
+			"the rebind list shows two rows with the same name and different keys",
+			(
+				(
+					"HFKeymap.get_action_label() gives %d label(s) to more than one action: %s. "
+					% [collisions.size(), str(collisions)]
+				)
+				+ "hf_shortcut_dialog.gd and hf_hotkey_palette.gd both list by label, so a "
+				+ "mapper rebinding 'Extrude Up' cannot tell which of the two rows is the one "
+				+ "their muscle memory uses, and rebinding the wrong one looks like a no-op"
+			)
+		)
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(KEYMAP_PATH))

--- a/tools/vibe/scenarios/shortcut_surfaces.gd.uid
+++ b/tools/vibe/scenarios/shortcut_surfaces.gd.uid
@@ -1,0 +1,1 @@
+uid://jl2r1ktteig8

--- a/tools/vibe/scenarios/timeline.gd
+++ b/tools/vibe/scenarios/timeline.gd
@@ -1,0 +1,173 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## The operation timeline overlay and the history browser beside it.
+##
+## Both exist to let a mapper read back what they just did and jump to it. So
+## what is worth checking is whether the glyph and colour an operation gets
+## actually tell it apart from the others, and whether the control that does
+## the jumping can be reached at all.
+
+const OperationReplay = preload("res://addons/hammerforge/ui/hf_operation_replay.gd")
+
+## The undo action names the plugin really records, taken from the
+## create_action / history_callback strings in the source.
+const REAL_ACTIONS := [
+	"Clear Brushes",
+	"Apply Brush Material",
+	"Create Polygon Brush",
+	"Clip Brush",
+	"Assign Face Material",
+	"Move to Floor",
+	"Bevel Edge",
+	"Group Selection",
+	"Bake Selected",
+	"Place Prefab: door",
+]
+
+
+func id() -> String:
+	return "timeline"
+
+
+func summary() -> String:
+	return "the glyph and colour an operation gets on the timeline, and whether Replay can be clicked"
+
+
+func run() -> void:
+	await _what_each_operation_looks_like()
+	await _reaching_the_replay_button()
+	await _the_three_different_caps()
+
+
+func _panel() -> Control:
+	var panel = OperationReplay.new()
+	_tree.get_root().add_child(panel)
+	return panel
+
+
+## Every real action name through the icon and colour tables.
+func _what_each_operation_looks_like() -> void:
+	var by_glyph: Dictionary = {}
+	for action in REAL_ACTIONS:
+		var glyph: String = OperationReplay._get_icon_for_action(action)
+		var colour: Color = OperationReplay._get_color_for_action(action)
+		note("  %-22s" % action, "'%s'  %s" % [glyph, colour])
+		by_glyph[glyph] = by_glyph.get(glyph, 0) + 1
+
+	var create_glyph := OperationReplay._get_icon_for_action("Create Polygon Brush")
+	var clear_glyph := OperationReplay._get_icon_for_action("Clear Brushes")
+	var clear_colour := OperationReplay._get_color_for_action("Clear Brushes")
+	var delete_colour := OperationReplay._get_color_for_action("Delete Selection")
+	note("Clear Brushes glyph/colour", "'%s' %s" % [clear_glyph, clear_colour])
+	note("Delete Selection colour", delete_colour)
+	if clear_glyph == create_glyph and clear_colour != delete_colour:
+		known(
+			437,
+			"a destructive operation is drawn on the timeline as a creation",
+			(
+				"_get_icon_for_action() tests 'draw'/'brush'/'create' before 'delete'/'remove' "
+				+ "is reachable for it, and 'Clear Brushes' contains 'brush', so it gets the "
+				+ (
+					"create glyph '%s' and the create colour %s rather than the destructive "
+					% [clear_glyph, clear_colour]
+				)
+				+ "red %s. The name is only in the tooltip" % str(delete_colour)
+			)
+		)
+
+	var material_glyph := OperationReplay._get_icon_for_action("Apply Brush Material")
+	var face_material_glyph := OperationReplay._get_icon_for_action("Assign Face Material")
+	note(
+		"Apply Brush Material vs Assign Face Material",
+		"'%s' vs '%s'" % [material_glyph, face_material_glyph]
+	)
+	if material_glyph != face_material_glyph:
+		known(
+			437,
+			"two material operations get different glyphs because one of them says 'brush'",
+			(
+				(
+					"'Apply Brush Material' is drawn '%s' (create) and 'Assign Face Material' is "
+					% material_glyph
+				)
+				+ (
+					"drawn '%s' (material). The generic 'brush' test sits above 'material', "
+					% face_material_glyph
+				)
+				+ "'move', 'rotate', 'vertex' and 'paint' in the same if-chain, so any action "
+				+ "whose name mentions a brush is filed as a creation whatever it did"
+			)
+		)
+
+	note("distinct glyphs across %d real action names" % REAL_ACTIONS.size(), by_glyph.size())
+	note(
+		"move and redo share a glyph",
+		(
+			OperationReplay._get_icon_for_action("Move Selection")
+			== OperationReplay._get_icon_for_action("Redo")
+		)
+	)
+
+
+## Hover an entry, then try to click Replay.
+func _reaching_the_replay_button() -> void:
+	var panel = _panel()
+	await frame()
+	panel.record_operation("Create Polygon Brush", 4)
+	panel.record_operation("Clip Brush", 5)
+	await frame()
+	note("entries", panel.get_entry_count())
+
+	panel._on_entry_hovered(1)
+	note("after hovering entry 1: Replay visible", panel._replay_btn.visible)
+	note("  hovered index", panel._hovered_index)
+
+	# Moving the pointer off the entry towards the Replay button is a mouse_exited
+	# on the entry -- there is nothing between them.
+	panel._on_entry_unhovered()
+	note("after the pointer leaves the entry: Replay visible", panel._replay_btn.visible)
+	note("  hovered index", panel._hovered_index)
+
+	var emitted := [false]
+	panel.replay_requested.connect(func(_i: int) -> void: emitted[0] = true)
+	panel._on_replay_pressed()
+	note("pressing Replay now emits", emitted[0])
+
+	# And after clicking the entry rather than hovering it.
+	panel._on_entry_clicked(1)
+	note("after clicking entry 1: Replay visible", panel._replay_btn.visible)
+	panel._on_entry_unhovered()
+	note("  then the pointer leaves: Replay visible", panel._replay_btn.visible)
+	panel._on_replay_pressed()
+	note("  pressing Replay emits", emitted[0])
+
+	if not emitted[0]:
+		known(
+			438,
+			"the Replay button cannot be reached: moving towards it is what hides it",
+			(
+				"_replay_btn is shown by _on_entry_hovered() and hidden again by "
+				+ "_on_entry_unhovered(), which also resets _hovered_index to -1. The button "
+				+ "sits in the header, outside the entry it belongs to, so any pointer path "
+				+ "from the entry to the button crosses a mouse_exited first. Clicking the "
+				+ "entry does not help -- _on_entry_clicked() sets the same _hovered_index "
+				+ "that the next mouse_exited clears. _on_replay_pressed() then sees -1 and "
+				+ "emits nothing, so the whole replay path is dead"
+			)
+		)
+	panel.queue_free()
+
+
+## Three components remember three different numbers of operations.
+func _the_three_different_caps() -> void:
+	var panel = _panel()
+	await frame()
+	for i in range(40):
+		panel.record_operation("Create Polygon Brush", i)
+	await frame()
+	note("timeline MAX_ENTRIES", OperationReplay.MAX_ENTRIES)
+	note("entries after 40 operations", panel.get_entry_count())
+	note("version at index 0 after the overflow", panel.get_entry_version(0))
+	note("history browser MAX_ENTRIES", HFHistoryBrowser.MAX_ENTRIES)
+	panel.queue_free()

--- a/tools/vibe/scenarios/timeline.gd.uid
+++ b/tools/vibe/scenarios/timeline.gd.uid
@@ -1,0 +1,1 @@
+uid://culejvypewrpq


### PR DESCRIPTION
The scaffolding from the second 2026-09-12 vibe session. Nine new scenarios in `tools/vibe/`, bringing the sweep to 47.

| scenario | covers | issues |
|---|---|---|
| `scatter` | what a scattered instance is oriented to, how many one click makes, and what the scene keeps | #429 #430 #431 #432 #433 |
| `selection-filter` | which faces each bulk filter reaches, and which faces no filter reaches at all | #434 #435 #436 |
| `timeline` | the glyph and colour an operation gets, and whether Replay can be clicked | #437 #438 |
| `shortcut-surfaces` | whether the HUD, the coach marks and the tooltips still tell the truth after a rebind | #439 #440 |
| `connectors` | what the live connector path costs per stroke, and whether the paint grid follows the level | #441 #442 |
| `examples` | what loading an example does to the level already in the scene | #443 #444 |
| `heightmap-io` | what a heightmap loses going through the `.hflevel`'s base64 PNG, in world units | #445 |
| `regions` | what the region eviction loop frees against what it thinks it freed | #446 |
| `quick-property` | whether the quick popup and the dock control behind it agree on range and step | #447 #448 |

Everything filed is recorded as `known(<issue>, ...)` rather than deleted, so each scenario keeps exercising its defect and goes red if a fix regresses.

**The existing `draw-tools` scenario found one too.** Its negative-width probe was green while #397 was open, because every path brush was inverted. With #397 closed the positive-width case is correct and the negative-width case is not:

```
signed baked volume of a 256x4x4 box:            -8192.0
signed baked volume of a 256-long path segment:  -8192.0   <- #397 fixed

path with width -16: brushes: 1
  size: (256.0, 4.0, 16.0)
  inward faces: 6 of 6
```

Filed as #450 and recorded as `known(450, ...)` in the same scenario.

The whole sweep is clean: 47 of 47 scenarios, `gdformat --check` and `gdlint` pass.