### PR TITLE
Read the shortcut chords from the keymap in the HUD, coach marks and tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,20 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **The HUD, the coach marks and the tooltips read the keymap instead of
+  spelling chords out** (#439, #440). `HFKeymap` is rebindable, and three of the
+  surfaces that tell a mapper which key does what held their chords as string
+  literals: 14 in `shortcut_hud.gd`, 6 in `hf_coach_marks.gd`, 5 in
+  `hf_tooltip_text.gd`. After one rebind the same editor showed the new chord in
+  the hotkey palette and the old one in the viewport HUD, the coach marks and
+  the tooltip - and the HUD is the one on screen while the mapper is working.
+  Nothing checked them against the defaults either, so changing a default left
+  three files behind with no error. Each surface now writes `{hollow}` and a new
+  `HFKeymap.format_chords()` renders it, with a test that every token names an
+  action the keymap knows and that no rebindable chord is written out. The
+  rebind list also showed two rows called "Extrude Up" and two called "Extrude
+  Down", because `get_action_label()` gave the same name to an action and its
+  alias; the aliases are named as aliases now.
 - **A shortcut rebound onto a chord another action already uses was accepted in
   silence** (#410). Nothing compared a new binding against the others, so
   `matches()` answered true for both, and `plugin_input_router` tests actions one

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,672 tests across 193 test scripts (3,665 passing plus seven intentional no-assert safety tests; 18,480 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,747 tests across 199 test scripts (3,740 passing plus seven intentional no-assert safety tests; 18,674 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,659 tests across 192 test scripts (3,652 passing plus seven intentional no-assert safety tests; 18,459 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,672 tests across 193 test scripts (3,665 passing plus seven intentional no-assert safety tests; 18,480 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,659 tests** across **192 scripts** (**3,652 passing** plus seven intentional no-assert safety tests; **18,459 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,672 tests** across **193 scripts** (**3,665 passing** plus seven intentional no-assert safety tests; **18,480 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,672 tests** across **193 scripts** (**3,665 passing** plus seven intentional no-assert safety tests; **18,480 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,747 tests** across **199 scripts** (**3,740 passing** plus seven intentional no-assert safety tests; **18,674 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3665%20passing-brightgreen" alt="3665 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3740%20passing-brightgreen" alt="3740 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3652%20passing-brightgreen" alt="3652 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3665%20passing-brightgreen" alt="3665 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,672 tests across 193 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,747 tests across 199 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,659 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,672 tests across 193 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/dock.gd
+++ b/addons/hammerforge/dock.gd
@@ -1109,6 +1109,10 @@ func _is_perf_panel_visible() -> bool:
 func set_keymap(km: HFKeymap) -> void:
 	_keymap = km
 	_update_toolbar_shortcut_labels()
+	# The tooltips name chords too, and they were applied in _ready(), before
+	# the plugin got here with the real keymap.
+	if is_node_ready():
+		_apply_all_tooltips()
 
 
 func _update_toolbar_shortcut_labels() -> void:

--- a/addons/hammerforge/hf_keymap.gd
+++ b/addons/hammerforge/hf_keymap.gd
@@ -199,6 +199,38 @@ func get_display_string(action: String) -> String:
 	return "+".join(parts)
 
 
+## Whether this keymap knows an action at all.
+func has_action(action: String) -> bool:
+	return _bindings.has(action)
+
+
+## Replace every `{action}` in `text` with the chord bound to that action.
+##
+## The surfaces that tell a mapper which key does what used to spell their
+## chords into string literals, so a rebind left them advertising a chord that
+## no longer did anything, and changing a default here left them behind with no
+## error. A token naming an action nothing is bound to is left alone rather than
+## quietly turning into "?", so a typo is visible on screen and a test can find
+## it.
+func format_chords(text: String) -> String:
+	var out := ""
+	var rest := text
+	while true:
+		var open_at := rest.find("{")
+		if open_at < 0:
+			return out + rest
+		var close_at := rest.find("}", open_at)
+		if close_at < 0:
+			return out + rest
+		var action := rest.substr(open_at + 1, close_at - open_at - 1)
+		if has_action(action):
+			out += rest.substr(0, open_at) + get_display_string(action)
+		else:
+			out += rest.substr(0, close_at + 1)
+		rest = rest.substr(close_at + 1)
+	return out
+
+
 ## Save current bindings to a JSON file.
 func save(path: String) -> void:
 	var file = FileAccess.open(path, FileAccess.WRITE)
@@ -352,8 +384,8 @@ static func get_action_label(action: String) -> String:
 		"tool_select": "Select",
 		"tool_extrude_up": "Extrude Up",
 		"tool_extrude_down": "Extrude Down",
-		"tool_extrude": "Extrude Up",
-		"tool_extrude_down_alt": "Extrude Down",
+		"tool_extrude": "Extrude Up (alt)",
+		"tool_extrude_down_alt": "Extrude Down (alt)",
 		"toggle_operation": "Toggle Add / Cut",
 		"toggle_paint_mode": "Toggle Paint Mode",
 		"quick_play": "Quick Play",

--- a/addons/hammerforge/plugin.gd
+++ b/addons/hammerforge/plugin.gd
@@ -227,6 +227,8 @@ func _enter_tree():
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, hud)
 	if hud.has_method("set_user_prefs"):
 		hud.set_user_prefs(_user_prefs)
+	if hud.has_method("set_keymap"):
+		hud.set_keymap(_keymap)
 	if dock:
 		hud.visible = dock.get_show_hud()
 	# Context toolbar (floating above 3D viewport)

--- a/addons/hammerforge/plugin_overlays.gd
+++ b/addons/hammerforge/plugin_overlays.gd
@@ -225,6 +225,7 @@ static func install_power_user_overlays(plugin: Object) -> void:
 		if plugin.base_control:
 			plugin._coach_marks.theme = plugin.base_control.theme
 		plugin._coach_marks.set_user_prefs(plugin._user_prefs)
+		plugin._coach_marks.set_keymap(plugin.get("_keymap"))
 		plugin._coach_marks.guide_dismissed.connect(plugin._on_coach_mark_dismissed)
 		attach_viewport_overlay(plugin, plugin._coach_marks)
 	if plugin._operation_replay == null:

--- a/addons/hammerforge/shortcut_hud.gd
+++ b/addons/hammerforge/shortcut_hud.gd
@@ -22,7 +22,12 @@ const HUD_WIDTH := 260.0
 ## and never move; this one holds still the same way.
 const ROW_FONT_SIZE := 12
 
+const HFKeymapType = preload("hf_keymap.gd")
+
 var _last_context := {}
+## The keymap every chord on this HUD is read from. A default one stands in
+## until the plugin hands over the real one, so the lines are never literals.
+var _keymap = null
 var _user_prefs = null  # HFUserPrefs — untyped to avoid preload
 var _row: HBoxContainer
 var _hint_label: Label
@@ -43,7 +48,7 @@ const MODE_HINTS := {
 	"extrude_down_idle": "Click a face to start extruding downward",
 	"paint_floor": "Drag to paint; Alt erases, Shift locks an axis, Ctrl picks material",
 	"paint_surface": "Click brush faces to apply material",
-	"vertex_edit": "Click vertex to select, drag to move, X/Y/Z to lock axis",
+	"vertex_edit": "Click vertex to select, drag to move, {axis_x}/{axis_y}/{axis_z} to lock axis",
 }
 
 
@@ -174,6 +179,21 @@ func _flash_grid_label() -> void:
 		)
 		. set_ease(Tween.EASE_OUT)
 	)
+
+
+## Hand the HUD the keymap its chords come from.
+func set_keymap(km) -> void:
+	_keymap = km
+	var ctx: Dictionary = _last_context.duplicate()
+	_last_context = {}
+	update_context(ctx)
+
+
+## Render `{action}` tokens in a line against the current keymap.
+func _chords(text: String) -> String:
+	if _keymap == null:
+		_keymap = HFKeymapType.load_or_default("")
+	return _keymap.format_chords(text)
 
 
 func update_context(ctx: Dictionary) -> void:
@@ -347,10 +367,10 @@ func _draw_idle_shortcuts(axis_lock: int) -> String:
 	lines.append("Click + Drag: Draw Base")
 	lines.append("Manage > Create Floor: Stable Surface")
 	lines.append("Shift: Square | Alt+Shift: Cube")
-	lines.append("X / Y / Z: Lock Axis%s" % _axis_suffix(axis_lock))
+	lines.append(_chords("{axis_x} / {axis_y} / {axis_z}: Lock Axis%s" % _axis_suffix(axis_lock)))
 	lines.append("Ctrl+Scroll: Brush Size")
 	lines.append("[ / ]: Grid Size Down/Up")
-	lines.append("Ctrl+D: Duplicate | Del: Remove")
+	lines.append(_chords("{duplicate}: Duplicate | {delete}: Remove"))
 	return "\n".join(lines)
 
 
@@ -381,10 +401,10 @@ func _select_mode_shortcuts() -> String:
 	lines.append("Drag Empty Space: Box Select")
 	lines.append("Drag Brush Widgets: Resize/Move")
 	lines.append("Escape: Clear Selection")
-	lines.append("Del: Remove | Ctrl+D: Duplicate")
+	lines.append(_chords("{delete}: Remove | {duplicate}: Duplicate"))
 	lines.append("Arrows: Nudge | PgUp/Dn: Y-Nudge")
-	lines.append("Ctrl+H: Hollow | Shift+X: Clip")
-	lines.append("Ctrl+Shift+F/C: Floor/Ceiling")
+	lines.append(_chords("{hollow}: Hollow | {clip}: Clip"))
+	lines.append(_chords("{move_to_floor} / {move_to_ceiling}: Floor / Ceiling"))
 	return "\n".join(lines)
 
 
@@ -392,7 +412,7 @@ func _extrude_idle_shortcuts(dir_label: String) -> String:
 	var lines := PackedStringArray()
 	lines.append("-- Extrude %s --" % dir_label)
 	lines.append("Click face + Drag: Extrude %s" % dir_label)
-	lines.append("U: Extrude Up | J: Extrude Down")
+	lines.append(_chords("{tool_extrude_up}: Extrude Up | {tool_extrude_down}: Extrude Down"))
 	lines.append("Right-click: Cancel")
 	return "\n".join(lines)
 
@@ -412,10 +432,17 @@ func _floor_paint_shortcuts() -> String:
 	lines.append("-- Floor Paint --")
 	lines.append("Click + Drag: Paint | Alt: Erase")
 	lines.append("Shift+Drag: Axis Lock | Ctrl+Click: Pick Material")
-	lines.append("B: Brush | E: Erase | R: Rect")
-	lines.append("L: Line | K: Bucket | Esc: Cancel Stroke")
-	lines.append("X/Z: Mirror | Y: Raise Last | H: Room Stamp")
-	lines.append("Enter: Confirm Connector Ghost")
+	lines.append(_chords("{paint_bucket}: Brush | {paint_erase}: Erase | {paint_ramp}: Rect"))
+	lines.append(_chords("{paint_line}: Line | {paint_fill}: Bucket | Esc: Cancel Stroke"))
+	lines.append(
+		_chords(
+			(
+				"{paint_mirror_x}/{paint_mirror_z}: Mirror | {paint_raise}: Raise Last"
+				+ " | {paint_room}: Room Stamp"
+			)
+		)
+	)
+	lines.append(_chords("{paint_confirm_connector}: Confirm Connector Ghost"))
 	return "\n".join(lines)
 
 
@@ -433,10 +460,10 @@ func _vertex_edit_shortcuts() -> String:
 	lines.append("Click: Select vertex")
 	lines.append("Shift+Click: Multi-select")
 	lines.append("Drag: Move selected")
-	lines.append("E: Toggle edge mode")
-	lines.append("Ctrl+W: Merge verts | Ctrl+E: Split edge")
-	lines.append("X / Y / Z: Lock axis")
-	lines.append("Esc: Deselect / V: Exit")
+	lines.append(_chords("{vertex_edge_mode}: Toggle edge mode"))
+	lines.append(_chords("{vertex_merge}: Merge verts | {vertex_split_edge}: Split edge"))
+	lines.append(_chords("{axis_x} / {axis_y} / {axis_z}: Lock axis"))
+	lines.append(_chords("Esc: Deselect / {vertex_edit}: Exit"))
 	return "\n".join(lines)
 
 

--- a/addons/hammerforge/ui/hf_coach_marks.gd
+++ b/addons/hammerforge/ui/hf_coach_marks.gd
@@ -9,6 +9,12 @@ extends PanelContainer
 
 signal guide_dismissed(tool_key: String, dont_show_again: bool)
 
+const HFKeymapType = preload("res://addons/hammerforge/hf_keymap.gd")
+
+## The keymap the steps read their chords from. A default one stands in until
+## the plugin hands over the real one.
+var _keymap = null
+
 const GUIDES: Dictionary = {
 	"polygon":
 	{
@@ -38,7 +44,7 @@ const GUIDES: Dictionary = {
 		"steps":
 		[
 			"Select one or more brushes to carve",
-			"Press Ctrl+Shift+R or use Command Palette",
+			"Press {carve} or use Command Palette",
 			"Overlapping volumes are split into fragments",
 			"Delete unwanted fragments after carving",
 		],
@@ -48,12 +54,12 @@ const GUIDES: Dictionary = {
 		"title": "Vertex Editing",
 		"steps":
 		[
-			"Press V to enter Vertex mode",
+			"Press {vertex_edit} to enter Vertex mode",
 			"Click vertices to select (Shift+click to multi-select)",
-			"Press E to switch to Edge sub-mode",
-			"Ctrl+W merges selected vertices",
-			"Ctrl+E splits the hovered edge",
-			"Press V again to exit Vertex mode",
+			"Press {vertex_edge_mode} to switch to Edge sub-mode",
+			"{vertex_merge} merges selected vertices",
+			"{vertex_split_edge} splits the hovered edge",
+			"Press {vertex_edit} again to exit Vertex mode",
 		],
 	},
 	"extrude":
@@ -61,7 +67,7 @@ const GUIDES: Dictionary = {
 		"title": "Face Extrusion",
 		"steps":
 		[
-			"Select a brush, then press U (up) or J (down)",
+			"Select a brush, then press {tool_extrude_up} (up) or {tool_extrude_down} (down)",
 			"Click a face to begin extruding",
 			"Drag to set extrusion distance",
 			"Click to confirm the new brush",
@@ -73,7 +79,7 @@ const GUIDES: Dictionary = {
 		"steps":
 		[
 			"Select one or more brushes to clip",
-			"Press Shift+X or use Command Palette",
+			"Press {clip} or use Command Palette",
 			"Brush is split along its midplane",
 			"Delete the unwanted half afterward",
 		],
@@ -84,7 +90,7 @@ const GUIDES: Dictionary = {
 		"steps":
 		[
 			"Select a solid brush",
-			"Press Ctrl+H or use Command Palette",
+			"Press {hollow} or use Command Palette",
 			"Enter wall thickness when prompted",
 			"Result: outer shell with inner subtraction",
 		],
@@ -222,10 +228,31 @@ func show_guide(tool_key: String) -> bool:
 	_current_tool_key = tool_key
 	var guide: Dictionary = GUIDES[tool_key]
 	_title_label.text = guide["title"]
-	_populate_steps(guide["steps"])
+	_populate_steps(steps_for(tool_key))
 	_dont_show.button_pressed = false
 	visible = true
 	return true
+
+
+## Hand the coach marks the keymap their chords come from.
+func set_keymap(km) -> void:
+	_keymap = km
+
+
+## A guide's steps with every `{action}` rendered against the current keymap.
+##
+## The steps name chords, and the keymap is rebindable, so they are stored as
+## tokens and resolved here rather than written out as literals that stop being
+## true the moment someone rebinds.
+func steps_for(tool_key: String) -> Array:
+	if not GUIDES.has(tool_key):
+		return []
+	if _keymap == null:
+		_keymap = HFKeymapType.load_or_default("")
+	var out: Array = []
+	for step in GUIDES[tool_key].get("steps", []):
+		out.append(_keymap.format_chords(str(step)))
+	return out
 
 
 ## Hide the current guide.

--- a/addons/hammerforge/ui/hf_tooltip_text.gd
+++ b/addons/hammerforge/ui/hf_tooltip_text.gd
@@ -9,6 +9,8 @@ extends RefCounted
 ## To add a new tooltip: add a `<dock_property>: <text>` pair to TEXTS.
 ## To override at runtime: pass an extra dict to `apply_all`.
 
+const HFKeymapType = preload("res://addons/hammerforge/hf_keymap.gd")
+
 const TEXTS := {
 	# --- Build tab: grid + toggles ---
 	"grid_snap": "Grid snap size in units\nControls brush placement and nudge step",
@@ -107,10 +109,10 @@ const TEXTS := {
 	"clear_cuts_btn": "Remove all pending cuts without applying",
 	"commit_cuts_btn": "Apply pending cuts, bake, then freeze/remove cut geometry",
 	"restore_cuts_btn": "Restore frozen committed cuts back to draft tree",
-	"hollow_btn": "Convert selected solid brush into a hollow room (Ctrl+H)",
+	"hollow_btn": "Convert selected solid brush into a hollow room ({hollow})",
 	"hollow_thickness": "Wall thickness for the hollow operation",
-	"move_floor_btn": "Snap selected brushes to the nearest surface below (Ctrl+Shift+F)",
-	"move_ceiling_btn": "Snap selected brushes to the nearest surface above (Ctrl+Shift+C)",
+	"move_floor_btn": "Snap selected brushes to the nearest surface below ({move_to_floor})",
+	"move_ceiling_btn": "Snap selected brushes to the nearest surface above ({move_to_ceiling})",
 	"tie_entity_btn": "Tag selected brushes as a brush entity class",
 	"untie_entity_btn": "Remove brush entity tag from selected brushes",
 	"brush_entity_class_opt": "Choose brush entity class (func_detail, trigger, etc.)",
@@ -138,7 +140,7 @@ const TEXTS := {
 	"import_settings_btn": "Import editor preferences from a settings file",
 	"save_preset_btn": "Save current brush settings as a reusable preset",
 	"quick_play_btn": "Bake and play the current scene",
-	"clip_btn": "Split selected brush along nearest axis plane (Shift+X)",
+	"clip_btn": "Split selected brush along nearest axis plane ({clip})",
 	# --- Entities tab ---
 	"create_entity_btn": "Create a new entity at the cursor position",
 	"io_output_name": "Output event name (e.g. OnTrigger, OnDamaged)",
@@ -165,13 +167,26 @@ static func set_tooltip(control: Control, text: String) -> void:
 
 ## Walk the catalog and apply each tooltip to its named dock property. Skips
 ## entries whose control isn't present yet (e.g. disabled features).
+## One tooltip, with every `{action}` rendered against `keymap`.
+##
+## The chords in this catalogue are tokens rather than literals: the keymap is
+## rebindable, and a tooltip naming a chord that no longer does anything is
+## worse than one naming none.
+static func text_for(prop_name: String, keymap = null) -> String:
+	var text := str(TEXTS.get(prop_name, ""))
+	if keymap == null:
+		keymap = HFKeymapType.load_or_default("")
+	return keymap.format_chords(text)
+
+
 static func apply_all(dock: Object) -> void:
 	if not is_instance_valid(dock):
 		return
+	var keymap = dock.get("_keymap")
 	for prop_name in TEXTS:
 		var control = dock.get(prop_name)
 		if control:
-			set_tooltip(control, TEXTS[prop_name])
+			set_tooltip(control, text_for(prop_name, keymap))
 
 
 ## Apply tooltips for the snap quick-buttons (which carry their snap value

--- a/docs/HammerForge_UserGuide.md
+++ b/docs/HammerForge_UserGuide.md
@@ -1168,7 +1168,9 @@ All keyboard shortcuts are data-driven and can be customized. The default bindin
 | Command palette | Shift+? / F1 / Ctrl+K | Searchable action palette with fuzzy search |
 | Operation timeline | Ctrl+Shift+T | Toggle operation replay timeline |
 
-**Rebinding:** Edit `user://hammerforge_keymap.json` (created on first run). Each entry maps an action name to `{"keycode": KEY_*, "ctrl": bool, "shift": bool, "alt": bool}`. Restart the plugin after editing. The JSON file is the interface; there is no rebinding UI.
+**Rebinding:** Edit `user://hammerforge_keymap.json` (created on first run). Each entry maps an action name to `{"keycode": KEY_*, "ctrl": bool, "shift": bool, "alt": bool}`. Restart the plugin after editing. The JSON file is the interface; there is no rebinding UI. Every surface that names a chord — the viewport HUD, the coach marks, the dock tooltips, the hotkey palette and the shortcut list — reads the binding rather than repeating it, so a rebind shows up everywhere at once.
+
+Extrude has two bindings each way. `Extrude Up` is U and `Extrude Up (alt)` is E; `Extrude Down` is J and `Extrude Down (alt)` is Shift+E. They are listed under their own names so you can tell which row you are changing.
 
 An entry that is not a binding, one with no usable `keycode`, or a key that is not a HammerForge action is reported once on load, naming the file and the key, and the default is used for it.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,672 tests across 193 scripts**: **3,665 passing tests**, seven intentional no-assert safety tests, and **18,480 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,747 tests across 199 scripts**: **3,740 passing tests**, seven intentional no-assert safety tests, and **18,674 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,659 tests across 192 scripts**: **3,652 passing tests**, seven intentional no-assert safety tests, and **18,459 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,672 tests across 193 scripts**: **3,665 passing tests**, seven intentional no-assert safety tests, and **18,480 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_shortcut_surfaces.gd
+++ b/tests/test_shortcut_surfaces.gd
@@ -1,0 +1,162 @@
+extends GutTest
+
+## #439, #440. The keymap is rebindable, and three of the surfaces that tell a
+## mapper which key does what spelled their chords into string literals instead
+## of asking it. Two actions also shared a display label, so the rebind list
+## showed two rows called "Extrude Up" with different keys.
+
+const HFKeymapType = preload("res://addons/hammerforge/hf_keymap.gd")
+const ShortcutHudScene = preload("res://addons/hammerforge/shortcut_hud.tscn")
+const CoachMarks = preload("res://addons/hammerforge/ui/hf_coach_marks.gd")
+const TooltipText = preload("res://addons/hammerforge/ui/hf_tooltip_text.gd")
+
+var keymap
+
+
+func before_each():
+	keymap = HFKeymapType.load_or_default("")
+
+
+# ===========================================================================
+# format_chords (#439)
+# ===========================================================================
+
+
+func test_a_token_becomes_the_current_chord():
+	assert_eq(keymap.format_chords("{hollow}: Hollow"), "Ctrl+H: Hollow")
+
+
+func test_a_token_follows_a_rebind():
+	keymap.set_binding("hollow", KEY_H, true, false, true)
+	assert_eq(keymap.format_chords("{hollow}: Hollow"), "Ctrl+Alt+H: Hollow")
+
+
+func test_several_tokens_in_one_line():
+	var line: String = keymap.format_chords("{axis_x} / {axis_y} / {axis_z}: Lock Axis")
+	assert_eq(line, "X / Y / Z: Lock Axis")
+
+
+func test_a_token_naming_no_action_is_left_alone():
+	assert_eq(
+		keymap.format_chords("{not_an_action}: Nothing"),
+		"{not_an_action}: Nothing",
+		"A typo stays visible rather than turning into a plausible '?'"
+	)
+
+
+func test_text_with_no_tokens_is_untouched():
+	assert_eq(keymap.format_chords("Right-click: Cancel"), "Right-click: Cancel")
+
+
+func test_has_action_answers_for_both():
+	assert_true(keymap.has_action("hollow"))
+	assert_false(keymap.has_action("not_an_action"))
+
+
+# ===========================================================================
+# The three surfaces read the keymap
+# ===========================================================================
+
+
+func test_the_hud_names_the_current_chord():
+	var hud = ShortcutHudScene.instantiate()
+	add_child_autoqfree(hud)
+	hud.set_keymap(keymap)
+	var before: String = hud._build_shortcuts_text({"tool": 1, "mode": 0})
+	assert_true(before.contains("Ctrl+H: Hollow"), "The default chord is on the HUD")
+	keymap.set_binding("hollow", KEY_H, true, false, true)
+	var after: String = hud._build_shortcuts_text({"tool": 1, "mode": 0})
+	assert_true(after.contains("Ctrl+Alt+H: Hollow"), "And so is the rebound one")
+	assert_false(after.contains("Ctrl+H: Hollow"), "The old chord is gone")
+
+
+func test_the_coach_marks_name_the_current_chord():
+	var marks = CoachMarks.new()
+	add_child_autoqfree(marks)
+	marks.set_keymap(keymap)
+	assert_true(
+		"Press Ctrl+H or use Command Palette" in marks.steps_for("hollow"),
+		"The default chord is in the guide"
+	)
+	keymap.set_binding("hollow", KEY_H, true, false, true)
+	assert_true("Press Ctrl+Alt+H or use Command Palette" in marks.steps_for("hollow"))
+
+
+func test_the_dock_tooltip_names_the_current_chord():
+	assert_string_contains(TooltipText.text_for("hollow_btn", keymap), "(Ctrl+H)")
+	keymap.set_binding("hollow", KEY_H, true, false, true)
+	assert_string_contains(TooltipText.text_for("hollow_btn", keymap), "(Ctrl+Alt+H)")
+
+
+func test_every_chord_token_in_the_three_surfaces_names_a_real_action():
+	var regex := RegEx.new()
+	regex.compile("\\{([a-z_0-9]+)\\}")
+	var unresolved: Array = []
+	for path in [
+		"res://addons/hammerforge/shortcut_hud.gd",
+		"res://addons/hammerforge/ui/hf_coach_marks.gd",
+		"res://addons/hammerforge/ui/hf_tooltip_text.gd",
+	]:
+		for line in FileAccess.get_file_as_string(path).split("\n"):
+			if line.strip_edges().begins_with("#"):
+				continue
+			for hit in regex.search_all(line):
+				var action := hit.get_string(1)
+				if not keymap.has_action(action) and not unresolved.has(action):
+					unresolved.append(action)
+	assert_eq(unresolved, [], "A token naming no action is rendered on screen in braces")
+
+
+func test_the_surfaces_hold_no_chord_literal():
+	var regex := RegEx.new()
+	regex.compile('"[^"]*(Ctrl|Alt)\\+[A-Za-z][^"]*"')
+	var literals: Array = []
+	for path in [
+		"res://addons/hammerforge/shortcut_hud.gd",
+		"res://addons/hammerforge/ui/hf_coach_marks.gd",
+		"res://addons/hammerforge/ui/hf_tooltip_text.gd",
+	]:
+		for line in FileAccess.get_file_as_string(path).split("\n"):
+			if line.strip_edges().begins_with("#"):
+				continue
+			for hit in regex.search_all(line):
+				literals.append(hit.get_string(0))
+	# Mouse gestures and held modifiers are not rebindable actions, so they are
+	# the one place a chord is allowed to be written out.
+	const NOT_ACTIONS := ["Scroll", "Click", "Alt+Shift", "picks material"]
+	var rebindable: Array = []
+	for literal in literals:
+		var is_gesture := false
+		for gesture in NOT_ACTIONS:
+			if str(literal).contains(gesture):
+				is_gesture = true
+				break
+		if not is_gesture:
+			rebindable.append(literal)
+	assert_eq(rebindable, [], "A rebindable chord belongs in a token, not a literal")
+
+
+# ===========================================================================
+# One label per action in the rebind list (#440)
+# ===========================================================================
+
+
+func test_no_two_actions_share_a_label():
+	var by_label := {}
+	for action in keymap.get_actions():
+		var label: String = HFKeymapType.get_action_label(action)
+		var seen: Array = by_label.get(label, [])
+		seen.append(action)
+		by_label[label] = seen
+	var collisions: Array = []
+	for label in by_label:
+		if (by_label[label] as Array).size() > 1:
+			collisions.append("%s: %s" % [label, str(by_label[label])])
+	assert_eq(collisions, [], "Two rows with one name cannot be told apart in the rebind list")
+
+
+func test_the_extrude_aliases_are_named_as_aliases():
+	assert_eq(HFKeymapType.get_action_label("tool_extrude_up"), "Extrude Up")
+	assert_eq(HFKeymapType.get_action_label("tool_extrude"), "Extrude Up (alt)")
+	assert_eq(HFKeymapType.get_action_label("tool_extrude_down"), "Extrude Down")
+	assert_eq(HFKeymapType.get_action_label("tool_extrude_down_alt"), "Extrude Down (alt)")

--- a/tools/vibe/scenarios/shortcut_surfaces.gd
+++ b/tools/vibe/scenarios/shortcut_surfaces.gd
@@ -40,9 +40,12 @@ func _select_mode_text(hud: Control) -> String:
 	return hud._build_shortcuts_text({"tool": 1, "mode": 0})
 
 
-func _coach_steps(guide: String) -> Array:
-	var guides: Dictionary = CoachMarks.GUIDES
-	return guides.get(guide, {}).get("steps", [])
+func _coach_steps(guide: String, keymap) -> Array:
+	var marks = CoachMarks.new()
+	marks.set_keymap(keymap)
+	var steps: Array = marks.steps_for(guide)
+	marks.free()
+	return steps
 
 
 func _who_reads_the_keymap_and_who_does_not() -> void:
@@ -50,6 +53,7 @@ func _who_reads_the_keymap_and_who_does_not() -> void:
 	note("default Hollow binding", keymap.get_display_string("hollow"))
 
 	var hud = _hud()
+	hud.set_keymap(keymap)
 	await frame()
 	var before := _select_mode_text(hud)
 	note("HUD select-mode line", before.split("\n")[7] if before.split("\n").size() > 7 else before)
@@ -63,11 +67,11 @@ func _who_reads_the_keymap_and_who_does_not() -> void:
 	var lying: Array = []
 	if after.contains("Ctrl+H"):
 		lying.append("viewport HUD: '%s'" % _line_containing(after, "Ctrl+H"))
-	var hollow_steps := _coach_steps("hollow")
+	var hollow_steps := _coach_steps("hollow", keymap)
 	for step in hollow_steps:
 		if str(step).contains("Ctrl+H"):
 			lying.append("coach mark: '%s'" % str(step))
-	var hollow_tip := str(TooltipText.TEXTS.get("hollow_btn", ""))
+	var hollow_tip := TooltipText.text_for("hollow_btn", keymap)
 	note("hollow_btn tooltip", hollow_tip)
 	if hollow_tip.contains("Ctrl+H"):
 		lying.append("dock tooltip: '%s'" % hollow_tip)
@@ -91,6 +95,16 @@ func _who_reads_the_keymap_and_who_does_not() -> void:
 	note("chord literals in hf_coach_marks.gd", hard_coded["coach"])
 	note("chord literals in hf_tooltip_text.gd", hard_coded["tooltips"])
 
+	# Every token in the three catalogues has to name an action the keymap
+	# knows, or format_chords() leaves it on screen in braces.
+	var unresolved := _unresolved_tokens(keymap)
+	note("chord tokens naming no action", unresolved)
+	if not unresolved.is_empty():
+		flag(
+			"a chord token in a shortcut surface names no action",
+			"format_chords() leaves %s on screen as written" % str(unresolved)
+		)
+
 	hud.queue_free()
 	DirAccess.remove_absolute(ProjectSettings.globalize_path(KEYMAP_PATH))
 
@@ -100,6 +114,31 @@ func _line_containing(text: String, needle: String) -> String:
 		if line.contains(needle):
 			return line
 	return ""
+
+
+## Every `{action}` token in the three surfaces that the keymap does not know.
+func _unresolved_tokens(keymap) -> Array:
+	var out: Array = []
+	var regex := RegEx.new()
+	regex.compile("\\{([a-z_0-9]+)\\}")
+	for path in [
+		"res://addons/hammerforge/shortcut_hud.gd",
+		"res://addons/hammerforge/ui/hf_coach_marks.gd",
+		"res://addons/hammerforge/ui/hf_tooltip_text.gd",
+	]:
+		var f := FileAccess.open(path, FileAccess.READ)
+		if not f:
+			continue
+		for line in f.get_as_text().split("
+"):
+			# Comments write {action} as a placeholder; only the strings count.
+			if line.strip_edges().begins_with("#"):
+				continue
+			for hit in regex.search_all(line):
+				var action := hit.get_string(1)
+				if not keymap.has_action(action) and not out.has(action):
+					out.append(action)
+	return out
 
 
 func _count_hard_coded_chords() -> Dictionary:


### PR DESCRIPTION
Fixes #439. Fixes #440.

- New `HFKeymap.format_chords()` replaces `{action}` with the chord currently bound to it, and `has_action()` says whether it knows one. A token naming no action is left on screen in braces rather than turning into a plausible `?`, so a typo is visible and a test can find it.
- `shortcut_hud.gd`, `hf_coach_marks.gd` and `hf_tooltip_text.gd` hold tokens instead of literals and are handed the keymap (`set_keymap()` on the HUD and the coach marks; `apply_all()` reads the dock's). `dock.set_keymap()` re-applies the tooltips, which `_ready()` had already written before the real keymap arrived.
- `get_action_label()` names the extrude aliases as aliases, so the rebind list no longer shows two rows called "Extrude Up" with different keys.
- New `tests/test_shortcut_surfaces.gd`: the rendered chord follows a rebind on all three surfaces, every token names a real action, no rebindable chord is written out, and no two actions share a label.
- Full suite: 3665 passing, 0 failing.
- CHANGELOG and the user guide rebinding notes updated.