### PR TITLE
Take the quick property ranges from the controls they write into

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,20 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **The quick property popup and the control behind it now agree** (#447,
+  #448). The double-tap popup (G G, B B, R R) restated the range of each field
+  instead of taking it from the dock control it writes into, and none of the
+  three pairs matched. The radius pair was the worst: the popup's own default
+  was ten times the maximum of the control it wrote to, so opening R R and
+  pressing Enter without typing anything set the surface paint radius to its
+  limit. The brush size spin had `min` 0.1 with `step` 0.5, so the only values
+  it could hold were 0.1, 0.6, 1.1 ... - it could not express a whole number at
+  all, and opening B B on a 4 unit brush silently showed 4.1. `show_property()`
+  now takes the min, max and step of the controls it stands in for.
+  A committed brush size also went to two places, `input_state.drag_size_default`
+  unclamped and the dock spins clamped, so the dock said 256 while the next
+  brush drawn was 500.5 across; the controls are written first and the size is
+  read back out of them, so there is one answer.
 - **A shortcut rebound onto a chord another action already uses was accepted in
   silence** (#410). Nothing compared a new binding against the others, so
   `matches()` answered true for both, and `plugin_input_router` tests actions one

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,659 tests across 192 test scripts (3,652 passing plus seven intentional no-assert safety tests; 18,459 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,667 tests across 193 test scripts (3,660 passing plus seven intentional no-assert safety tests; 18,487 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,667 tests across 193 test scripts (3,660 passing plus seven intentional no-assert safety tests; 18,487 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,722 tests across 198 test scripts (3,715 passing plus seven intentional no-assert safety tests; 18,633 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,667 tests** across **193 scripts** (**3,660 passing** plus seven intentional no-assert safety tests; **18,487 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,722 tests** across **198 scripts** (**3,715 passing** plus seven intentional no-assert safety tests; **18,633 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,659 tests** across **192 scripts** (**3,652 passing** plus seven intentional no-assert safety tests; **18,459 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,667 tests** across **193 scripts** (**3,660 passing** plus seven intentional no-assert safety tests; **18,487 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3652%20passing-brightgreen" alt="3652 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3660%20passing-brightgreen" alt="3660 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3660%20passing-brightgreen" alt="3660 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3715%20passing-brightgreen" alt="3715 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,667 tests across 193 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,722 tests across 198 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,659 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,667 tests across 193 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/plugin_overlays.gd
+++ b/addons/hammerforge/plugin_overlays.gd
@@ -528,7 +528,12 @@ static func handle_double_tap(plugin: Object, keycode: int, root: Node, paint_mo
 	match keycode:
 		KEY_G:
 			var snap_value: float = root.grid_snap if root else 16.0
-			show_quick_property(plugin, HFQuickProperty.PropertyType.GRID_SNAP, [snap_value])
+			show_quick_property(
+				plugin,
+				HFQuickProperty.PropertyType.GRID_SNAP,
+				[snap_value],
+				_ranges_of(plugin, ["grid_snap"])
+			)
 			return true
 		KEY_B:
 			if paint_mode:
@@ -539,18 +544,51 @@ static func handle_double_tap(plugin: Object, keycode: int, root: Node, paint_mo
 				else Vector3(4, 4, 4)
 			)
 			show_quick_property(
-				plugin, HFQuickProperty.PropertyType.BRUSH_SIZE, [size.x, size.y, size.z]
+				plugin,
+				HFQuickProperty.PropertyType.BRUSH_SIZE,
+				[size.x, size.y, size.z],
+				_ranges_of(plugin, ["size_x", "size_y", "size_z"])
 			)
 			return true
 		KEY_R:
 			if paint_mode:
-				var radius: float = plugin.dock.get_surface_paint_radius() if plugin.dock else 5.0
-				show_quick_property(plugin, HFQuickProperty.PropertyType.PAINT_RADIUS, [radius])
+				var radius: float = plugin.dock.get_surface_paint_radius() if plugin.dock else 0.25
+				show_quick_property(
+					plugin,
+					HFQuickProperty.PropertyType.PAINT_RADIUS,
+					[radius],
+					_ranges_of(plugin, ["surface_paint_radius"])
+				)
 				return true
 	return false
 
 
-static func show_quick_property(plugin: Object, property_type: int, values: Array) -> void:
+## The min/max/step of the named dock controls, for the popup that stands in
+## for them. Empty when the dock is not there, which leaves the popup on its
+## own defaults.
+static func _ranges_of(plugin: Object, control_names: Array) -> Array:
+	var out: Array = []
+	if plugin == null or not plugin.dock:
+		return out
+	for control_name in control_names:
+		var control = plugin.dock.get(control_name)
+		if control is Range:
+			(
+				out
+				. append(
+					{
+						"min": control.min_value,
+						"max": control.max_value,
+						"step": control.step,
+					}
+				)
+			)
+	return out
+
+
+static func show_quick_property(
+	plugin: Object, property_type: int, values: Array, ranges: Array = []
+) -> void:
 	if (
 		plugin == null
 		or not plugin._quick_property
@@ -558,7 +596,7 @@ static func show_quick_property(plugin: Object, property_type: int, values: Arra
 	):
 		return
 	plugin._quick_property.show_property(
-		property_type, plugin._get_current_overlay_mouse_pos(), values
+		property_type, plugin._get_current_overlay_mouse_pos(), values, ranges
 	)
 
 
@@ -572,11 +610,19 @@ static func on_quick_property_committed(plugin: Object, property_type: int, valu
 				plugin.dock._apply_grid_snap(float(values[0]))
 		HFQuickProperty.PropertyType.BRUSH_SIZE:
 			if root and root.input_state and values.size() >= 3:
-				root.input_state.drag_size_default = Vector3(values[0], values[1], values[2])
-				if plugin.dock:
+				# The dock spins clamp and round; drag_size_default takes
+				# whatever it is given. Write the controls first and read the
+				# size back out of them, so the two ends cannot disagree about
+				# how big the next brush is.
+				var applied := Vector3(values[0], values[1], values[2])
+				if plugin.dock and plugin.dock.size_x:
 					plugin.dock.size_x.value = values[0]
 					plugin.dock.size_y.value = values[1]
 					plugin.dock.size_z.value = values[2]
+					applied = Vector3(
+						plugin.dock.size_x.value, plugin.dock.size_y.value, plugin.dock.size_z.value
+					)
+				root.input_state.drag_size_default = applied
 		HFQuickProperty.PropertyType.PAINT_RADIUS:
 			if plugin.dock and not values.is_empty() and plugin.dock.surface_paint_radius:
 				plugin.dock.surface_paint_radius.value = float(values[0])

--- a/addons/hammerforge/ui/hf_quick_property.gd
+++ b/addons/hammerforge/ui/hf_quick_property.gd
@@ -10,6 +10,11 @@ signal value_committed(property_type: int, values: Array)
 
 enum PropertyType { GRID_SNAP, BRUSH_SIZE, PAINT_RADIUS }
 
+## Only used when the caller has no control to take a range from.
+const DEFAULT_GRID_SNAP_RANGE := {"min": 0.0, "max": 128.0, "step": 1.0}
+const DEFAULT_BRUSH_SIZE_RANGE := {"min": 1.0, "max": 256.0, "step": 1.0}
+const DEFAULT_PAINT_RADIUS_RANGE := {"min": 0.01, "max": 0.5, "step": 0.01}
+
 var _type: int = PropertyType.GRID_SNAP
 var _vbox: VBoxContainer
 var _spinboxes: Array[SpinBox] = []
@@ -31,7 +36,15 @@ func _ready() -> void:
 	_apply_style()
 
 
-func show_property(type: int, pos: Vector2, current_values: Array) -> void:
+## Show the popup for one property.
+##
+## `ranges` carries the min/max/step of the dock controls the committed value
+## is written into, one entry per field. Restating them here instead meant the
+## popup offered values the control could not hold - its own default radius was
+## ten times that control's maximum, and the brush size step of 0.5 from a
+## minimum of 0.1 could not express a whole number at all, so opening the popup
+## on a 4 unit brush showed 4.1 and committing it changed the size.
+func show_property(type: int, pos: Vector2, current_values: Array, ranges: Array = []) -> void:
 	_type = type
 	_spinboxes.clear()
 	# Clear old children
@@ -41,25 +54,27 @@ func show_property(type: int, pos: Vector2, current_values: Array) -> void:
 
 	match type:
 		PropertyType.GRID_SNAP:
+			var r: Dictionary = _range_at(ranges, 0, DEFAULT_GRID_SNAP_RANGE)
 			_add_labeled_spin(
 				"Grid Snap",
-				0.0,
-				256.0,
-				1.0,
+				r["min"],
+				r["max"],
+				r["step"],
 				current_values[0] if not current_values.is_empty() else 16.0
 			)
 		PropertyType.BRUSH_SIZE:
 			var defaults: Array = current_values if current_values.size() >= 3 else [4.0, 4.0, 4.0]
-			_add_labeled_spin("X", 0.1, 1024.0, 0.5, defaults[0])
-			_add_labeled_spin("Y", 0.1, 1024.0, 0.5, defaults[1])
-			_add_labeled_spin("Z", 0.1, 1024.0, 0.5, defaults[2])
+			for i in range(3):
+				var r: Dictionary = _range_at(ranges, i, DEFAULT_BRUSH_SIZE_RANGE)
+				_add_labeled_spin(["X", "Y", "Z"][i], r["min"], r["max"], r["step"], defaults[i])
 		PropertyType.PAINT_RADIUS:
+			var r: Dictionary = _range_at(ranges, 0, DEFAULT_PAINT_RADIUS_RANGE)
 			_add_labeled_spin(
 				"Radius",
-				0.1,
-				512.0,
-				0.1,
-				current_values[0] if not current_values.is_empty() else 5.0
+				r["min"],
+				r["max"],
+				r["step"],
+				current_values[0] if not current_values.is_empty() else r["min"]
 			)
 
 	_active = true
@@ -80,6 +95,21 @@ func show_property(type: int, pos: Vector2, current_values: Array) -> void:
 	if not _spinboxes.is_empty():
 		_spinboxes[0].get_line_edit().grab_focus()
 		_spinboxes[0].get_line_edit().select_all()
+
+
+## The range for field `index`, falling back to `fallback` when the caller gave
+## none. A single entry stands for every field.
+static func _range_at(ranges: Array, index: int, fallback: Dictionary) -> Dictionary:
+	if ranges.is_empty():
+		return fallback
+	var entry = ranges[index] if index < ranges.size() else ranges[0]
+	if not (entry is Dictionary):
+		return fallback
+	return {
+		"min": float(entry.get("min", fallback["min"])),
+		"max": float(entry.get("max", fallback["max"])),
+		"step": float(entry.get("step", fallback["step"])),
+	}
 
 
 func hide_popup() -> void:

--- a/docs/HammerForge_Editor_Smoke_Checklist.md
+++ b/docs/HammerForge_Editor_Smoke_Checklist.md
@@ -706,8 +706,8 @@ It writes one PNG per tab under `user://console_preview/`.
 - Type a new value (e.g. 4) and press **Enter**; confirm the grid snap updates and the popup closes.
 - Tap **G G** again; press **Escape**; confirm the popup closes without changing the value.
 - Tap **G G** again; click somewhere outside the popup; confirm it dismisses (click consumed, no brush placed).
-- Select a brush. Tap **B** twice (B B); confirm a popup appears with 3 SpinBoxes (X, Y, Z).
-- Enable paint mode. Tap **R** twice (R R); confirm a popup appears with a "Paint Radius" SpinBox.
+- Select a brush. Tap **B** twice (B B); confirm a popup appears with 3 SpinBoxes (X, Y, Z) reading the current size exactly, and that the three ranges match the Size X/Y/Z spins in the Build tab. Type a size, press **Enter**, and confirm the dock spins and the next brush you draw are the same size.
+- Enable paint mode. Tap **R** twice (R R); confirm a popup appears with a "Paint Radius" SpinBox whose range is the one the paint radius control in the dock has.
 
 ### 32. Clean Brush Visuals and Lifecycle
 - Draw a new additive box; confirm it has a clean green-tinted surface with **no always-on triangle wireframe**.

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,659 tests across 192 scripts**: **3,652 passing tests**, seven intentional no-assert safety tests, and **18,459 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,667 tests across 193 scripts**: **3,660 passing tests**, seven intentional no-assert safety tests, and **18,487 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,667 tests across 193 scripts**: **3,660 passing tests**, seven intentional no-assert safety tests, and **18,487 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,722 tests across 198 scripts**: **3,715 passing tests**, seven intentional no-assert safety tests, and **18,633 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_quick_property_ranges.gd
+++ b/tests/test_quick_property_ranges.gd
@@ -1,0 +1,152 @@
+extends GutTest
+
+## #447, #448. The double-tap popup (G G, B B, R R) builds its own spinboxes and
+## pushes the value into a dock control. It used to restate the ranges rather
+## than take them, so none of the three pairs agreed about what a legal value
+## was, and the committed brush size went into two places of which only one
+## clamped.
+
+const HFQuickProperty = preload("res://addons/hammerforge/ui/hf_quick_property.gd")
+const HFPluginOverlays = preload("res://addons/hammerforge/plugin_overlays.gd")
+const DockScene = preload("res://addons/hammerforge/dock.tscn")
+const LevelRootType = preload("res://addons/hammerforge/level_root.gd")
+
+
+class PluginStub:
+	extends RefCounted
+
+	var active_root: Node3D = null
+	var dock: Node = null
+
+	func _get_level_root() -> Node3D:
+		return active_root
+
+
+var popup
+
+
+func before_each():
+	popup = HFQuickProperty.new()
+	add_child_autoqfree(popup)
+
+
+func after_each():
+	popup = null
+
+
+func _spin_of(type: int, values: Array, ranges: Array = []) -> SpinBox:
+	popup.show_property(type, Vector2(10, 10), values, ranges)
+	return popup._spinboxes[0] if not popup._spinboxes.is_empty() else null
+
+
+# ===========================================================================
+# The popup takes its range from the control it writes into (#447)
+# ===========================================================================
+
+
+func test_a_given_range_is_used_for_the_spin():
+	var spin := _spin_of(
+		HFQuickProperty.PropertyType.PAINT_RADIUS, [0.25], [{"min": 0.01, "max": 0.5, "step": 0.01}]
+	)
+	assert_not_null(spin)
+	assert_eq(spin.min_value, 0.01)
+	assert_eq(spin.max_value, 0.5)
+	assert_eq(spin.step, 0.01)
+	assert_almost_eq(spin.value, 0.25, 0.001, "And the current value survives")
+
+
+func test_one_given_range_covers_all_three_size_fields():
+	popup.show_property(
+		HFQuickProperty.PropertyType.BRUSH_SIZE,
+		Vector2.ZERO,
+		[8.0, 8.0, 8.0],
+		[{"min": 2.0, "max": 64.0, "step": 2.0}]
+	)
+	assert_eq(popup._spinboxes.size(), 3)
+	for spin in popup._spinboxes:
+		assert_eq(spin.max_value, 64.0)
+		assert_eq(spin.value, 8.0)
+
+
+func test_the_brush_size_spin_can_hold_a_whole_number():
+	var spin := _spin_of(HFQuickProperty.PropertyType.BRUSH_SIZE, [4.0, 4.0, 4.0])
+	assert_eq(spin.value, 4.0, "Opening the popup on a 4 unit brush must not change it to 4.1")
+
+
+func test_the_fallback_ranges_match_the_dock_controls():
+	var dock = DockScene.instantiate()
+	add_child_autoqfree(dock)
+	assert_eq(dock.grid_snap.min_value, HFQuickProperty.DEFAULT_GRID_SNAP_RANGE["min"])
+	assert_eq(dock.grid_snap.max_value, HFQuickProperty.DEFAULT_GRID_SNAP_RANGE["max"])
+	assert_eq(dock.grid_snap.step, HFQuickProperty.DEFAULT_GRID_SNAP_RANGE["step"])
+	assert_eq(dock.size_x.min_value, HFQuickProperty.DEFAULT_BRUSH_SIZE_RANGE["min"])
+	assert_eq(dock.size_x.max_value, HFQuickProperty.DEFAULT_BRUSH_SIZE_RANGE["max"])
+	assert_eq(dock.size_x.step, HFQuickProperty.DEFAULT_BRUSH_SIZE_RANGE["step"])
+	if dock.surface_paint_radius:
+		assert_eq(
+			dock.surface_paint_radius.max_value, HFQuickProperty.DEFAULT_PAINT_RADIUS_RANGE["max"]
+		)
+
+
+func test_ranges_of_reads_the_dock_controls():
+	var dock = DockScene.instantiate()
+	add_child_autoqfree(dock)
+	var plugin := PluginStub.new()
+	plugin.dock = dock
+	var ranges: Array = HFPluginOverlays._ranges_of(plugin, ["size_x", "size_y", "size_z"])
+	assert_eq(ranges.size(), 3)
+	assert_eq(ranges[0]["min"], dock.size_x.min_value)
+	assert_eq(ranges[0]["max"], dock.size_x.max_value)
+
+
+func test_ranges_of_is_empty_without_a_dock():
+	var plugin := PluginStub.new()
+	assert_eq(HFPluginOverlays._ranges_of(plugin, ["size_x"]), [])
+
+
+# ===========================================================================
+# One answer for the committed brush size (#448)
+# ===========================================================================
+
+
+func test_a_committed_size_leaves_both_ends_agreeing():
+	var dock = DockScene.instantiate()
+	add_child_autoqfree(dock)
+	var root := LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	dock.level_root = root
+	var plugin := PluginStub.new()
+	plugin.active_root = root
+	plugin.dock = dock
+
+	HFPluginOverlays.on_quick_property_committed(
+		plugin, HFQuickProperty.PropertyType.BRUSH_SIZE, [500.5, 500.5, 500.5]
+	)
+	var shown := Vector3(dock.size_x.value, dock.size_y.value, dock.size_z.value)
+	assert_eq(shown, Vector3(256, 256, 256), "The dock spins clamp, as they always did")
+	assert_eq(
+		root.input_state.drag_size_default,
+		shown,
+		"And the next brush is drawn at the size the dock shows"
+	)
+
+
+func test_a_size_inside_the_range_is_committed_as_typed():
+	var dock = DockScene.instantiate()
+	add_child_autoqfree(dock)
+	var root := LevelRootType.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	dock.level_root = root
+	var plugin := PluginStub.new()
+	plugin.active_root = root
+	plugin.dock = dock
+
+	HFPluginOverlays.on_quick_property_committed(
+		plugin, HFQuickProperty.PropertyType.BRUSH_SIZE, [32.0, 16.0, 8.0]
+	)
+	assert_eq(root.input_state.drag_size_default, Vector3(32, 16, 8))
+	assert_eq(Vector3(dock.size_x.value, dock.size_y.value, dock.size_z.value), Vector3(32, 16, 8))

--- a/tools/vibe/scenarios/quick_property.gd
+++ b/tools/vibe/scenarios/quick_property.gd
@@ -9,6 +9,20 @@ extends "res://tools/vibe/hf_vibe_scenario.gd"
 ## value is.
 
 const QuickProperty = preload("res://addons/hammerforge/ui/hf_quick_property.gd")
+const PluginOverlays = preload("res://addons/hammerforge/plugin_overlays.gd")
+const DockScene = preload("res://addons/hammerforge/dock.tscn")
+
+
+## Enough of the plugin for on_quick_property_committed() to run against.
+class PluginStub:
+	extends RefCounted
+
+	var active_root: Node3D = null
+	var dock: Node = null
+	var _quick_property: Node = null
+
+	func _get_level_root() -> Node3D:
+		return active_root
 
 
 func id() -> String:
@@ -121,18 +135,24 @@ func _what_a_committed_value_becomes() -> void:
 			)
 		)
 
-	# BRUSH_SIZE goes two places: unclamped into input_state.drag_size_default and
-	# clamped into the dock spins.
+	# BRUSH_SIZE goes two places: into input_state.drag_size_default and into the
+	# dock spins, which clamp and round. Drive the real commit path and read
+	# both ends back.
 	var root: Node3D = await fresh_root()
+	var dock = DockScene.instantiate()
+	_tree.get_root().add_child(dock)
 	await frame()
+	dock.level_root = root
+	var plugin := PluginStub.new()
+	plugin.active_root = root
+	plugin.dock = dock
+
 	var typed := Vector3(500.5, 500.5, 500.5)
-	root.input_state.drag_size_default = typed
-	var dock_shows := Vector3(
-		_through(1.0, 256.0, 1.0, typed.x),
-		_through(1.0, 256.0, 1.0, typed.y),
-		_through(1.0, 256.0, 1.0, typed.z)
+	PluginOverlays.on_quick_property_committed(
+		plugin, QuickProperty.PropertyType.BRUSH_SIZE, [typed.x, typed.y, typed.z]
 	)
-	note("popup allows a brush size up to", 1024.0)
+	await frame()
+	var dock_shows := Vector3(dock.size_x.value, dock.size_y.value, dock.size_z.value)
 	note("typed size", typed)
 	note("what the dock spins show", dock_shows)
 	note("what input_state.drag_size_default holds", root.input_state.drag_size_default)
@@ -141,23 +161,18 @@ func _what_a_committed_value_becomes() -> void:
 			448,
 			"a brush size from the quick popup leaves the dock and the draw tool disagreeing",
 			(
-				"on_quick_property_committed() writes the raw values into "
-				+ "input_state.drag_size_default and the same values into dock.size_x/y/z, "
-				+ (
-					"which are 1..256 step 1 and clamp them. A typed %s leaves the dock reading "
-					% str(typed)
+				(
+					"the dock spins read %s and the next brush is drawn at %s. "
+					% [dock_shows, root.input_state.drag_size_default]
 				)
-				+ (
-					"%s while the next brush drawn is %s. The popup's own spin is 0.1..1024 "
-					% [str(dock_shows), str(root.input_state.drag_size_default)]
-				)
-				+ "step 0.5, so any value with a half unit in it or above 256 splits the two"
+				+ "on_quick_property_committed() writes the same values into both ends, and "
+				+ "only one of them clamps"
 			)
 		)
-
-	var brush = root.create_brush_from_info(
-		{"shape": 0, "size": root.input_state.drag_size_default}
+	var drawn = root.create_brush_from_info(
+		{"shape": 0, "size": root.input_state.drag_size_default, "center": Vector3.ZERO}
 	)
 	await frame()
-	note("a brush drawn at that size measures", HFVibe.local_extent(brush))
+	note("a brush drawn at that size measures", drawn.size)
+	dock.queue_free()
 	popup.queue_free()


### PR DESCRIPTION
Fixes #447. Fixes #448.

- `show_property()` takes a `ranges` argument and builds each spin from the min, max and step of the dock control it stands in for. `handle_double_tap()` reads them off `dock.grid_snap`, `dock.size_x/y/z` and `dock.surface_paint_radius`. The fallbacks now match those controls instead of contradicting them, and a test asserts that.
- The brush size spin can hold a whole number again: `min` 0.1 with `step` 0.5 could only express 0.1, 0.6, 1.1 ..., so opening B B on a 4 unit brush showed 4.1 and committing it changed the size.
- `on_quick_property_committed()` writes the dock spins first and reads the size back out of them into `drag_size_default`, so the dock and the draw tool cannot disagree about how big the next brush is.
- New `tests/test_quick_property_ranges.gd`, and the quick-property vibe scenario drives the real commit path against an instantiated dock instead of simulating it.
- CHANGELOG and the smoke checklist updated.