### PR TITLE
Make the timeline's Replay button reachable and its glyphs name the operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,23 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **The operation timeline's Replay button can be clicked, and its glyphs name
+  the operation** (#437, #438). The button lives in the panel header, outside
+  the entry it applies to, and was shown on hover and hidden again on
+  mouse_exited - so any pointer path from the entry to the button hid it on the
+  way, and `_hovered_index` went back to -1 so a press would have emitted
+  nothing anyway. `replay_requested` never fired, which made
+  `HFPluginUndoEvents.on_replay_requested()` - the only way to jump to a point
+  in the timeline - unreachable from the UI. A click now sets a selection that
+  only another click, a clear or the panel closing takes away, and the hover
+  drives the detail line alone. The glyph and colour tables also tested the
+  generic draw/brush/create case above most of the specific ones, and most of
+  the plugin's undo action names contain the word "brush", so "Clear Brushes"
+  was drawn as a creation in the create blue, and "Apply Brush Material" and
+  "Assign Face Material" got different glyphs for the same kind of operation.
+  The generic test is last now, destruction is first, and "bevel" and "prefab"
+  have their own glyphs rather than falling through to the catch-all.
+  `HFHistoryBrowser` calls the same two functions, so both surfaces are right.
 - **A shortcut rebound onto a chord another action already uses was accepted in
   silence** (#410). Nothing compared a new binding against the others, so
   `matches()` answered true for both, and `plugin_input_router` tests actions one

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,659 tests across 192 test scripts (3,652 passing plus seven intentional no-assert safety tests; 18,459 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,671 tests across 192 test scripts (3,664 passing plus seven intentional no-assert safety tests; 18,479 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,671 tests across 192 test scripts (3,664 passing plus seven intentional no-assert safety tests; 18,479 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,734 tests across 198 test scripts (3,727 passing plus seven intentional no-assert safety tests; 18,653 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,659 tests** across **192 scripts** (**3,652 passing** plus seven intentional no-assert safety tests; **18,459 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,671 tests** across **192 scripts** (**3,664 passing** plus seven intentional no-assert safety tests; **18,479 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,671 tests** across **192 scripts** (**3,664 passing** plus seven intentional no-assert safety tests; **18,479 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,734 tests** across **198 scripts** (**3,727 passing** plus seven intentional no-assert safety tests; **18,653 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3652%20passing-brightgreen" alt="3652 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3664%20passing-brightgreen" alt="3664 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3664%20passing-brightgreen" alt="3664 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3727%20passing-brightgreen" alt="3727 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,671 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,734 tests across 198 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,659 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,671 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/ui/hf_operation_replay.gd
+++ b/addons/hammerforge/ui/hf_operation_replay.gd
@@ -18,6 +18,11 @@ var _timeline_container: HBoxContainer
 var _detail_label: Label
 var _replay_btn: Button
 var _hovered_index := -1
+## The entry Replay acts on. A click sets it and only another click, a clear or
+## the panel closing takes it away. It used to be the hover, and the Replay
+## button sits in the header outside the entry, so any pointer path from one to
+## the other crossed a mouse_exited and took the button with it.
+var _selected_index := -1
 var _scroll: ScrollContainer
 
 
@@ -93,18 +98,26 @@ func record_operation(action_name: String, version: int = -1) -> void:
 	_entries.append(entry)
 	if _entries.size() > MAX_ENTRIES:
 		_entries.pop_front()
+		# Every index moved down one, the selection with it.
+		if _selected_index >= 0:
+			_selected_index -= 1
+			if _selected_index < 0:
+				_clear_selection()
 	_rebuild_timeline()
 
 
 ## Clear all entries.
 func clear() -> void:
 	_entries.clear()
+	_clear_selection()
 	_rebuild_timeline()
 
 
 ## Toggle visibility.
 func toggle_visible() -> void:
 	visible = not visible
+	if not visible:
+		_clear_selection()
 
 
 ## Get the number of recorded entries.
@@ -162,17 +175,15 @@ func _on_entry_hovered(index: int) -> void:
 		else:
 			time_str = "%dh ago" % int(elapsed / 3600.0)
 		_detail_label.text = "%s  (%s)" % [entry["name"], time_str]
-		_replay_btn.visible = true
 
 
 func _on_entry_unhovered() -> void:
 	_hovered_index = -1
-	_detail_label.text = "Hover an operation to see details"
-	_replay_btn.visible = false
+	_refresh_detail_label()
 
 
 func _on_entry_clicked(index: int) -> void:
-	_hovered_index = index
+	_selected_index = index
 	_replay_btn.visible = true
 	if index >= 0 and index < _entries.size():
 		var entry: Dictionary = _entries[index]
@@ -180,33 +191,61 @@ func _on_entry_clicked(index: int) -> void:
 
 
 func _on_replay_pressed() -> void:
-	if _hovered_index >= 0 and _hovered_index < _entries.size():
-		replay_requested.emit(_hovered_index)
+	if _selected_index >= 0 and _selected_index < _entries.size():
+		replay_requested.emit(_selected_index)
 
 
+## The detail line when nothing is hovered: the selected entry, or the prompt.
+func _refresh_detail_label() -> void:
+	if not _detail_label:
+		return
+	if _selected_index >= 0 and _selected_index < _entries.size():
+		var entry: Dictionary = _entries[_selected_index]
+		_detail_label.text = "%s  (click Replay to undo/redo to this point)" % entry["name"]
+		return
+	_detail_label.text = "Hover an operation to see details"
+
+
+## Forget which entry Replay would act on.
+func _clear_selection() -> void:
+	_selected_index = -1
+	if _replay_btn:
+		_replay_btn.visible = false
+	_refresh_detail_label()
+
+
+## The glyph an operation is drawn with.
+##
+## Most of the plugin's undo action names contain the word "brush", so the
+## generic draw/brush/create test has to come last or everything is filed as a
+## creation whatever it did - "Clear Brushes" included, which was drawn as a
+## creation in the create colour. Every test above it names the operation
+## rather than the noun it was performed on.
 static func _get_icon_for_action(action_name: String) -> String:
 	var lower := action_name.to_lower()
-	# More specific matches first (before generic "brush" catch-all)
+	# Destructive first: the entry a mapper most needs to find on the timeline.
+	if "delete" in lower or "remove" in lower or "clear" in lower:
+		return "x"
 	if "carve" in lower:
 		return "#"
 	if "hollow" in lower:
 		return "O"
 	if "clip" in lower:
 		return "/"
+	if "bevel" in lower or "chamfer" in lower:
+		return "\\"
 	if "extrude" in lower:
 		return "^"
 	if "subtract" in lower:
 		return "-"
-	if "duplicate" in lower:
+	if "duplicate" in lower or "array" in lower:
 		return "="
-	if "delete" in lower or "remove" in lower:
-		return "x"
-	if "draw" in lower or "brush" in lower or "create" in lower:
-		return "+"
-	if "move" in lower or "translate" in lower:
-		return ">"
+	if "material" in lower or "texture" in lower:
+		return "M"
 	if "paint" in lower:
 		return "~"
+	if "prefab" in lower or "instance" in lower:
+		return "@"
 	if "group" in lower:
 		return "G"
 	if "vertex" in lower or "merge" in lower or "split" in lower:
@@ -217,37 +256,43 @@ static func _get_icon_for_action(action_name: String) -> String:
 		return "<"
 	if "redo" in lower:
 		return ">"
+	if "move" in lower or "translate" in lower or "nudge" in lower:
+		return "T"
 	if "rotate" in lower:
 		return "R"
 	if "scale" in lower:
 		return "S"
-	if "material" in lower or "texture" in lower:
-		return "M"
 	if "entity" in lower:
 		return "E"
 	if "path" in lower:
 		return "P"
 	if "polygon" in lower:
 		return "N"
+	# Generic, and last.
+	if "draw" in lower or "brush" in lower or "create" in lower:
+		return "+"
 	return "*"
 
 
+## The colour an operation is drawn in. Same ordering rule as the glyphs: the
+## generic create test is last, so an action that merely mentions a brush is
+## not painted as a creation.
 static func _get_color_for_action(action_name: String) -> Color:
 	var lower := action_name.to_lower()
-	if "delete" in lower or "remove" in lower:
+	if "delete" in lower or "remove" in lower or "clear" in lower:
 		return Color(0.9, 0.35, 0.3, 0.9)
 	if "subtract" in lower:
 		return Color(0.9, 0.55, 0.3, 0.9)
 	if "extrude" in lower:
 		return Color(0.3, 0.8, 0.5, 0.9)
-	if "carve" in lower or "clip" in lower:
+	if "carve" in lower or "clip" in lower or "bevel" in lower or "chamfer" in lower:
 		return Color(0.9, 0.8, 0.3, 0.9)
 	if "paint" in lower or "material" in lower or "texture" in lower:
 		return Color(0.5, 0.7, 0.9, 0.9)
-	if "draw" in lower or "brush" in lower or "create" in lower:
-		return Color(0.3, 0.7, 1.0, 0.9)
 	if "vertex" in lower or "merge" in lower or "split" in lower:
 		return Color(0.7, 0.5, 0.9, 0.9)
 	if "bake" in lower:
 		return Color(0.3, 0.9, 0.7, 0.9)
+	if "draw" in lower or "brush" in lower or "create" in lower:
+		return Color(0.3, 0.7, 1.0, 0.9)
 	return Color(0.7, 0.7, 0.7, 0.8)

--- a/docs/HammerForge_Editor_Smoke_Checklist.md
+++ b/docs/HammerForge_Editor_Smoke_Checklist.md
@@ -553,8 +553,9 @@ It writes one PNG per tab under `user://console_preview/`.
 - Draw a brush; confirm a "+" icon appears in the timeline.
 - Delete the brush; confirm an "x" icon appears.
 - Undo the delete; confirm the timeline still shows both operations.
-- Hover an icon in the timeline; confirm the detail label shows the operation name and elapsed time (e.g. "Draw Brush (5s ago)").
-- Click an icon, then click **Replay**; confirm the editor undoes/redoes to reach that point in history with a toast ("Replay: undid N steps" or "Replay: redid N steps").
+- Hover an icon in the timeline; confirm the detail label shows the operation name and elapsed time (e.g. "Draw Brush (5s ago)"), and that the **Replay** button does not appear on hover alone.
+- Click an icon; confirm **Replay** appears and stays there while you move the pointer off the entry and onto the button. Click **Replay**; confirm the editor undoes/redoes to reach that point in history with a toast ("Replay: undid N steps" or "Replay: redid N steps").
+- Clear the brushes; confirm the entry is drawn with the destructive "x" in red rather than the blue "+" a creation gets.
 - Draw several more brushes to accumulate 5+ timeline entries. Confirm the timeline scrolls horizontally.
 - Press **Ctrl+Shift+T** again; confirm the timeline hides.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,671 tests across 192 scripts**: **3,664 passing tests**, seven intentional no-assert safety tests, and **18,479 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,734 tests across 198 scripts**: **3,727 passing tests**, seven intentional no-assert safety tests, and **18,653 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,659 tests across 192 scripts**: **3,652 passing tests**, seven intentional no-assert safety tests, and **18,459 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,671 tests across 192 scripts**: **3,664 passing tests**, seven intentional no-assert safety tests, and **18,479 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_operation_replay.gd
+++ b/tests/test_operation_replay.gd
@@ -134,16 +134,138 @@ func test_replay_signal():
 	var received := []
 	replay.replay_requested.connect(func(idx): received.append(idx))
 	replay.record_operation("Draw Brush")
-	replay._hovered_index = 0
+	replay._on_entry_clicked(0)
 	replay._on_replay_pressed()
 	assert_eq(received, [0])
 
 
-func test_replay_button_visible_on_hover():
+# ===========================================================================
+# Replay follows the selection, not the hover (#438)
+# ===========================================================================
+
+
+func test_hovering_an_entry_does_not_raise_the_replay_button():
 	replay.record_operation("Draw Brush")
 	assert_false(replay._replay_btn.visible)
 	replay._on_entry_hovered(0)
+	assert_false(
+		replay._replay_btn.visible,
+		"The button is in the header, so reaching for it would be what hides it"
+	)
+
+
+func test_clicking_an_entry_raises_the_replay_button():
+	replay.record_operation("Draw Brush")
+	replay._on_entry_clicked(0)
 	assert_true(replay._replay_btn.visible)
+
+
+func test_the_replay_button_survives_the_pointer_leaving_the_entry():
+	var received := []
+	replay.replay_requested.connect(func(idx): received.append(idx))
+	replay.record_operation("Draw Brush")
+	replay.record_operation("Clip Brush")
+	replay._on_entry_clicked(1)
+	replay._on_entry_unhovered()
+	assert_true(replay._replay_btn.visible, "Moving towards the button must not hide it")
+	replay._on_replay_pressed()
+	assert_eq(received, [1], "And pressing it replays the entry that was clicked")
+
+
+func test_a_second_click_moves_the_selection():
+	var received := []
+	replay.replay_requested.connect(func(idx): received.append(idx))
+	replay.record_operation("Draw Brush")
+	replay.record_operation("Clip Brush")
+	replay._on_entry_clicked(1)
+	replay._on_entry_clicked(0)
+	replay._on_replay_pressed()
+	assert_eq(received, [0])
+
+
+func test_the_detail_line_goes_back_to_the_selected_entry_after_a_hover():
+	replay.record_operation("Draw Brush")
+	replay.record_operation("Clip Brush")
+	replay._on_entry_clicked(0)
+	replay._on_entry_hovered(1)
+	assert_true(replay._detail_label.text.begins_with("Clip Brush"))
+	replay._on_entry_unhovered()
+	assert_true(
+		replay._detail_label.text.begins_with("Draw Brush"),
+		"With nothing hovered the line describes the selection"
+	)
+
+
+func test_clearing_the_timeline_drops_the_selection():
+	var received := []
+	replay.replay_requested.connect(func(idx): received.append(idx))
+	replay.record_operation("Draw Brush")
+	replay._on_entry_clicked(0)
+	replay.clear()
+	assert_false(replay._replay_btn.visible)
+	replay._on_replay_pressed()
+	assert_eq(received, [], "There is nothing to replay to")
+
+
+func test_hiding_the_panel_drops_the_selection():
+	replay.record_operation("Draw Brush")
+	replay._on_entry_clicked(0)
+	replay.toggle_visible()  # shown
+	replay.toggle_visible()  # hidden again
+	assert_false(replay._replay_btn.visible)
+
+
+func test_the_selection_follows_an_entry_pushed_off_the_front():
+	var received := []
+	replay.replay_requested.connect(func(idx): received.append(idx))
+	for i in range(HFOperationReplay.MAX_ENTRIES):
+		replay.record_operation("Draw Brush", i)
+	replay._on_entry_clicked(5)
+	replay.record_operation("Clip Brush", 99)
+	replay._on_replay_pressed()
+	assert_eq(received, [4], "The entry the mapper picked moved down one")
+
+
+# ===========================================================================
+# The glyph names the operation, not the noun it was performed on (#437)
+# ===========================================================================
+
+
+func test_clear_brushes_is_drawn_as_destruction():
+	assert_eq(HFOperationReplay._get_icon_for_action("Clear Brushes"), "x")
+	assert_eq(
+		HFOperationReplay._get_color_for_action("Clear Brushes"),
+		HFOperationReplay._get_color_for_action("Delete Selection"),
+		"The one entry a mapper most needs to find is not drawn as a creation"
+	)
+
+
+func test_the_two_material_operations_look_the_same():
+	assert_eq(
+		HFOperationReplay._get_icon_for_action("Apply Brush Material"),
+		HFOperationReplay._get_icon_for_action("Assign Face Material")
+	)
+	assert_eq(HFOperationReplay._get_icon_for_action("Apply Brush Material"), "M")
+
+
+func test_bevel_and_prefab_do_not_fall_through_to_the_same_glyph():
+	var bevel := HFOperationReplay._get_icon_for_action("Bevel Edge")
+	var prefab := HFOperationReplay._get_icon_for_action("Place Prefab: door")
+	assert_ne(bevel, prefab)
+	assert_ne(bevel, "*", "Neither falls through to the catch-all")
+	assert_ne(prefab, "*")
+
+
+func test_move_and_redo_do_not_share_a_glyph():
+	assert_ne(
+		HFOperationReplay._get_icon_for_action("Move Selection"),
+		HFOperationReplay._get_icon_for_action("Redo")
+	)
+
+
+func test_a_plain_creation_still_gets_the_create_glyph_and_colour():
+	assert_eq(HFOperationReplay._get_icon_for_action("Draw Brush"), "+")
+	assert_eq(HFOperationReplay._get_color_for_action("Draw Brush"), Color(0.3, 0.7, 1.0, 0.9))
 
 
 # ===========================================================================


### PR DESCRIPTION
Fixes #437. Fixes #438.

- The panel now keeps a `_selected_index` that a click sets and only another click, `clear()` or the panel closing takes away. Replay's visibility and `_on_replay_pressed()` follow the selection; the hover drives the detail line alone and falls back to describing the selection. The selection follows an entry pushed off the front by `MAX_ENTRIES`.
- `_get_icon_for_action()` and `_get_color_for_action()` put the generic draw/brush/create test last and destruction first, so "Clear Brushes" is an "x" in red instead of a "+" in create blue, and "Apply Brush Material" and "Assign Face Material" are both "M". "bevel" and "prefab" have their own glyphs instead of falling through to "*", and move no longer shares ">" with redo.
- `HFHistoryBrowser` calls the same two static functions, so it is fixed with them.
- `test_replay_signal` and `test_replay_button_visible_on_hover` asserted the old hover behaviour and are rewritten; eleven more tests cover the selection lifecycle and the glyph table.
- CHANGELOG and the smoke checklist updated.