### PR TITLE
Make the selection filters cover every face, skip hidden brushes and report an empty result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,18 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **The selection filters reach every face, only the visible ones, and say when
+  they match nothing** (#434, #435, #436). Walls was `|n.y| < 0.3`, Floors was
+  `n.y > 0.7` and Ceilings was `n.y < -0.7`, so a face 17 to 45 degrees off
+  level - a ramp, a chamfer, a bevelled edge, most of what a mapper opens a
+  bulk face filter for - belonged to no button at all. The three now partition
+  the sphere between them at one threshold. `_get_all_brushes()` also walked
+  `_iter_pick_nodes()` with no visibility test, so every bulk filter selected
+  faces on brushes hidden by a visgroup and the paint or material assignment
+  that followed edited geometry the mapper had hidden precisely so it would not
+  be; hidden brushes are now left out. And a filter that matched nothing closed
+  in silence with the previous selection standing, in three different ways:
+  they now all close and report what was looked for.
 - **A shortcut rebound onto a chord another action already uses was accepted in
   silence** (#410). Nothing compared a new binding against the others, so
   `matches()` answered true for both, and `plugin_input_router` tests actions one

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,659 tests across 192 test scripts (3,652 passing plus seven intentional no-assert safety tests; 18,459 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,669 tests across 193 test scripts (3,662 passing plus seven intentional no-assert safety tests; 18,475 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,669 tests across 193 test scripts (3,662 passing plus seven intentional no-assert safety tests; 18,475 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,699 tests across 196 test scripts (3,692 passing plus seven intentional no-assert safety tests; 18,583 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,659 tests** across **192 scripts** (**3,652 passing** plus seven intentional no-assert safety tests; **18,459 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,669 tests** across **193 scripts** (**3,662 passing** plus seven intentional no-assert safety tests; **18,475 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,669 tests** across **193 scripts** (**3,662 passing** plus seven intentional no-assert safety tests; **18,475 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,699 tests** across **196 scripts** (**3,692 passing** plus seven intentional no-assert safety tests; **18,583 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3652%20passing-brightgreen" alt="3652 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3662%20passing-brightgreen" alt="3662 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3662%20passing-brightgreen" alt="3662 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3692%20passing-brightgreen" alt="3692 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,669 tests across 193 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,699 tests across 196 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,659 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,669 tests across 193 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/plugin.gd
+++ b/addons/hammerforge/plugin.gd
@@ -250,6 +250,7 @@ func _enter_tree():
 	# Selection filter popover (Window-based — not a Control, so managed manually)
 	_selection_filter = HFSelectionFilter.new()
 	_selection_filter.filter_applied.connect(_on_selection_filter_applied)
+	_selection_filter.filter_reported.connect(_on_selection_filter_reported)
 	get_editor_interface().get_base_control().add_child(_selection_filter)
 	if should_install_power_user_overlays(_user_prefs):
 		_install_power_user_overlays()
@@ -407,6 +408,7 @@ func _exit_tree():
 	if _selection_filter:
 		if is_instance_valid(_selection_filter):
 			_selection_filter.filter_applied.disconnect(_on_selection_filter_applied)
+			_selection_filter.filter_reported.disconnect(_on_selection_filter_reported)
 			if _selection_filter.get_parent():
 				_selection_filter.get_parent().remove_child(_selection_filter)
 			_selection_filter.queue_free()
@@ -1303,6 +1305,12 @@ func _show_selection_filter() -> void:
 
 func _on_selection_filter_applied(nodes: Array, faces: Dictionary) -> void:
 	HFPluginSelectionCommands.on_filter_applied(self, nodes, faces)
+
+
+## A filter that matched nothing says so, rather than closing in silence.
+func _on_selection_filter_reported(message: String) -> void:
+	if dock:
+		dock.show_toast(message, 1)
 
 
 # ---------------------------------------------------------------------------

--- a/addons/hammerforge/ui/hf_selection_filter.gd
+++ b/addons/hammerforge/ui/hf_selection_filter.gd
@@ -5,6 +5,21 @@ extends PopupPanel
 ## and "Select Similar" based on the current face or brush.
 
 signal filter_applied(nodes: Array, faces: Dictionary)
+## Emitted instead of `filter_applied` when a filter has nothing to select,
+## carrying the reason. A filter that matched nothing used to close in silence
+## and leave the previous selection standing, which is indistinguishable from a
+## dead button.
+signal filter_reported(message: String)
+
+## Where a wall stops being a wall and starts being a ramp.
+##
+## The three normal buttons partition the sphere between them: anything within
+## this much of vertical is a wall, everything else is a floor or a ceiling by
+## its sign. They used to sample three patches with a gap between them, and a
+## face 17 to 45 degrees off level - a ramp, a chamfer, a bevelled edge - was
+## reachable from no button at all.
+const WALL_NORMAL_Y := 0.3
+const WALL_TILT_DEGREES := 17
 
 var _root: Node = null  # LevelRoot reference
 var _hf_selection: Array = []  # Current plugin selection
@@ -38,9 +53,21 @@ func _build_ui() -> void:
 	var normal_row1 = HBoxContainer.new()
 	normal_row1.add_theme_constant_override("separation", 4)
 	_vbox.add_child(normal_row1)
-	_add_filter_btn(normal_row1, "Walls", "Select all vertical faces (walls)", "_filter_walls")
-	_add_filter_btn(normal_row1, "Floors", "Select all upward-facing faces", "_filter_floors")
-	_add_filter_btn(normal_row1, "Ceilings", "Select all downward-facing faces", "_filter_ceilings")
+	_add_filter_btn(
+		normal_row1,
+		"Walls",
+		"Select faces within %d degrees of vertical" % WALL_TILT_DEGREES,
+		"_filter_walls"
+	)
+	_add_filter_btn(
+		normal_row1, "Floors", "Select upward-facing faces, ramps included", "_filter_floors"
+	)
+	_add_filter_btn(
+		normal_row1,
+		"Ceilings",
+		"Select downward-facing faces, overhangs included",
+		"_filter_ceilings"
+	)
 
 	_vbox.add_child(HSeparator.new())
 
@@ -173,29 +200,46 @@ func _rebuild_visgroup_buttons() -> void:
 # ---------------------------------------------------------------------------
 
 
+## Every brush a bulk filter is allowed to touch.
+##
+## A hidden brush is left out. Hiding geometry to work on what is behind it is
+## the normal use of a visgroup, which is exactly when a bulk filter is most
+## likely to be reached for, and a material assignment or a nudge made straight
+## after the filter would land on geometry the mapper cannot see.
 func _get_all_brushes() -> Array:
 	if not _root:
 		return []
 	var out: Array = []
 	for node in _root._iter_pick_nodes():
-		if _root.is_brush_node(node):
-			out.append(node)
+		if not _root.is_brush_node(node):
+			continue
+		if node is Node3D and not (node as Node3D).is_visible_in_tree():
+			continue
+		out.append(node)
 	return out
 
 
+## Close the popover and say why nothing was selected.
+func _report(message: String) -> void:
+	filter_reported.emit(message)
+	visible = false
+
+
 func _filter_walls() -> void:
-	_select_faces_by_normal(func(n: Vector3) -> bool: return absf(n.y) < 0.3)
+	_select_faces_by_normal(
+		func(n: Vector3) -> bool: return absf(n.y) <= WALL_NORMAL_Y, "vertical faces"
+	)
 
 
 func _filter_floors() -> void:
-	_select_faces_by_normal(func(n: Vector3) -> bool: return n.y > 0.7)
+	_select_faces_by_normal(func(n: Vector3) -> bool: return n.y > WALL_NORMAL_Y, "upward faces")
 
 
 func _filter_ceilings() -> void:
-	_select_faces_by_normal(func(n: Vector3) -> bool: return n.y < -0.7)
+	_select_faces_by_normal(func(n: Vector3) -> bool: return n.y < -WALL_NORMAL_Y, "downward faces")
 
 
-func _select_faces_by_normal(predicate: Callable) -> void:
+func _select_faces_by_normal(predicate: Callable, what: String) -> void:
 	if not _root:
 		return
 	var face_sel: Dictionary = {}
@@ -213,6 +257,9 @@ func _select_faces_by_normal(predicate: Callable) -> void:
 					indices.append(i)
 		if not indices.is_empty():
 			face_sel[key] = indices
+	if face_sel.is_empty():
+		_report("No %s on any visible brush" % what)
+		return
 	filter_applied.emit([], face_sel)
 	visible = false
 
@@ -223,6 +270,7 @@ func _filter_same_material() -> void:
 	# Get material indices from currently selected faces
 	var mat_indices: Array = _get_selected_material_indices()
 	if mat_indices.is_empty():
+		_report("Select a face first, then Same Material")
 		return
 	var face_sel: Dictionary = {}
 	var brushes := _get_all_brushes()
@@ -236,6 +284,9 @@ func _filter_same_material() -> void:
 				indices.append(i)
 		if not indices.is_empty():
 			face_sel[key] = indices
+	if face_sel.is_empty():
+		_report("No visible face uses that material")
+		return
 	filter_applied.emit([], face_sel)
 	visible = false
 
@@ -247,6 +298,7 @@ func _filter_similar_faces() -> void:
 	var ref_normals: Array = _get_selected_face_world_normals()
 	var ref_faces: Array = _get_selected_face_refs()
 	if ref_faces.is_empty():
+		_report("Select a face first, then Similar Faces")
 		return
 	var face_sel: Dictionary = {}
 	var brushes := _get_all_brushes()
@@ -268,6 +320,9 @@ func _filter_similar_faces() -> void:
 					break
 		if not indices.is_empty():
 			face_sel[key] = indices
+	if face_sel.is_empty():
+		_report("No visible face matches the selected one")
+		return
 	filter_applied.emit([], face_sel)
 	visible = false
 
@@ -281,6 +336,7 @@ func _filter_similar_brushes() -> void:
 		if node is DraftBrush and is_instance_valid(node):
 			ref_sizes.append((node as DraftBrush).size)
 	if ref_sizes.is_empty():
+		_report("Select a brush first, then Similar Brushes")
 		return
 	var tolerance := 0.2
 	var picked: Array = []
@@ -293,6 +349,9 @@ func _filter_similar_brushes() -> void:
 			if _size_similar(sz, ref_sz, tolerance):
 				picked.append(brush)
 				break
+	if picked.is_empty():
+		_report("No visible brush is a similar size")
+		return
 	filter_applied.emit(picked, {})
 	visible = false
 
@@ -301,6 +360,9 @@ func _filter_visgroup(vg_name: String) -> void:
 	if not _root or not _root.visgroup_system:
 		return
 	var members: Array = _root.visgroup_system.get_members_of(vg_name)
+	if members.is_empty():
+		_report("Visgroup %s has no members" % vg_name)
+		return
 	filter_applied.emit(members, {})
 	visible = false
 
@@ -313,6 +375,9 @@ func _filter_detail() -> void:
 			var cls: String = str(brush.get_meta("brush_entity_class", ""))
 			if cls == "func_detail" or cls.contains("detail"):
 				picked.append(brush)
+	if picked.is_empty():
+		_report("No detail brushes in this level")
+		return
 	filter_applied.emit(picked, {})
 	visible = false
 
@@ -324,6 +389,9 @@ func _filter_structural() -> void:
 		var cls: String = str(brush.get_meta("brush_entity_class", ""))
 		if cls == "" or cls == "worldspawn":
 			picked.append(brush)
+	if picked.is_empty():
+		_report("No structural brushes in this level")
+		return
 	filter_applied.emit(picked, {})
 	visible = false
 

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -887,11 +887,13 @@ Press **Shift+F** or click the **Flt** button on the context toolbar to open the
 
 | Category | Filters | Description |
 |----------|---------|-------------|
-| **By Normal** | Walls, Floors, Ceilings | Select faces by surface direction |
+| **By Normal** | Walls, Floors, Ceilings | Select faces by surface direction. The three partition every direction between them: a face within 17 degrees of vertical is a wall, everything else is a floor or a ceiling by its sign, so ramps and chamfers come out with the floors |
 | **By Material** | Same Material | Select all faces matching the selected face's material |
 | **Select Similar** | Similar Faces, Similar Brushes | Faces: match material + normal (15°). Brushes: match size (20% tolerance, orientation-agnostic) |
 | **By Visgroup** | *(dynamic)* | One button per visgroup — select all members |
 | **By Type** | Detail, Structural | func_detail vs worldspawn brushes |
+
+Filters only ever reach brushes you can see. A brush hidden on its own or by a visgroup is left out, so a material assignment made straight after a filter cannot land on geometry you hid on purpose. A filter that matches nothing leaves the current selection alone and says why ("No detail brushes in this level", "Select a face first, then Same Material").
 
 ### Select Similar
 Press **Shift+S** to quickly select similar geometry without opening the filter popover:

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,669 tests across 193 scripts**: **3,662 passing tests**, seven intentional no-assert safety tests, and **18,475 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,699 tests across 196 scripts**: **3,692 passing tests**, seven intentional no-assert safety tests, and **18,583 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,659 tests across 192 scripts**: **3,652 passing tests**, seven intentional no-assert safety tests, and **18,459 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,669 tests across 193 scripts**: **3,662 passing tests**, seven intentional no-assert safety tests, and **18,475 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_selection_filter_coverage.gd
+++ b/tests/test_selection_filter_coverage.gd
@@ -1,0 +1,168 @@
+extends GutTest
+
+## #434, #435, #436. The Selection Filters popover is a bulk selection a mapper
+## then acts on. What matters is that the three normal buttons between them name
+## every face, that a hidden brush is not in the answer, and that a filter with
+## nothing to select says so.
+
+const HFSelectionFilter = preload("res://addons/hammerforge/ui/hf_selection_filter.gd")
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+
+var root: LevelRoot
+
+
+class Capture:
+	extends RefCounted
+
+	var nodes: Array = []
+	var faces: Dictionary = {}
+	var emitted := false
+	var message := ""
+
+	func take(p_nodes: Array, p_faces: Dictionary) -> void:
+		nodes = p_nodes
+		faces = p_faces
+		emitted = true
+
+	func hear(p_message: String) -> void:
+		message = p_message
+
+
+func before_each():
+	root = LevelRootType.new()
+	root.auto_spawn_player = false
+	root.commit_freeze = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+
+
+func after_each():
+	root = null
+
+
+func _box(size: Vector3, centre: Vector3 = Vector3.ZERO) -> Node:
+	return root.create_brush_from_info({"shape": 0, "size": size, "center": centre})
+
+
+func _run(method: String, selection: Array = []) -> Capture:
+	var sf = HFSelectionFilter.new()
+	sf._root = root
+	sf._hf_selection = selection
+	var cap := Capture.new()
+	sf.filter_applied.connect(cap.take)
+	sf.filter_reported.connect(cap.hear)
+	sf.call(method)
+	sf.free()
+	return cap
+
+
+func _face_total(cap: Capture) -> int:
+	var total := 0
+	for key in cap.faces.keys():
+		total += (cap.faces[key] as Array).size()
+	return total
+
+
+# ===========================================================================
+# The three normal buttons cover the sphere (#434)
+# ===========================================================================
+
+
+func test_no_face_of_a_ramp_is_left_to_no_filter():
+	var brush := _box(Vector3(64, 16, 64)) as Node3D
+	# 50 degrees off level: steeper than a floor was, shallower than a wall.
+	brush.rotation = Vector3(deg_to_rad(50.0), 0.0, 0.0)
+	var faces: Array = brush.get_faces()
+	var reached := {}
+	for method in ["_filter_walls", "_filter_floors", "_filter_ceilings"]:
+		var cap := _run(method)
+		for key in cap.faces.keys():
+			for i in cap.faces[key]:
+				reached[int(i)] = true
+	assert_eq(reached.size(), faces.size(), "Every face of a ramp belongs to one of the three")
+
+
+func test_the_three_normal_filters_do_not_overlap():
+	var brush := _box(Vector3(64, 16, 64)) as Node3D
+	brush.rotation = Vector3(deg_to_rad(50.0), 0.0, 0.0)
+	var counted := 0
+	var seen := {}
+	for method in ["_filter_walls", "_filter_floors", "_filter_ceilings"]:
+		var cap := _run(method)
+		counted += _face_total(cap)
+		for key in cap.faces.keys():
+			for i in cap.faces[key]:
+				seen[int(i)] = true
+	assert_eq(counted, seen.size(), "No face is selected by two of the three")
+
+
+func test_a_level_face_is_still_a_floor():
+	_box(Vector3(64, 16, 64))
+	var cap := _run("_filter_floors")
+	assert_eq(_face_total(cap), 1, "A flat box has one upward face")
+
+
+# ===========================================================================
+# Hidden brushes are left alone (#435)
+# ===========================================================================
+
+
+func test_a_filter_skips_a_hidden_brush():
+	var shown := _box(Vector3(64, 64, 64)) as Node3D
+	var hidden := _box(Vector3(64, 64, 64), Vector3(256, 0, 0)) as Node3D
+	hidden.visible = false
+	var cap := _run("_filter_floors")
+	assert_eq(cap.faces.size(), 1, "Only the visible brush contributes faces")
+	assert_true(cap.faces.has(HFBrushSystem.face_key(shown)), "And it is the visible one")
+
+
+func test_a_node_filter_skips_a_hidden_brush():
+	_box(Vector3(64, 64, 64))
+	var hidden := _box(Vector3(64, 64, 64), Vector3(256, 0, 0)) as Node3D
+	hidden.visible = false
+	var cap := _run("_filter_structural")
+	assert_eq(cap.nodes.size(), 1, "The hidden brush is not picked")
+	assert_false(cap.nodes.has(hidden))
+
+
+# ===========================================================================
+# A filter with nothing to select says so (#436)
+# ===========================================================================
+
+
+func test_a_filter_that_matches_nothing_reports_instead_of_emitting():
+	_box(Vector3(64, 64, 64))
+	var cap := _run("_filter_detail")
+	assert_false(cap.emitted, "The previous selection is left alone")
+	assert_string_contains(cap.message, "No detail brushes")
+
+
+func test_a_filter_with_nothing_to_match_against_asks_for_a_selection():
+	_box(Vector3(64, 64, 64))
+	var cap := _run("_filter_same_material")
+	assert_false(cap.emitted)
+	assert_string_contains(cap.message, "Select a face first")
+
+
+func test_similar_brushes_with_no_brush_selected_asks_for_one():
+	_box(Vector3(64, 64, 64))
+	var cap := _run("_filter_similar_brushes")
+	assert_false(cap.emitted)
+	assert_string_contains(cap.message, "Select a brush first")
+
+
+func test_a_filter_that_matches_something_still_emits():
+	_box(Vector3(64, 64, 64))
+	var cap := _run("_filter_structural")
+	assert_true(cap.emitted, "A structural brush is there to select")
+	assert_eq(cap.message, "", "And nothing is reported")
+
+
+func test_a_filter_closes_the_popover_either_way():
+	var sf = HFSelectionFilter.new()
+	sf._root = root
+	_box(Vector3(64, 64, 64))
+	sf.visible = true
+	sf._filter_same_material()
+	assert_false(sf.visible, "The popover closes even when it has nothing to do")
+	sf.free()

--- a/tools/vibe/scenarios/selection_filter.gd
+++ b/tools/vibe/scenarios/selection_filter.gd
@@ -32,11 +32,15 @@ class Capture:
 	var nodes: Array = []
 	var faces: Dictionary = {}
 	var emitted := false
+	var message := ""
 
 	func take(p_nodes: Array, p_faces: Dictionary) -> void:
 		nodes = p_nodes
 		faces = p_faces
 		emitted = true
+
+	func hear(p_message: String) -> void:
+		message = p_message
 
 
 func _filter_for(root: Node3D, selection: Array = []):
@@ -50,6 +54,7 @@ func _run_filter(root: Node3D, method: String, selection: Array = []) -> Capture
 	var f = _filter_for(root, selection)
 	var cap := Capture.new()
 	f.filter_applied.connect(cap.take)
+	f.filter_reported.connect(cap.hear)
 	f.call(method)
 	f.free()
 	return cap
@@ -184,7 +189,8 @@ func _a_filter_that_matches_nothing() -> void:
 	note("detail filter on a level with no detail brushes: emitted", empty.emitted)
 	note("  nodes", empty.nodes.size())
 	note("  faces", empty.faces.size())
-	if empty.emitted and empty.nodes.is_empty() and empty.faces.is_empty():
+	note("  said", empty.message if empty.message != "" else "<nothing>")
+	if empty.message == "" and empty.nodes.is_empty() and empty.faces.is_empty():
 		known(
 			436,
 			"a filter that matches nothing reports nothing and leaves the old selection standing",
@@ -201,8 +207,20 @@ func _a_filter_that_matches_nothing() -> void:
 	var f = _filter_for(root, [])
 	var cap := Capture.new()
 	f.filter_applied.connect(cap.take)
+	f.filter_reported.connect(cap.hear)
 	f.visible = true
 	f._filter_same_material()
 	note("same-material with no face selected: emitted", cap.emitted)
+	note("  said", cap.message if cap.message != "" else "<nothing>")
 	note("  popover still open", f.visible)
+	if cap.message == "" or f.visible:
+		known(
+			436,
+			"a filter with nothing to match against says nothing and stays open",
+			(
+				"_filter_same_material() returned before emitting and before the "
+				+ "visible = false below it, so the popover is still on screen with the "
+				+ "previous selection untouched and no message anywhere"
+			)
+		)
 	f.free()


### PR DESCRIPTION
Fixes #434. Fixes #435. Fixes #436.

- The three normal filters now partition the sphere at one threshold (`WALL_NORMAL_Y`, 0.3): within 17 degrees of vertical is a wall, everything else is a floor or a ceiling by its sign. The old thresholds left everything 17 to 45 degrees off level unreachable, which is the ramps and chamfers the filter is most often opened for. Tooltips say what each button covers.
- `_get_all_brushes()` skips a brush that is not `is_visible_in_tree()`, so a bulk filter cannot hand the next material assignment geometry the mapper hid.
- A new `filter_reported` signal carries the reason when a filter has nothing to select. Every filter now closes the popover and says what was looked for, instead of the three different silences it had. The plugin shows it as a toast.
- New `tests/test_selection_filter_coverage.gd`: full coverage and no overlap over a 50 degree ramp, hidden brushes excluded from both the face and node paths, and each empty case reporting rather than emitting.
- CHANGELOG and the user guide updated.