### PR TITLE
Commit the three missing test .uid files

### DIFF
--- a/tests/test_decals_are_part_of_the_level.gd.uid
+++ b/tests/test_decals_are_part_of_the_level.gd.uid
@@ -1,0 +1,1 @@
+uid://sni511ydqi45

--- a/tests/test_extrude_tool_preview_and_ids.gd.uid
+++ b/tests/test_extrude_tool_preview_and_ids.gd.uid
@@ -1,0 +1,1 @@
+uid://ddjk4ki8tvrki

--- a/tests/test_painted_face_material.gd.uid
+++ b/tests/test_painted_face_material.gd.uid
@@ -1,0 +1,1 @@
+uid://c5wvd7ikuadk1


### PR DESCRIPTION
`tests/` carries a `.uid` beside every test script — 190 of 193. The three gaps are the tests added by #420, #421 and #425, where the `.uid` was never committed alongside the `.gd`.

```
tests/test_decals_are_part_of_the_level.gd.uid
tests/test_extrude_tool_preview_and_ids.gd.uid
tests/test_painted_face_material.gd.uid
```

Godot regenerates a missing `.uid` on import with a fresh value, so every checkout minted its own and the three turned up as untracked files in unrelated branches. Committing them makes it 193 of 193.

No behaviour change — the ids are what the current checkout already resolves.