### PR TITLE
Scan only the touched cells on the live connector path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,18 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **The live auto-connector path costs the stroke instead of the level**
+  (#441). `defs_for_touched_cells()` is documented as the cheap path that "does
+  not scan or rebuild geometry", and its first statement was a full
+  `detect_boundaries()` - which walks every cell of every chunk of every layer
+  to build a dictionary from scratch, then compares each filled cell against
+  every other layer. The touched-cell filter ran afterwards, on the result, so
+  the cheap path cost the same as the scan it claimed to avoid and grew with
+  the size of the level rather than the size of the stroke: 39 ms per committed
+  stroke on a level with 8,192 painted cells, while dragging. The live path now
+  walks the touched cells and their four neighbours directly, and a test
+  asserts it gives the same answer as filtering the full scan so the two cannot
+  drift apart.
 - **A shortcut rebound onto a chord another action already uses was accepted in
   silence** (#410). Nothing compared a new binding against the others, so
   `matches()` answered true for both, and `plugin_input_router` tests actions one

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,659 tests across 192 test scripts (3,652 passing plus seven intentional no-assert safety tests; 18,459 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,667 tests across 192 test scripts (3,660 passing plus seven intentional no-assert safety tests; 18,471 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,667 tests across 192 test scripts (3,660 passing plus seven intentional no-assert safety tests; 18,471 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,755 tests across 199 test scripts (3,748 passing plus seven intentional no-assert safety tests; 18,686 assertions; verified in CI on September 12, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,659 tests** across **192 scripts** (**3,652 passing** plus seven intentional no-assert safety tests; **18,459 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,667 tests** across **192 scripts** (**3,660 passing** plus seven intentional no-assert safety tests; **18,471 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,667 tests** across **192 scripts** (**3,660 passing** plus seven intentional no-assert safety tests; **18,471 assertions**).
+Full suite (verified in CI on September 12, 2026): **3,755 tests** across **199 scripts** (**3,748 passing** plus seven intentional no-assert safety tests; **18,686 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3652%20passing-brightgreen" alt="3652 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3660%20passing-brightgreen" alt="3660 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3660%20passing-brightgreen" alt="3660 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3748%20passing-brightgreen" alt="3748 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,659 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,667 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,667 tests across 192 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,755 tests across 199 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/paint/hf_auto_connector.gd
+++ b/addons/hammerforge/paint/hf_auto_connector.gd
@@ -173,6 +173,88 @@ func generate_connectors(layers: HFPaintLayerManager, settings: Settings = null)
 	return generate_definitions(defs_from_groups(groups, settings), layers)
 
 
+## Boundary segments that touch one of `cells` in layer `layer_index`.
+##
+## The same answer `detect_boundaries()` gives filtered down to these cells, at
+## the cost of the cells rather than the cost of the level. The full scan walks
+## every cell of every chunk of every layer to build a dictionary from scratch,
+## then compares each filled cell against every other layer; this walks the
+## handful of cells a stroke touched and their four neighbours.
+##
+## `test_auto_connector.gd` asserts the two agree, which is what keeps this from
+## drifting away from the scan it stands in for.
+func boundaries_for_cells(
+	layers: HFPaintLayerManager, layer_index: int, cells: Dictionary
+) -> Array[ConnectorSegment]:
+	var segments: Array[ConnectorSegment] = []
+	if layers == null or layers.layers.size() < 2:
+		return segments
+	if layer_index < 0 or layer_index >= layers.layers.size():
+		return segments
+	var directions: Array[Vector2i] = [
+		Vector2i(1, 0), Vector2i(-1, 0), Vector2i(0, 1), Vector2i(0, -1)
+	]
+	var paired: Dictionary = {}
+	for cell: Vector2i in cells:
+		for dir in directions:
+			var neighbour: Vector2i = cell + dir
+			# The touched cell as the source of a boundary.
+			_collect_segments_at(layers, layer_index, cell, neighbour, dir, paired, segments)
+			# And as the destination: a cell next door in another layer whose own
+			# unfilled neighbour is this one.
+			for j in range(layers.layers.size()):
+				if j == layer_index:
+					continue
+				_collect_segments_at(layers, j, neighbour, cell, -dir, paired, segments)
+	return segments
+
+
+## One cell, one direction: the boundary test `detect_boundaries()` runs in its
+## innermost loop, against the layers directly rather than a prebuilt map.
+func _collect_segments_at(
+	layers: HFPaintLayerManager,
+	i: int,
+	cell: Vector2i,
+	neighbour: Vector2i,
+	dir: Vector2i,
+	paired: Dictionary,
+	out: Array[ConnectorSegment]
+) -> void:
+	var layer_i: HFPaintLayer = layers.layers[i]
+	if layer_i == null or not layer_i.get_cell(cell):
+		return
+	# Only interested if the neighbour is NOT filled in this layer.
+	if layer_i.get_cell(neighbour):
+		return
+	var h_i: float = layer_i.grid.layer_y + layer_i.get_height_at(cell)
+	for j in range(layers.layers.size()):
+		if j == i:
+			continue
+		var layer_j: HFPaintLayer = layers.layers[j]
+		if layer_j == null or not layer_j.get_cell(neighbour):
+			continue
+		var h_j: float = layer_j.grid.layer_y + layer_j.get_height_at(neighbour)
+		var diff := absf(h_j - h_i)
+		if diff < MIN_HEIGHT_DIFF:
+			continue
+		var lo: int = mini(i, j)
+		var hi: int = maxi(i, j)
+		var c_lo: Vector2i = cell if i < j else neighbour
+		var c_hi: Vector2i = neighbour if i < j else cell
+		var key := "%d_%d_%d_%d_%d_%d" % [lo, hi, c_lo.x, c_lo.y, c_hi.x, c_hi.y]
+		if paired.has(key):
+			continue
+		paired[key] = true
+		var seg := ConnectorSegment.new()
+		seg.from_layer_index = i
+		seg.to_layer_index = j
+		seg.from_cell = cell
+		seg.to_cell = neighbour
+		seg.height_diff = diff
+		seg.direction = dir
+		out.append(seg)
+
+
 ## Return connector definitions only for boundaries touched by the latest paint
 ## footprint. This is the live-ghost path; it does not scan or rebuild geometry.
 func defs_for_touched_cells(
@@ -185,17 +267,8 @@ func defs_for_touched_cells(
 		return []
 	if settings == null:
 		settings = Settings.new()
-	var filtered: Array[ConnectorSegment] = []
-	for segment in detect_boundaries(layers):
-		var touches_from := (
-			segment.from_layer_index == touched_layer_index and touched_cells.has(segment.from_cell)
-		)
-		var touches_to := (
-			segment.to_layer_index == touched_layer_index and touched_cells.has(segment.to_cell)
-		)
-		if touches_from or touches_to:
-			filtered.append(segment)
-	return defs_from_groups(group_segments(filtered), settings)
+	var touched := boundaries_for_cells(layers, touched_layer_index, touched_cells)
+	return defs_from_groups(group_segments(touched), settings)
 
 
 func defs_from_groups(groups: Array, settings: Settings) -> Array:

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,659 tests across 192 scripts**: **3,652 passing tests**, seven intentional no-assert safety tests, and **18,459 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,667 tests across 192 scripts**: **3,660 passing tests**, seven intentional no-assert safety tests, and **18,471 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,667 tests across 192 scripts**: **3,660 passing tests**, seven intentional no-assert safety tests, and **18,471 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 12, 2026 contains **3,755 tests across 199 scripts**: **3,748 passing tests**, seven intentional no-assert safety tests, and **18,686 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_auto_connector.gd
+++ b/tests/test_auto_connector.gd
@@ -520,3 +520,119 @@ func test_confirmed_connector_is_not_duplicated_when_automatic_detection_is_on()
 		if child.name.begins_with("AutoConnector"):
 			count += 1
 	assert_eq(count, 1)
+
+
+# ---------------------------------------------------------------------------
+# The live path costs the stroke, not the level (#441)
+# ---------------------------------------------------------------------------
+
+
+func _segment_keys(segments: Array) -> Array:
+	var keys: Array = []
+	for seg in segments:
+		var lo: int = mini(seg.from_layer_index, seg.to_layer_index)
+		var hi: int = maxi(seg.from_layer_index, seg.to_layer_index)
+		var a: Vector2i = (
+			seg.from_cell if seg.from_layer_index < seg.to_layer_index else seg.to_cell
+		)
+		var b: Vector2i = (
+			seg.to_cell if seg.from_layer_index < seg.to_layer_index else seg.from_cell
+		)
+		keys.append("%d_%d_%d_%d_%d_%d" % [lo, hi, a.x, a.y, b.x, b.y])
+	keys.sort()
+	return keys
+
+
+func _two_level_manager() -> HFPaintLayerManagerScript:
+	var mgr := _make_layer_manager()
+	var lower := mgr.create_layer(&"lo", 0.0)
+	var upper := mgr.create_layer(&"hi", 4.0)
+	for y in range(4):
+		for x in range(4):
+			lower.set_cell(Vector2i(x, y), true)
+	for y in range(4):
+		for x in range(4, 8):
+			upper.set_cell(Vector2i(x, y), true)
+	return mgr
+
+
+func test_the_touched_scan_agrees_with_the_full_scan():
+	var mgr := _two_level_manager()
+	var all_cells: Dictionary = {}
+	for y in range(4):
+		for x in range(4):
+			all_cells[Vector2i(x, y)] = true
+	var touched := gen.boundaries_for_cells(mgr, 0, all_cells)
+	var full: Array = []
+	for seg in gen.detect_boundaries(mgr):
+		if (
+			(seg.from_layer_index == 0 and all_cells.has(seg.from_cell))
+			or (seg.to_layer_index == 0 and all_cells.has(seg.to_cell))
+		):
+			full.append(seg)
+	assert_eq(
+		_segment_keys(touched),
+		_segment_keys(full),
+		"The cheap path answers exactly what the scan it stands in for would"
+	)
+
+
+func test_the_touched_scan_finds_a_boundary_from_either_side():
+	var mgr := _two_level_manager()
+	var from_lower := gen.boundaries_for_cells(mgr, 0, {Vector2i(3, 1): true})
+	assert_eq(from_lower.size(), 1, "The lower cell's own boundary")
+	var from_upper := gen.boundaries_for_cells(mgr, 1, {Vector2i(4, 1): true})
+	assert_eq(_segment_keys(from_upper), _segment_keys(from_lower), "Same boundary, other side")
+
+
+func test_the_touched_scan_ignores_cells_away_from_a_boundary():
+	var mgr := _two_level_manager()
+	assert_eq(gen.boundaries_for_cells(mgr, 0, {Vector2i(0, 0): true}).size(), 0)
+
+
+func test_the_touched_scan_is_empty_without_a_second_layer():
+	var mgr := _make_layer_manager()
+	var only := mgr.create_layer(&"a", 0.0)
+	only.set_cell(Vector2i(0, 0), true)
+	assert_eq(gen.boundaries_for_cells(mgr, 0, {Vector2i(0, 0): true}).size(), 0)
+
+
+func test_the_touched_scan_refuses_a_layer_index_out_of_range():
+	var mgr := _two_level_manager()
+	assert_eq(gen.boundaries_for_cells(mgr, 7, {Vector2i(3, 1): true}).size(), 0)
+
+
+func test_defs_for_touched_cells_matches_the_full_scan_for_that_cell():
+	var mgr := _two_level_manager()
+	var settings := HFAutoConnectorScript.Settings.new()
+	var defs: Array = gen.defs_for_touched_cells(mgr, 0, {Vector2i(3, 1): true}, settings)
+	assert_eq(defs.size(), 1, "One boundary under the stroke, one connector")
+	assert_eq(defs[0].from_layer_index, 0)
+	assert_eq(defs[0].to_layer_index, 1)
+
+
+func test_defs_for_touched_cells_is_empty_for_an_empty_footprint():
+	var mgr := _two_level_manager()
+	assert_eq(gen.defs_for_touched_cells(mgr, 0, {}).size(), 0)
+
+
+func test_the_touched_scan_does_not_grow_with_the_level():
+	# The old live path ran a full detect_boundaries() and filtered the result,
+	# so one touched cell cost what the whole level cost.
+	var mgr := _make_layer_manager()
+	var lower := mgr.create_layer(&"lo", 0.0)
+	var upper := mgr.create_layer(&"hi", 4.0)
+	for y in range(64):
+		for x in range(64):
+			lower.set_cell(Vector2i(x, y), true)
+	for y in range(64):
+		for x in range(64, 128):
+			upper.set_cell(Vector2i(x, y), true)
+	var started := Time.get_ticks_usec()
+	var touched := gen.boundaries_for_cells(mgr, 0, {Vector2i(63, 10): true})
+	var took := Time.get_ticks_usec() - started
+	assert_eq(touched.size(), 1)
+	var full_started := Time.get_ticks_usec()
+	gen.detect_boundaries(mgr)
+	var full_took := Time.get_ticks_usec() - full_started
+	assert_lt(took, full_took / 4, "One cell costs a fraction of the level-wide scan")


### PR DESCRIPTION
Fixes #441.

- New `HFAutoConnector.boundaries_for_cells()` walks the cells a stroke touched and their four neighbours, testing each against the layers directly. `defs_for_touched_cells()` uses it instead of running a full `detect_boundaries()` and filtering the result, which cost what the whole level cost on every committed stroke - 39 ms with 8,192 painted cells, while dragging.
- A test asserts the restricted scan gives exactly the same segments as filtering the full scan, so the two cannot drift apart; another asserts one touched cell costs a fraction of the level-wide scan.
- Measured with the connectors vibe scenario: one touched cell is 0 ms at 128, 2,048 and 8,192 painted cells, and returns the same definition it did before.
- CHANGELOG updated.