### PR TITLE
Hold a tool setting to its schema range wherever the value comes from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,20 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **A tool setting is now held to its own schema, wherever the value comes
+  from** (#450). `HFEditorTool.set_setting()` wrote whatever it was handed. The
+  schema's `min`/`max` was read in exactly two places - `get_setting()` for the
+  default, and the SpinBox `dock._build_tool_settings()` generates - so the
+  constraint lived in one control and the tool itself had no opinion. A path
+  drawn at width -16 built an inside-out corridor: a negative half-extent swaps
+  the two sides of every corner ring and reverses the winding of all six quads,
+  and `HFBrushSystem._usable_size()` - the one guard that knows a negative size
+  builds a brush inside out - only ever saw the size, which it quietly
+  corrected, and never the face array a CUSTOM brush actually renders and
+  bakes. Three values outside one schema gave three different outcomes; they
+  now all give the schema's. A value that is not a number is refused and the
+  previous one kept. `_build_segment_brush()` also refuses a non-positive width
+  or height outright rather than building a ring from it.
 - **A shortcut rebound onto a chord another action already uses was accepted in
   silence** (#410). Nothing compared a new binding against the others, so
   `matches()` answered true for both, and `plugin_input_router` tests actions one

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,671 tests across 193 test scripts (3,664 passing plus seven intentional no-assert safety tests; 18,474 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,714 tests across 197 test scripts (3,707 passing plus seven intentional no-assert safety tests; 18,605 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,659 tests across 192 test scripts (3,652 passing plus seven intentional no-assert safety tests; 18,459 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,671 tests across 193 test scripts (3,664 passing plus seven intentional no-assert safety tests; 18,474 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,659 tests** across **192 scripts** (**3,652 passing** plus seven intentional no-assert safety tests; **18,459 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,671 tests** across **193 scripts** (**3,664 passing** plus seven intentional no-assert safety tests; **18,474 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,671 tests** across **193 scripts** (**3,664 passing** plus seven intentional no-assert safety tests; **18,474 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,714 tests** across **197 scripts** (**3,707 passing** plus seven intentional no-assert safety tests; **18,605 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3664%20passing-brightgreen" alt="3664 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3707%20passing-brightgreen" alt="3707 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3652%20passing-brightgreen" alt="3652 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3664%20passing-brightgreen" alt="3664 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,671 tests across 193 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,714 tests across 197 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,659 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,671 tests across 193 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/hf_editor_tool.gd
+++ b/addons/hammerforge/hf_editor_tool.gd
@@ -121,5 +121,33 @@ func get_setting(key: String) -> Variant:
 
 
 ## Write a setting value by key.
+##
+## A numeric setting is held to its schema's min and max here rather than only
+## in the SpinBox the dock generates from that schema, so a preset, a restore, a
+## script or a control someone adds later cannot put a value into the tool that
+## the tool itself says is illegal. A value that is not a number is refused
+## outright: the geometry built from one is not wrong in a way anything
+## downstream can see.
 func set_setting(key: String, value: Variant) -> void:
+	var prop := _schema_for(key)
+	var kind := str(prop.get("type", ""))
+	if (kind == "float" or kind == "int") and (value is float or value is int):
+		var number := float(value)
+		if not is_finite(number):
+			HFLog.warn("HammerForge: %s is not a number, keeping %s" % [key, str(get_setting(key))])
+			return
+		if prop.has("min"):
+			number = maxf(number, float(prop["min"]))
+		if prop.has("max"):
+			number = minf(number, float(prop["max"]))
+		_settings[key] = int(round(number)) if kind == "int" else number
+		return
 	_settings[key] = value
+
+
+## The schema entry for a setting, or an empty dictionary if it has none.
+func _schema_for(key: String) -> Dictionary:
+	for prop in get_settings_schema():
+		if prop is Dictionary and str(prop.get("name", "")) == key:
+			return prop
+	return {}

--- a/addons/hammerforge/hf_path_tool.gd
+++ b/addons/hammerforge/hf_path_tool.gd
@@ -336,6 +336,12 @@ func _build_segment_brush(
 	var length := dir.length()
 	if length < 0.01:
 		return {}
+	# A negative half-extent swaps the two sides of every corner ring, which
+	# reverses the winding of all six quads and builds the corridor inside out.
+	# _usable_size() catches a negative in the reported size and never sees the
+	# face array that a CUSTOM brush actually renders and bakes.
+	if width <= 0.0 or height <= 0.0:
+		return {}
 	dir = dir.normalized()
 	# Perpendicular in XZ plane
 	var perp := Vector3(-dir.z, 0.0, dir.x)

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -1390,7 +1390,9 @@ During placement, a cyan polyline shows the path with parallel offset lines indi
 | railing_post_spacing | 2.0 | Distance between railing posts |
 | trim_width | 0.2 | Width of edge trim strips |
 | trim_height | 0.1 | Height of edge trim strips |
-| trim_material_idx | -1 | Material index for trim faces (-1 = default material) |
+| trim_material_idx | 0 | Material index for trim faces |
+
+Every numeric setting is held to the range in the tool's schema wherever the value comes from, not only in the dock's spinbox: a width below the minimum or above the maximum is clamped to it, and a value that is not a number is refused and the previous one kept.
 
 ### Auto-Generated Extras
 When `path_extra` is set to a value other than None, additional geometry is auto-generated after the base path segments:

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,659 tests across 192 scripts**: **3,652 passing tests**, seven intentional no-assert safety tests, and **18,459 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,671 tests across 193 scripts**: **3,664 passing tests**, seven intentional no-assert safety tests, and **18,474 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,671 tests across 193 scripts**: **3,664 passing tests**, seven intentional no-assert safety tests, and **18,474 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,714 tests across 197 scripts**: **3,707 passing tests**, seven intentional no-assert safety tests, and **18,605 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_tool_setting_bounds.gd
+++ b/tests/test_tool_setting_bounds.gd
@@ -1,0 +1,104 @@
+extends GutTest
+
+## #450. The schema's min/max used to be read in exactly two places: the default
+## in `get_setting()`, and the SpinBox `dock._build_tool_settings()` generates.
+## So the constraint lived in one control and the tool itself had no opinion - a
+## preset, a restore or a script could hand it anything, and three values
+## outside one schema failed three different ways.
+
+const HFPathTool = preload("res://addons/hammerforge/hf_path_tool.gd")
+const HFEditorTool = preload("res://addons/hammerforge/hf_editor_tool.gd")
+
+
+func _tool():
+	return HFPathTool.new()
+
+
+func test_a_value_below_the_schema_minimum_is_clamped():
+	var tool_instance = _tool()
+	tool_instance.set_setting("path_width", -16.0)
+	assert_eq(tool_instance.get_setting("path_width"), 0.5, "Held to the schema's min")
+
+
+func test_a_value_above_the_schema_maximum_is_clamped():
+	var tool_instance = _tool()
+	tool_instance.set_setting("path_width", 1.0e9)
+	assert_eq(tool_instance.get_setting("path_width"), 64.0, "Held to the schema's max")
+
+
+func test_zero_is_clamped_to_the_schema_minimum_not_the_brush_minimum():
+	var tool_instance = _tool()
+	tool_instance.set_setting("path_height", 0.0)
+	assert_eq(
+		tool_instance.get_setting("path_height"), 0.5, "The schema's 0.5, not MIN_BRUSH_EXTENT"
+	)
+
+
+func test_a_value_inside_the_range_is_kept_as_given():
+	var tool_instance = _tool()
+	tool_instance.set_setting("path_width", 12.5)
+	assert_eq(tool_instance.get_setting("path_width"), 12.5)
+
+
+func test_a_value_that_is_not_a_number_is_refused():
+	var tool_instance = _tool()
+	tool_instance.set_setting("path_width", 8.0)
+	tool_instance.set_setting("path_width", NAN)
+	assert_eq(tool_instance.get_setting("path_width"), 8.0, "The last real value is kept")
+	assert_push_warning("is not a number")
+
+
+func test_an_infinite_value_is_refused():
+	var tool_instance = _tool()
+	tool_instance.set_setting("path_width", 8.0)
+	tool_instance.set_setting("path_width", INF)
+	assert_eq(tool_instance.get_setting("path_width"), 8.0)
+	assert_push_warning("is not a number")
+
+
+func test_a_setting_with_no_schema_entry_is_stored_as_given():
+	var tool_instance = _tool()
+	tool_instance.set_setting("not_in_the_schema", -99.0)
+	assert_eq(tool_instance.get_setting("not_in_the_schema"), -99.0)
+
+
+func test_a_non_numeric_setting_is_untouched():
+	var tool_instance = _tool()
+	tool_instance.set_setting("miter_joints", false)
+	assert_eq(tool_instance.get_setting("miter_joints"), false)
+
+
+func test_a_bare_tool_with_no_schema_still_stores_settings():
+	var bare = HFEditorTool.new()
+	bare.set_setting("anything", 3.5)
+	assert_eq(bare.get_setting("anything"), 3.5)
+
+
+# ===========================================================================
+# The geometry refuses a degenerate segment on its own too
+# ===========================================================================
+
+
+func test_a_segment_of_no_width_builds_nothing():
+	var tool_instance = _tool()
+	var info: Dictionary = tool_instance._build_segment_brush(
+		Vector3.ZERO, Vector3(256, 0, 0), -16.0, 4.0, "grp"
+	)
+	assert_true(info.is_empty(), "A negative width reverses the winding, so it builds nothing")
+
+
+func test_a_segment_of_no_height_builds_nothing():
+	var tool_instance = _tool()
+	var info: Dictionary = tool_instance._build_segment_brush(
+		Vector3.ZERO, Vector3(256, 0, 0), 4.0, 0.0, "grp"
+	)
+	assert_true(info.is_empty())
+
+
+func test_a_normal_segment_still_builds():
+	var tool_instance = _tool()
+	var info: Dictionary = tool_instance._build_segment_brush(
+		Vector3.ZERO, Vector3(256, 0, 0), 4.0, 4.0, "grp"
+	)
+	assert_false(info.is_empty())
+	assert_eq(info.get("size"), Vector3(256, 4, 4))

--- a/tools/vibe/scenarios/draw_tools.gd
+++ b/tools/vibe/scenarios/draw_tools.gd
@@ -101,9 +101,14 @@ func _polygon_winding_both_ways() -> void:
 		flag("polygon tool: pentagon has %d inward faces" % p_inward)
 
 
-## What the tool's own convexity gate lets through. `_is_convex_xz()` skips any
-## cross product under 0.001, which is every cross product a degenerate polygon
-## has.
+## What the tool's own gates let through.
+##
+## `_is_convex_xz()` skips any cross product under 0.001, which is every cross
+## product a degenerate polygon has, so it is not the check that decides. The
+## gates that do are the area test in `_begin_height_stage()` - the only way
+## into the height stage, and so the only way to a brush - and the repeat-point
+## test on each click. Both are asked here rather than the builder underneath
+## them, because the builder is not reachable past a gate that refuses.
 func _polygon_degenerate_input() -> void:
 	var root: Node3D = await fresh_root()
 
@@ -112,32 +117,44 @@ func _polygon_degenerate_input() -> void:
 		"collinear points pass the convexity gate",
 		PolygonTool._is_convex_xz(PackedVector3Array(collinear))
 	)
-	var flat := _polygon_brush(root, collinear)
-	await frame()
-	if flat != null:
-		var extent := HFVibe.local_extent(flat)
-		note("brush from three collinear points: extent", extent)
-		if extent.z <= 0.001 or extent.x <= 0.001:
-			known(
-				398,
-				"polygon tool builds a zero-thickness brush from collinear points",
-				"extent %s, faces %d, volume 0 -- nothing refuses it" % [extent, flat.faces.size()]
-			)
-		var report: Dictionary = root.validation_system.validate(false)
-		note("validate() issues on the flat brush", report.get("issues", []).size())
+	var tool_instance = PolygonTool.new()
+	tool_instance.root = root
+	tool_instance._polygon_points = PackedVector3Array(collinear)
+	tool_instance._ground_y = 0.0
+	var extruded: bool = tool_instance._begin_height_stage(Vector2.ZERO)
+	note("collinear points reach the height stage", extruded)
+	if extruded:
+		var flat := _polygon_brush(root, collinear)
+		await frame()
+		if flat != null:
+			var extent := HFVibe.local_extent(flat)
+			note("brush from three collinear points: extent", extent)
+			if extent.z <= 0.001 or extent.x <= 0.001:
+				known(
+					398,
+					"polygon tool builds a zero-thickness brush from collinear points",
+					(
+						"extent %s, faces %d, volume 0 -- nothing refuses it"
+						% [extent, flat.faces.size()]
+					)
+				)
 
-	var dup := [Vector3(-32, 0, -32), Vector3(-32, 0, -32), Vector3(32, 0, 32)]
-	var dup_brush := _polygon_brush(root, dup)
-	await frame()
-	if dup_brush != null:
-		known(
-			399,
-			"polygon tool accepts a repeated vertex",
-			(
-				"two of the three points are identical: %d faces, some with zero area"
-				% dup_brush.faces.size()
+	var placed := PackedVector3Array([Vector3(-32, 0, -32)])
+	var repeat_refused: bool = PolygonTool._is_repeat_point(placed, Vector3(-32, 0, -32))
+	note("a second click on a placed vertex is refused", repeat_refused)
+	if not repeat_refused:
+		var dup := [Vector3(-32, 0, -32), Vector3(-32, 0, -32), Vector3(32, 0, 32)]
+		var dup_brush := _polygon_brush(root, dup)
+		await frame()
+		if dup_brush != null:
+			known(
+				399,
+				"polygon tool accepts a repeated vertex",
+				(
+					"two of the three points are identical: %d faces, some with zero area"
+					% dup_brush.faces.size()
+				)
 			)
-		)
 
 	for issue in HFVibe.check_invariants(root):
 		flag("invariant after degenerate polygons", issue)


### PR DESCRIPTION
Fixes #450.

- `HFEditorTool.set_setting()` clamps a numeric setting to its schema's `min`/`max` and refuses a value that is not a number, keeping the previous one. The constraint used to live only in the SpinBox the dock generates from that schema, so a preset, a restore or a script could put anything into the tool.
- `HFPathTool._build_segment_brush()` refuses a non-positive width or height. A negative half-extent swaps the two sides of every corner ring and reverses the winding of all six quads, and `_usable_size()` only sees the size it then corrects, never the face array a CUSTOM brush renders and bakes.
- New `tests/test_tool_setting_bounds.gd`: below, above, inside, zero, NaN, INF, no schema entry, non-numeric, and the segment refusals.
- The draw-tools vibe scenario now asks the gates a user actually goes through for the degenerate polygon cases, which #398 and #399 fixed; it was calling the builder underneath them and reporting both as still reproducing.
- CHANGELOG and the path tool settings table updated (`trim_material_idx` was documented as -1, which the schema has never allowed).