### PR TITLE
Store heightmaps as raw floats instead of an 8 bit PNG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **Saving a level no longer rounds every heightmap sample to 8 bits** (#445). A
+  paint layer's heightmap is a `FORMAT_RF` image - one 32 bit float per sample -
+  and `HFHeightmapIO` stored it as a base64 PNG. PNG has no float channel, so
+  Godot wrote it as 8 bit and the decode converted the 8 bit result back to RF:
+  256 height values survived across the whole range, anything above 1.0 or below
+  0.0 was clamped to the limit, and each save re-rounded the already rounded
+  data. `HFStateSystem.capture_state()` uses the same encoder, so an undo of an
+  unrelated operation moved the terrain. The heightmap is now stored as the raw
+  float buffer, zstd compressed, behind a small header, which loses nothing. A
+  base64 PNG written by an older version is still recognised and loaded.
 - **A shortcut rebound onto a chord another action already uses was accepted in
   silence** (#410). Nothing compared a new binding against the others, so
   `matches()` answered true for both, and `plugin_input_router` tests actions one

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,659 tests across 192 test scripts (3,652 passing plus seven intentional no-assert safety tests; 18,459 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,664 tests across 192 test scripts (3,657 passing plus seven intentional no-assert safety tests; 18,471 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -349,7 +349,7 @@ Foliage Populator
 - Brush records include face data (materials, UVs, paint layers), visgroup membership, group_id, and `brush_entity_class`.
 - Entity records include visgroup membership, group_id, and `io_outputs` (Entity I/O connections).
 - Paint layers include grid settings, chunk size, bitset data, `material_ids`, `blend_weights` (+ _2/_3), and terrain slot settings.
-- Optional per-layer: `heightmap_b64` (base64 PNG), `height_scale`. Missing keys = no heightmap (backward-compatible).
+- Optional per-layer: `heightmap_b64` (base64 raw float buffer, zstd compressed; a base64 PNG from an older version still loads), `height_scale`. Missing keys = no heightmap (backward-compatible).
 - Level settings include `texture_lock`, `cordon_enabled`, `cordon_aabb_pos`, `cordon_aabb_size`.
 - Visgroup definitions and group registry stored in state via `capture_visgroups()` / `capture_groups()`.
 

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,659 tests** across **192 scripts** (**3,652 passing** plus seven intentional no-assert safety tests; **18,459 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,664 tests** across **192 scripts** (**3,657 passing** plus seven intentional no-assert safety tests; **18,471 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3652%20passing-brightgreen" alt="3652 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3657%20passing-brightgreen" alt="3657 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,659 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,664 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/paint/hf_heightmap_io.gd
+++ b/addons/hammerforge/paint/hf_heightmap_io.gd
@@ -23,20 +23,78 @@ static func generate_noise(width: int, height: int, settings: Dictionary = {}) -
 	return img
 
 
+## Heightmaps are FORMAT_RF - one 32 bit float per sample - so they are stored
+## as the raw float buffer, zstd compressed, behind a small header. PNG has no
+## float channel: it would round every sample to 8 bits and clamp it to 0..1,
+## and because the same encoder backs capture_state() that loss applied to undo
+## as well as to the saved file.
+const RAW_MAGIC := 0x4D484648  # "HFHM"
+const RAW_VERSION := 1
+const RAW_HEADER_SIZE := 20
+
+
 static func encode_to_base64(img: Image) -> String:
 	if img == null or img.is_empty():
 		return ""
-	var png := img.save_png_to_buffer()
-	return Marshalls.raw_to_base64(png)
+	var src := img
+	if src.get_format() != Image.FORMAT_RF:
+		src = Image.new()
+		src.copy_from(img)
+		src.convert(Image.FORMAT_RF)
+	var pixels := src.get_data()
+	var packed := pixels.compress(FileAccess.COMPRESSION_ZSTD)
+	var buf := PackedByteArray()
+	buf.resize(RAW_HEADER_SIZE)
+	buf.encode_u32(0, RAW_MAGIC)
+	buf.encode_u32(4, RAW_VERSION)
+	buf.encode_u32(8, src.get_width())
+	buf.encode_u32(12, src.get_height())
+	buf.encode_u32(16, pixels.size())
+	buf.append_array(packed)
+	return Marshalls.raw_to_base64(buf)
 
 
 static func decode_from_base64(data: String) -> Image:
 	if data == "":
 		return null
 	var raw := Marshalls.base64_to_raw(data)
+	if raw.size() >= RAW_HEADER_SIZE and raw.decode_u32(0) == RAW_MAGIC:
+		return _decode_raw(raw)
+	# Levels saved before the float format stored an 8 bit PNG.
 	var img := Image.new()
 	if img.load_png_from_buffer(raw) != OK:
 		push_error("HFHeightmapIO: Failed to decode heightmap from base64")
 		return null
 	img.convert(Image.FORMAT_RF)
 	return img
+
+
+static func _decode_raw(raw: PackedByteArray) -> Image:
+	var version := int(raw.decode_u32(4))
+	if version != RAW_VERSION:
+		push_error(
+			(
+				(
+					"HFHeightmapIO: Heightmap format version %d was written by a newer "
+					+ "HammerForge and cannot be read here."
+				)
+				% version
+			)
+		)
+		return null
+	var w := int(raw.decode_u32(8))
+	var h := int(raw.decode_u32(12))
+	var expected := int(raw.decode_u32(16))
+	if w <= 0 or h <= 0 or expected != w * h * 4:
+		push_error("HFHeightmapIO: Heightmap header describes %dx%d in %d bytes" % [w, h, expected])
+		return null
+	var pixels := raw.slice(RAW_HEADER_SIZE).decompress(expected, FileAccess.COMPRESSION_ZSTD)
+	if pixels.size() != expected:
+		push_error(
+			(
+				"HFHeightmapIO: Heightmap payload unpacked to %d bytes, expected %d"
+				% [pixels.size(), expected]
+			)
+		)
+		return null
+	return Image.create_from_data(w, h, false, Image.FORMAT_RF, pixels)

--- a/docs/HammerForge_FloorPaint_Greyboxing.md
+++ b/docs/HammerForge_FloorPaint_Greyboxing.md
@@ -133,7 +133,7 @@ Paint layers serialize into the level save:
 - chunk size
 - chunks with bitset data, `material_ids`, and `blend_weights` / `blend_weights_2` / `blend_weights_3`
 - per-cell wall height overrides
-- `heightmap_b64` (base64-encoded PNG) and `height_scale` per layer (optional, backward-compatible)
+- `heightmap_b64` (base64-encoded raw float buffer, zstd compressed) and `height_scale` per layer (optional, backward-compatible; a base64 PNG written by an older version still loads)
 - `terrain_slot_paths`, `terrain_slot_uv_scales`, `terrain_slot_tints` per layer
 - confirmed paint connector definitions
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,659 tests across 192 scripts**: **3,652 passing tests**, seven intentional no-assert safety tests, and **18,459 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,664 tests across 192 scripts**: **3,657 passing tests**, seven intentional no-assert safety tests, and **18,471 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_heightmap_io.gd
+++ b/tests/test_heightmap_io.gd
@@ -132,3 +132,61 @@ func test_noise_encode_decode_round_trip():
 	assert_almost_eq(
 		decoded.get_pixel(20, 20).r, original.get_pixel(20, 20).r, 0.01, "Pixel (20,20) survives"
 	)
+
+
+# ===========================================================================
+# Float fidelity (#445)
+# ===========================================================================
+
+
+func test_round_trip_keeps_exact_float_values():
+	var img = Image.create(4, 4, false, Image.FORMAT_RF)
+	img.set_pixel(0, 0, Color(0.123456, 0, 0, 1))
+	img.set_pixel(1, 1, Color(0.987654, 0, 0, 1))
+	var decoded = HFHeightmapIO.decode_from_base64(HFHeightmapIO.encode_to_base64(img))
+	assert_not_null(decoded)
+	assert_almost_eq(decoded.get_pixel(0, 0).r, 0.123456, 0.0000005, "Exact sample preserved")
+	assert_almost_eq(decoded.get_pixel(1, 1).r, 0.987654, 0.0000005, "Exact sample preserved")
+
+
+func test_round_trip_keeps_values_outside_zero_one():
+	var img = Image.create(2, 2, false, Image.FORMAT_RF)
+	img.set_pixel(0, 0, Color(4.5, 0, 0, 1))
+	img.set_pixel(1, 0, Color(-2.0, 0, 0, 1))
+	var decoded = HFHeightmapIO.decode_from_base64(HFHeightmapIO.encode_to_base64(img))
+	assert_not_null(decoded)
+	assert_almost_eq(decoded.get_pixel(0, 0).r, 4.5, 0.0001, "Height above 1.0 survives")
+	assert_almost_eq(decoded.get_pixel(1, 0).r, -2.0, 0.0001, "Height below 0.0 survives")
+
+
+func test_round_trip_keeps_every_step_of_a_ramp():
+	var img = Image.create(64, 1, false, Image.FORMAT_RF)
+	for x in range(64):
+		img.set_pixel(x, 0, Color(float(x) / 64.0, 0, 0, 1))
+	var decoded = HFHeightmapIO.decode_from_base64(HFHeightmapIO.encode_to_base64(img))
+	var distinct := {}
+	for x in range(64):
+		distinct[decoded.get_pixel(x, 0).r] = true
+	assert_eq(distinct.size(), 64, "All 64 ramp steps stay distinct")
+
+
+func test_decode_accepts_legacy_png_payload():
+	var img = Image.create(8, 8, false, Image.FORMAT_RF)
+	img.fill(Color(0.5, 0, 0, 1))
+	var legacy = Marshalls.raw_to_base64(img.save_png_to_buffer())
+	var decoded = HFHeightmapIO.decode_from_base64(legacy)
+	assert_not_null(decoded, "A level saved before the float format still loads")
+	assert_eq(decoded.get_format(), Image.FORMAT_RF, "Legacy payload converts to RF")
+	assert_eq(decoded.get_width(), 8)
+
+
+func test_decode_rejects_payload_whose_header_does_not_match():
+	var img = Image.create(8, 8, false, Image.FORMAT_RF)
+	img.fill(Color(0.25, 0, 0, 1))
+	var raw = Marshalls.base64_to_raw(HFHeightmapIO.encode_to_base64(img))
+	raw.encode_u32(8, 9)  # claim 9x8 samples, which no longer matches the byte count
+	assert_null(
+		HFHeightmapIO.decode_from_base64(Marshalls.raw_to_base64(raw)),
+		"A payload whose header disagrees with its size decodes to null"
+	)
+	assert_push_error("header describes 9x8")


### PR DESCRIPTION
Fixes #445.

- `HFHeightmapIO` now encodes a paint layer's `FORMAT_RF` heightmap as the raw float buffer, zstd compressed, behind a 20 byte header. PNG has no float channel, so the old path rounded every sample to 8 bits and clamped it to 0..1.
- `HFStateSystem.capture_state()` calls the same encoder, so this also stops an unrelated undo from moving the terrain.
- A base64 PNG written by an older version is still recognised and loaded.
- Tests for exact float round trip, out of range heights, a 64 step ramp, legacy PNG payloads, and a mismatched header.
- CHANGELOG, SPEC and the floor paint doc updated.