### PR TITLE
Ten vibe scenarios over the dock, texturing and the playtest

### DIFF
--- a/tools/vibe/README.md
+++ b/tools/vibe/README.md
@@ -104,6 +104,16 @@ it from here.
 | `heightmap-io` | what a heightmap loses going through the `.hflevel`'s base64 PNG, in world units |
 | `regions` | what the region eviction loop frees against what it thinks it freed |
 | `quick-property` | whether the quick popup and the dock control behind it agree on range and step |
+| `dock-undo` | which dock commands change the level without registering an undo step |
+| `dock-settings` | what an exported settings file carries back onto the level, and what a hand-edited one does |
+| `uv-defaults` | whether a brush's faces are born with a projection that can show a texture |
+| `surface-paint` | where a surface paint stroke lands against where the cursor was, and what one costs |
+| `dock-cordon` | whether the cordon spins can hold the cordon the level was given |
+| `playtest-spawn` | where the playtest player's feet end up against the spawn the validator approved |
+| `entity-props` | what a colour or vector entity property is after a save, a load and a `.map` export |
+| `bake-materials` | whether per-face materials reach the baked mesh with the settings a level starts with |
+| `dock-ranges` | whether each dock spin and the level property behind it agree about the legal range |
+| `brush-sides` | whether a cylinder or a cone is built with the number of sides it was asked for |
 
 ## Adding a scenario
 

--- a/tools/vibe/hf_vibe_runner.gd
+++ b/tools/vibe/hf_vibe_runner.gd
@@ -62,6 +62,16 @@ const SCENARIOS: Array[String] = [
 	"res://tools/vibe/scenarios/heightmap_io.gd",
 	"res://tools/vibe/scenarios/regions.gd",
 	"res://tools/vibe/scenarios/quick_property.gd",
+	"res://tools/vibe/scenarios/dock_undo.gd",
+	"res://tools/vibe/scenarios/dock_settings.gd",
+	"res://tools/vibe/scenarios/uv_defaults.gd",
+	"res://tools/vibe/scenarios/surface_paint.gd",
+	"res://tools/vibe/scenarios/dock_cordon.gd",
+	"res://tools/vibe/scenarios/playtest_spawn.gd",
+	"res://tools/vibe/scenarios/entity_props.gd",
+	"res://tools/vibe/scenarios/bake_materials.gd",
+	"res://tools/vibe/scenarios/dock_ranges.gd",
+	"res://tools/vibe/scenarios/brush_sides.gd",
 ]
 
 

--- a/tools/vibe/run_vibe.py
+++ b/tools/vibe/run_vibe.py
@@ -77,6 +77,16 @@ SCENARIOS = [
     "heightmap-io",
     "regions",
     "quick-property",
+    "dock-undo",
+    "dock-settings",
+    "uv-defaults",
+    "surface-paint",
+    "dock-cordon",
+    "playtest-spawn",
+    "entity-props",
+    "bake-materials",
+    "dock-ranges",
+    "brush-sides",
 ]
 
 # Generous: chaos runs 300 operations and cost saves eight levels. A scenario

--- a/tools/vibe/scenarios/bake_materials.gd
+++ b/tools/vibe/scenarios/bake_materials.gd
@@ -1,0 +1,112 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## What the bake does with the materials a mapper put on faces.
+##
+## The Materials panel assigns a palette slot per face, the face carries
+## `material_idx`, and the editor preview shows it. The bake has two paths: the
+## face-material path, which triangulates each face and resolves its own
+## material, and the CSG path, which does not. Which one runs is decided by
+## `bake_use_face_materials`, a check box in the Advanced fold of the Test tab,
+## and `LevelRoot.bake_use_face_materials` defaults to `false`.
+
+const FaceData = preload("res://addons/hammerforge/face_data.gd")
+
+
+func id() -> String:
+	return "bake-materials"
+
+
+func summary() -> String:
+	return "whether per-face materials reach the baked mesh with the settings a level starts with"
+
+
+func run() -> void:
+	await _two_materials_on_one_brush()
+
+
+## Every material on every surface under the baked container.
+func _baked_materials(root: Node3D) -> Array:
+	var out: Array = []
+	var stack: Array = [root.baked_container]
+	while not stack.is_empty():
+		var node = stack.pop_back()
+		if node == null:
+			continue
+		for child in node.get_children():
+			stack.append(child)
+		if node is MeshInstance3D:
+			var mesh: Mesh = node.mesh
+			if mesh == null:
+				continue
+			for s in mesh.get_surface_count():
+				var m = node.get_surface_override_material(s)
+				if m == null:
+					m = mesh.surface_get_material(s)
+				out.append(m)
+	return out
+
+
+func _distinct(materials: Array) -> int:
+	var seen: Array = []
+	for m in materials:
+		if m != null and not seen.has(m):
+			seen.append(m)
+	return seen.size()
+
+
+func _coloured(colour: Color) -> StandardMaterial3D:
+	var mat := StandardMaterial3D.new()
+	mat.albedo_color = colour
+	return mat
+
+
+func _two_materials_on_one_brush() -> void:
+	var root: Node3D = await fresh_root("BakeMaterialLevel")
+	var b = box(root, Vector3(128, 64, 32))
+	await frame()
+	var red: int = root.add_material_to_palette(_coloured(Color.RED))
+	var blue: int = root.add_material_to_palette(_coloured(Color.BLUE))
+	for i in range(b.faces.size()):
+		b.faces[i].material_idx = red if i < 3 else blue
+	b.rebuild_preview()
+	await frame()
+	note("palette slots", [red, blue])
+	note("bake_use_face_materials on a fresh level", root.get("bake_use_face_materials"))
+
+	root.tag_full_reconcile()
+	var ok: bool = await root.bake(true, false, 0)
+	await frame()
+	var as_shipped: Array = _baked_materials(root)
+	note("bake succeeded", ok)
+	note("surfaces in the baked mesh, as shipped", as_shipped.size())
+	note("distinct materials on them", _distinct(as_shipped))
+
+	root.set("bake_use_face_materials", true)
+	root.tag_full_reconcile()
+	var ok2: bool = await root.bake(true, false, 0)
+	await frame()
+	var with_flag: Array = _baked_materials(root)
+	note("bake succeeded with the flag on", ok2)
+	note("surfaces in the baked mesh with the flag on", with_flag.size())
+	note("distinct materials on them", _distinct(with_flag))
+
+	if _distinct(as_shipped) < 2 and _distinct(with_flag) >= 2:
+		known(
+			466,
+			"per-face materials do not reach the bake a level starts with",
+			(
+				(
+					"two palette materials on one brush's faces come out as %d material(s) on the"
+					+ " baked mesh with the settings a new level has, and %d once"
+					+ " bake_use_face_materials is turned on. The flag defaults to false on"
+					+ " LevelRoot and the check box that mirrors it is unticked inside the Test"
+					+ " tab's Advanced fold, so the Materials panel, the face selection filters and"
+					+ " the UV controls all work on the preview and stop at the bake. Nothing on"
+					+ " the bake path says the face materials were dropped -- the log line that"
+					+ " does exist fires the other way round, when the flag is on and a cut forces"
+					+ " the CSG path."
+				)
+				% [_distinct(as_shipped), _distinct(with_flag)]
+			)
+		)

--- a/tools/vibe/scenarios/bake_materials.gd.uid
+++ b/tools/vibe/scenarios/bake_materials.gd.uid
@@ -1,0 +1,1 @@
+uid://f5y7a1uygx1h

--- a/tools/vibe/scenarios/brush_sides.gd
+++ b/tools/vibe/scenarios/brush_sides.gd
@@ -1,0 +1,89 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## What `sides` does to a brush that has a radius.
+##
+## `DraftBrush.sides` is part of a brush: it is in `create_brush_from_info()`, in
+## the `.hflevel`, in `HFDuplicator.shape_signature()`, and in a brush preset.
+## The pyramid and the prisms build from it. This asks what the round shapes do
+## with it, and what one of them costs.
+
+const DraftBrush = preload("res://addons/hammerforge/brush_instance.gd")
+
+const CYLINDER := 1
+const CONE := 3
+const PYRAMID := 5
+
+
+func id() -> String:
+	return "brush-sides"
+
+
+func summary() -> String:
+	return "whether a cylinder or a cone is built with the number of sides it was asked for"
+
+
+func run() -> void:
+	await _sides_on_every_round_shape()
+
+
+func _made(root: Node3D, shape: int, sides: int) -> Dictionary:
+	var brush = root.create_brush_from_info(
+		{"shape": shape, "size": Vector3(64, 64, 64), "sides": sides}
+	)
+	await frame()
+	if brush == null:
+		return {}
+	var tri_count := 0
+	for face in brush.get_faces():
+		var tri: Dictionary = face.triangulate()
+		tri_count += int((tri.get("verts", PackedVector3Array()) as PackedVector3Array).size() / 3)
+	return {
+		"sides_asked": sides,
+		"sides_stored": int(brush.sides),
+		"faces": brush.get_faces().size(),
+		"triangles": tri_count,
+	}
+
+
+func _sides_on_every_round_shape() -> void:
+	var root: Node3D = await fresh_root("SidesLevel")
+	for shape in [["cylinder", CYLINDER], ["cone", CONE], ["pyramid", PYRAMID]]:
+		var counts: Array = []
+		for sides in [3, 6, 8, 16]:
+			var made: Dictionary = await _made(root, int(shape[1]), sides)
+			if made.is_empty():
+				continue
+			note(
+				"%s asked for %d sides" % [shape[0], sides],
+				(
+					"stores sides %d, builds %d faces / %d triangles"
+					% [made["sides_stored"], made["faces"], made["triangles"]]
+				)
+			)
+			counts.append(int(made["faces"]))
+		var varies := false
+		for c in counts:
+			if c != counts[0]:
+				varies = true
+		if not varies and counts.size() > 1 and shape[1] != PYRAMID:
+			known(
+				482,
+				"a %s is the same %d faces whatever sides it is given" % [shape[0], counts[0]],
+				(
+					(
+						"_build_base_mesh() makes a CylinderMesh and sets height and radius and"
+						+ " nothing else, so `radial_segments` stays at Godot's default of 64 -- a"
+						+ " %s asked for 3, 6, 8 or 16 sides is a 64-gon every time, %d faces after"
+						+ " the coplanar merge. The number is not ignored quietly either: it is"
+						+ " stored on the brush, written to the .hflevel, and counted in"
+						+ " HFDuplicator.shape_signature(), so two brushes that differ only in"
+						+ " `sides` are the same geometry and different signatures."
+						+ " PrefabFactory.create_prefab() has the same gap from the other side:"
+						+ " it works out safe_sides and then sets sides = 16 on the cylinder and"
+						+ " the cone regardless. The pyramid on the same run honours what it was"
+						+ " asked for."
+					)
+					% [shape[0], counts[0]]
+				)
+			)

--- a/tools/vibe/scenarios/brush_sides.gd.uid
+++ b/tools/vibe/scenarios/brush_sides.gd.uid
@@ -1,0 +1,1 @@
+uid://syinuu86xnqs

--- a/tools/vibe/scenarios/cost.gd
+++ b/tools/vibe/scenarios/cost.gd
@@ -21,7 +21,24 @@ const SHAPES: Array = [
 ]
 
 ## A brush costing more than this to save is worth a look. A box is ~1.2 KB.
+## Curved shapes are past it by their nature -- a sphere is thousands of genuinely
+## separate planes -- so the size is recorded for them and the face count is what
+## holds the line. See FACE_BUDGET.
 const SIZE_BUDGET_BYTES := 32768
+
+## The face counts #328 landed on, when coplanar triangles that share an edge
+## started merging into one FaceData. A shape past its number here has gone back
+## to one face per mesh triangle, which is what #322 was.
+const FACE_BUDGET := {
+	"box": 6,
+	"wedge": 5,
+	"tetrahedron": 4,
+	"cylinder": 66,
+	"cone": 129,
+	"dodecahedron": 12,
+	"sphere": 2240,
+	"torus": 2059,
+}
 
 
 func id() -> String:
@@ -59,9 +76,18 @@ func run() -> void:
 		var bytes := HFVibe.file_size(path)
 		note("%-14s %8d %10d %12d %9d" % [label, faces, build_ms, bytes, save_ms])
 		if bytes > SIZE_BUDGET_BYTES:
-			known(
-				322,
-				"one %s costs %d bytes to save" % [label, bytes],
-				"%d faces, one per mesh triangle" % faces
+			note("%s is past the %d byte budget" % [label, SIZE_BUDGET_BYTES], bytes)
+		var budget: int = int(FACE_BUDGET.get(label, 0))
+		if budget > 0 and faces > budget:
+			flag(
+				"one %s stores %d faces where #328 left it at %d" % [label, faces, budget],
+				(
+					(
+						"coplanar triangles that share an edge are meant to merge into one FaceData"
+						+ " before the list is stored. %d faces means they are not, which is #322"
+						+ " again: %d bytes to save and the same multiplier on every later operation."
+					)
+					% [faces, bytes]
+				)
 			)
 		root.free()

--- a/tools/vibe/scenarios/dock_cordon.gd
+++ b/tools/vibe/scenarios/dock_cordon.gd
@@ -1,0 +1,86 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## The cordon controls against the cordon the level actually bakes with.
+##
+## Set from Selection writes the bounds onto the level and then copies the six
+## numbers into the six spins. Those spins have a range, and writing a value
+## into a SpinBox that is outside it is not an error -- it is a different value,
+## and one that fires `value_changed` on the way past.
+
+const DockScene = preload("res://addons/hammerforge/dock.tscn")
+
+
+func id() -> String:
+	return "dock-cordon"
+
+
+func summary() -> String:
+	return "whether the cordon spins can hold the cordon the level was given"
+
+
+func run() -> void:
+	await _a_selection_outside_the_spin_range()
+
+
+func _dock(root: Node3D) -> Node:
+	var dock = DockScene.instantiate()
+	_tree.get_root().add_child(dock)
+	await frame()
+	dock.level_root = root
+	return dock
+
+
+func _a_selection_outside_the_spin_range() -> void:
+	var root: Node3D = await fresh_root("CordonLevel")
+	var dock = await _dock(root)
+	await frame()
+	note("cordon spin range", [dock.cordon_min_x.min_value, dock.cordon_min_x.max_value])
+
+	# A room out at the edge of a large map. Quake-scale maps run past +-4096 per
+	# axis, and the structure builders take a width or radius up to 4096 for one
+	# piece of geometry, so this is a level rather than a stress test.
+	var far = box(root, Vector3(256, 256, 256), Vector3(12000, 0, 0))
+	await frame()
+	dock.set_selection_nodes([far])
+	dock._on_cordon_from_selection()
+	await frame()
+
+	var bounds: AABB = root.get("cordon_aabb")
+	note("cordon the level holds after Set from Selection", bounds)
+	note(
+		"the six spins now read",
+		[
+			dock.cordon_min_x.value,
+			dock.cordon_min_y.value,
+			dock.cordon_min_z.value,
+			dock.cordon_max_x.value,
+			dock.cordon_max_y.value,
+			dock.cordon_max_z.value,
+		]
+	)
+	var brush_position: Vector3 = far.global_position
+	note("the brush the cordon was set from is at", brush_position)
+	note("does the cordon contain it", bounds.has_point(brush_position))
+	if not bounds.has_point(brush_position):
+		known(
+			467,
+			"Set Cordon from Selection leaves a cordon that excludes the selection",
+			(
+				(
+					"set_cordon_from_selection() puts the right AABB on the level, and then the"
+					+ " handler copies the six numbers into the cordon spins, which are built with"
+					+ " a -9999..9999 range. Each assignment clamps and fires value_changed, and"
+					+ " on_cordon_value_changed() reads the six clamped spins straight back onto"
+					+ " level_root.cordon_aabb. The selection sits at %s, the cordon ends up %s,"
+					+ " the cordon is now switched on, and the next bake drops the very geometry"
+					+ " the button was pressed for."
+				)
+				% [brush_position, bounds]
+			)
+		)
+
+	var enabled = root.get("cordon_enabled")
+	note("cordon enabled after the button", enabled)
+	dock.queue_free()
+	await frame()

--- a/tools/vibe/scenarios/dock_cordon.gd.uid
+++ b/tools/vibe/scenarios/dock_cordon.gd.uid
@@ -1,0 +1,1 @@
+uid://cs6mrwcuigiw1

--- a/tools/vibe/scenarios/dock_ranges.gd
+++ b/tools/vibe/scenarios/dock_ranges.gd
@@ -1,0 +1,94 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## Every dock spin that writes a level setting, turned to both ends of its own
+## range, against what the level did with the number.
+##
+## `HFDockConnections.connect_settings()` wires each control straight to
+## `level_root.set(property, value)`. The controls carry one range, declared
+## where the tab is built; the properties carry another, declared as setters on
+## `LevelRoot`. Nothing checks that the two agree, and when they do not the dock
+## goes on showing a number the level does not hold.
+
+const DockScene = preload("res://addons/hammerforge/dock.tscn")
+
+## control name on the dock -> the level property it is bound to, from
+## connect_settings()'s float_bindings and int_bindings.
+const BINDINGS := [
+	["bake_chunk_size_spin", "bake_chunk_size"],
+	["bake_lightmap_texel", "bake_lightmap_texel_size"],
+	["bake_navmesh_cell_size", "bake_navmesh_cell_size"],
+	["bake_navmesh_cell_height", "bake_navmesh_cell_height"],
+	["bake_navmesh_agent_height", "bake_navmesh_agent_height"],
+	["bake_navmesh_agent_radius", "bake_navmesh_agent_radius"],
+	["bake_connector_stair_height_spin", "bake_connector_stair_height"],
+	["bake_occluder_min_area_spin", "bake_occluder_min_area"],
+	["autosave_minutes", "hflevel_autosave_minutes"],
+	["autosave_keep", "hflevel_autosave_keep"],
+	["bake_connector_width_spin", "bake_connector_width"],
+]
+
+
+func id() -> String:
+	return "dock-ranges"
+
+
+func summary() -> String:
+	return "whether each dock spin and the level property behind it agree about the legal range"
+
+
+func run() -> void:
+	await _both_ends_of_every_spin()
+
+
+func _dock(root: Node3D) -> Node:
+	var dock = DockScene.instantiate()
+	_tree.get_root().add_child(dock)
+	await frame()
+	dock.level_root = root
+	return dock
+
+
+func _both_ends_of_every_spin() -> void:
+	var root: Node3D = await fresh_root("RangeLevel")
+	var dock = await _dock(root)
+	await frame()
+	var disagreements: Array = []
+	for binding in BINDINGS:
+		var control: SpinBox = dock.get(binding[0]) as SpinBox
+		var property: String = binding[1]
+		if control == null:
+			note("no control for %s" % property, binding[0])
+			continue
+		note("%s spin range" % property, [control.min_value, control.max_value, control.step])
+		for end in [control.min_value, control.max_value]:
+			control.value = end
+			control.value_changed.emit(control.value)
+			await frame()
+			var held = root.get(property)
+			var shown: float = float(control.value)
+			var kept: bool = is_equal_approx(float(held), shown)
+			note(
+				"%s: spin set to %s" % [property, shown],
+				"level holds %s%s" % [held, "" if kept else "   <-- different"]
+			)
+			if not kept:
+				disagreements.append(
+					"%s: the spin allows %s, the level holds %s" % [property, shown, held]
+				)
+	note("bindings where the two ends disagree", disagreements.size())
+	if not disagreements.is_empty():
+		known(
+			481,
+			"dock spins offer values the level refuses, and go on showing them",
+			(
+				(
+					"each of these is a control whose declared range is wider than the setter"
+					+ " behind it, so turning the spin to its own end leaves the dock reading one"
+					+ " number and the bake using another, with nothing said either way: %s"
+				)
+				% str(disagreements)
+			)
+		)
+	dock.queue_free()
+	await frame()

--- a/tools/vibe/scenarios/dock_ranges.gd.uid
+++ b/tools/vibe/scenarios/dock_ranges.gd.uid
@@ -1,0 +1,1 @@
+uid://28jscdsmgoe

--- a/tools/vibe/scenarios/dock_settings.gd
+++ b/tools/vibe/scenarios/dock_settings.gd
@@ -1,0 +1,144 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## Export Settings and Import Settings, against each other and against the level.
+##
+## The Test tab writes a `.hfsettings` file of the dock's own numbers and reads
+## one back. It is the file a mapper mails to somebody else, or keeps between
+## projects, so it is also the file that arrives hand-edited, truncated, or
+## written by an older build. Nothing on the way in checks a single value --
+## `_apply_editor_settings()` takes the dictionary as it comes -- which is the
+## exposure `hf_user_prefs.gd` was given a validator for in #423.
+##
+## Two questions: does a value survive the round trip onto the level, and what
+## does a value the dock would never have written do when it arrives.
+
+const DockScene = preload("res://addons/hammerforge/dock.tscn")
+
+
+func id() -> String:
+	return "dock-settings"
+
+
+func summary() -> String:
+	return "what an exported settings file carries back onto the level, and what a hand-edited one does"
+
+
+func run() -> void:
+	await _the_round_trip()
+	await _values_the_dock_would_never_write()
+
+
+func _dock(root: Node3D) -> Node:
+	var dock = DockScene.instantiate()
+	_tree.get_root().add_child(dock)
+	await frame()
+	dock.level_root = root
+	return dock
+
+
+func _the_round_trip() -> void:
+	var root: Node3D = await fresh_root("SettingsLevel")
+	var dock = await _dock(root)
+	await frame()
+
+	# A mapper sets up their bake the way they like it and exports.
+	dock.bake_navmesh.button_pressed = true
+	dock.bake_lightmap_texel.value = 0.25
+	if dock.bake_connector_mode_opt:
+		dock.bake_connector_mode_opt.select(2)  # Auto
+		dock.bake_connector_mode_opt.item_selected.emit(2)
+	await frame()
+	var exported: Dictionary = dock._collect_editor_settings()
+	note("exported keys", exported.keys())
+	note("exported connector mode", exported.get("bake", {}).get("connector_mode", null))
+	note("root bake_connector_mode before import", root.get("bake_connector_mode"))
+
+	# The same file opened on a second level, which is what Import Settings is
+	# for. Everything starts at the defaults.
+	var other: Node3D = await fresh_root("SettingsLevelB")
+	var other_dock = await _dock(other)
+	await frame()
+	note("second level bake_connector_mode at rest", other.get("bake_connector_mode"))
+	note("second level bake_navmesh at rest", other.get("bake_navmesh"))
+	other_dock._apply_editor_settings(exported)
+	await frame()
+	note("after import: dropdown shows", other_dock.bake_connector_mode_opt.get_selected_id())
+	note("after import: level holds", other.get("bake_connector_mode"))
+	note("after import: level bake_navmesh", other.get("bake_navmesh"))
+	note("after import: level lightmap texel", other.get("bake_lightmap_texel_size"))
+	if (
+		int(other_dock.bake_connector_mode_opt.get_selected_id())
+		!= int(other.get("bake_connector_mode"))
+	):
+		known(
+			477,
+			"Import Settings leaves the connector mode on the dropdown only",
+			(
+				"_apply_editor_settings() calls OptionButton.select(), which by design does not"
+				+ " emit item_selected, and the level is only written from that signal"
+				+ " (HFDockConnections.connect_settings). Every check box and spin in the same"
+				+ " block does reach the level, because setting those does emit. So the bake"
+				+ " runs with the old connector mode while the dock shows the imported one, and"
+				+ " nothing says which is in force."
+			)
+		)
+
+	other_dock.queue_free()
+	dock.queue_free()
+	await frame()
+
+
+func _values_the_dock_would_never_write() -> void:
+	var root: Node3D = await fresh_root("MalformedSettingsLevel")
+	var dock = await _dock(root)
+	await frame()
+	note("grid snap spin range", [dock.grid_snap.min_value, dock.grid_snap.max_value])
+	note("level grid_snap at rest", root.get("grid_snap"))
+
+	# A file from a project that works in bigger units, or one typo away from it.
+	dock._apply_editor_settings({"grid_snap": 4096.0})
+	await frame()
+	note("after grid_snap 4096: spin shows", dock.grid_snap.value)
+	note("after grid_snap 4096: level holds", root.get("grid_snap"))
+	if not is_equal_approx(float(dock.grid_snap.value), float(root.get("grid_snap"))):
+		known(
+			478,
+			"Import Settings puts a grid snap on the level that the dock refuses to show",
+			(
+				(
+					"_apply_grid_snap() assigns the value to the SpinBox -- which clamps it to the"
+					+ " 0..128 the scene declares -- and then writes the *argument* to"
+					+ " level_root.grid_snap, unclamped. The dock reads %s and the level snaps to"
+					+ " %s, and _save_user_pref() writes the out-of-range number into the prefs"
+					+ " file so it comes back next session."
+				)
+				% [dock.grid_snap.value, root.get("grid_snap")]
+			)
+		)
+
+	# What the level does with the snap it was given, at the point the editor
+	# snaps everything through.
+	var snapped_point: Vector3 = root._snap_point(Vector3(37.0, 5.0, -12.0))
+	note("a position snapped with the imported grid", snapped_point)
+
+	# Text where a number belongs, which is what a hand edit or a JSON writer
+	# that quotes everything produces.
+	dock._apply_editor_settings({"grid_snap": "sixteen"})
+	await frame()
+	note('after grid_snap "sixteen": level holds', root.get("grid_snap"))
+	if is_zero_approx(float(root.get("grid_snap"))):
+		known(
+			478,
+			"A non-numeric grid snap silently becomes zero",
+			(
+				'float("sixteen") is 0.0 in GDScript, and nothing between the file and the'
+				+ " level checks. The dock shows 0, the level snaps to 0, and the mapper is"
+				+ " told nothing about the file being unreadable. hf_user_prefs.gd validates"
+				+ " every value it loads for exactly this reason (#423); the settings file has"
+				+ " no such pass."
+			)
+		)
+
+	dock.queue_free()
+	await frame()

--- a/tools/vibe/scenarios/dock_settings.gd.uid
+++ b/tools/vibe/scenarios/dock_settings.gd.uid
@@ -1,0 +1,1 @@
+uid://b4a7mrneq2p46

--- a/tools/vibe/scenarios/dock_undo.gd
+++ b/tools/vibe/scenarios/dock_undo.gd
@@ -1,0 +1,316 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## Which dock buttons reach the undo stack, and which change the level behind it.
+##
+## The dock has one wrapper for a command that changes the level:
+## `_commit_state_action()`, which snapshots the level, runs the method and
+## registers the pair with `EditorUndoRedoManager` so Ctrl+Z puts it back. Forty
+## of the dock's buttons use it. This asks which ones do not, and what a mapper
+## loses when they press one.
+##
+## `capture_state()` carries visgroups, groups, entities and paint layers, so
+## every action below *could* be undone through the same wrapper its neighbours
+## use. Nothing about the data is in the way.
+
+const DockScene = preload("res://addons/hammerforge/dock.tscn")
+const DraftEntity = preload("res://addons/hammerforge/draft_entity.gd")
+
+## The files a dock button's body lives in, for the "which wrapper does it use"
+## reading. A button that changes the level and never names one of these is
+## changing it outside the undo system.
+const HANDLER_SOURCES := [
+	"res://addons/hammerforge/dock.gd",
+	"res://addons/hammerforge/dock_visgroup_handler.gd",
+	"res://addons/hammerforge/dock_entity_handler.gd",
+	"res://addons/hammerforge/dock_paint_handler.gd",
+]
+
+
+func id() -> String:
+	return "dock-undo"
+
+
+func summary() -> String:
+	return "which dock commands change the level without registering an undo step"
+
+
+func run() -> void:
+	await _visgroups_and_groups()
+	await _entities_and_their_wiring()
+	await _paint_layers()
+
+
+## The dock, wired to a root, the way the plugin hands it one.
+func _dock(root: Node3D) -> Node:
+	var dock = DockScene.instantiate()
+	_tree.get_root().add_child(dock)
+	await frame()
+	dock.level_root = root
+	return dock
+
+
+## Every `func <name>` body in the handler sources, so a claim about which
+## wrapper a button uses is read off the code rather than guessed.
+func _body(function_name: String) -> String:
+	for path in HANDLER_SOURCES:
+		var source := FileAccess.get_file_as_string(path)
+		var start := source.find("\nfunc %s(" % function_name)
+		if start < 0:
+			start = source.find("\nstatic func %s(" % function_name)
+		if start < 0:
+			continue
+		var rest := source.substr(start + 1)
+		var end := rest.find("\n\n\n")
+		return rest if end < 0 else rest.substr(0, end)
+	return ""
+
+
+## Whether a button's body registers an undo step at all.
+func _undo_wrapped(function_name: String) -> bool:
+	var body := _body(function_name)
+	return (
+		body.contains("_commit_state_action")
+		or body.contains("_commit_full_state_action")
+		or body.contains("_commit_done_state_action")
+		or body.contains("HFUndoHelper")
+	)
+
+
+func _visgroup_names(root: Node3D) -> Array:
+	return Array(root.visgroup_system.get_visgroup_names())
+
+
+func _visgroups_and_groups() -> void:
+	var root: Node3D = await fresh_root("VisgroupLevel")
+	var dock = await _dock(root)
+	var brush_a := box(root, Vector3(64, 64, 64), Vector3(0, 0, 0))
+	var brush_b := box(root, Vector3(64, 64, 64), Vector3(128, 0, 0))
+	await frame()
+
+	dock.visgroup_name_input.text = "Lights"
+	dock._on_visgroup_add()
+	await frame()
+	note("visgroups after New", _visgroup_names(root))
+	note("New Visgroup registers an undo step", _undo_wrapped("on_visgroup_add"))
+
+	dock.set_selection_nodes([brush_a, brush_b])
+	dock.visgroup_list.select(0)
+	dock._on_visgroup_add_selection()
+	await frame()
+	var members_a := Array(brush_a.get_meta("visgroups", PackedStringArray()))
+	note("brush A visgroups after Add Sel", members_a)
+
+	# The same button a second time, exactly as a mapper would press it after
+	# selecting more geometry. Nothing about the selection changed.
+	var selected_after: PackedInt32Array = dock.visgroup_list.get_selected_items()
+	note("visgroup list selection after Add Sel", selected_after)
+	if selected_after.is_empty():
+		known(
+			476,
+			"Add Sel clears the visgroup it just added to",
+			(
+				"HFDockVisgroupHandler.on_visgroup_add_selection() ends in refresh_visgroup_ui(),"
+				+ " which calls ItemList.clear() and rebuilds the rows. The highlighted row is"
+				+ ' gone, so get_selected_visgroup_name() answers "" and the next Add Sel,'
+				+ " Rem Sel or Delete is a silent no-op until the mapper clicks the visgroup"
+				+ " again. on_visgroup_item_clicked() re-selects its row after the same refresh,"
+				+ " so the loss was known about on the neighbouring path."
+			)
+		)
+
+	var before_delete: Dictionary = root.capture_state()
+	dock.visgroup_list.select(0)
+	dock._on_visgroup_delete()
+	await frame()
+	var after_delete: Dictionary = root.capture_state()
+	note("visgroups after Delete", _visgroup_names(root))
+	note(
+		"brush A visgroups after Delete", Array(brush_a.get_meta("visgroups", PackedStringArray()))
+	)
+	note("Delete Visgroup registers an undo step", _undo_wrapped("on_visgroup_delete"))
+	var state_moved: bool = (
+		HFVibe.canonical(before_delete.get("visgroups", []))
+		!= HFVibe.canonical(after_delete.get("visgroups", []))
+	)
+	if state_moved and not _undo_wrapped("on_visgroup_delete"):
+		known(
+			470,
+			"Delete Visgroup is not undoable",
+			(
+				"on_visgroup_delete() calls level_root.remove_visgroup() directly. That erases"
+				+ " the visgroup record and strips the membership meta off every node that"
+				+ ' carried it, and capture_state() holds both under "visgroups" -- so the'
+				+ " wrapper every neighbouring button uses would have restored it. Ctrl+Z after"
+				+ " it undoes whatever the mapper did before instead."
+			)
+		)
+
+	dock.set_selection_nodes([brush_a, brush_b])
+	var before_group: Dictionary = root.capture_state()
+	dock._on_group_selection()
+	await frame()
+	var after_group: Dictionary = root.capture_state()
+	note("groups after Group Sel", after_group.get("groups", []))
+	note("Group Selection registers an undo step", _undo_wrapped("on_group_selection"))
+	if (
+		(
+			HFVibe.canonical(before_group.get("groups", []))
+			!= HFVibe.canonical(after_group.get("groups", []))
+		)
+		and not _undo_wrapped("on_group_selection")
+	):
+		known(
+			471,
+			"Group Selection and Ungroup are not undoable",
+			(
+				"Both call record_history(), which only appends a row to the dock's own history"
+				+ " list -- it never touches undo_redo. The group registry and the group_id meta"
+				+ " on every member move with no undo step behind them."
+			)
+		)
+
+	dock.queue_free()
+	await frame()
+
+
+func _entities_and_their_wiring() -> void:
+	var root: Node3D = await fresh_root("EntityLevel")
+	var dock = await _dock(root)
+	await frame()
+
+	var before_create: Dictionary = root.capture_state()
+	dock._on_create_entity()
+	await frame()
+	var after_create: Dictionary = root.capture_state()
+	var created: int = (
+		(after_create.get("entities", []) as Array).size()
+		- (before_create.get("entities", []) as Array).size()
+	)
+	note("entities added by Create Entity", created)
+	note("Create Entity registers an undo step", _undo_wrapped("on_create_entity"))
+	if created > 0 and not _undo_wrapped("on_create_entity"):
+		known(
+			472,
+			"Create Entity is not undoable",
+			(
+				"on_create_entity() calls level_root.add_entity() straight. Placing a brush"
+				+ ' goes through HFUndoHelper (plugin._commit_brush_placement, "Place Brush");'
+				+ " creating an entity goes through nothing, so the new node cannot be taken"
+				+ " back with Ctrl+Z and the next undo removes something else."
+			)
+		)
+
+	var entity: Node3D = null
+	for child in root.entities_node.get_children():
+		if child is DraftEntity:
+			entity = child
+	if entity == null:
+		note("no entity to wire", "skipping the I/O half")
+		dock.queue_free()
+		await frame()
+		return
+
+	entity.entity_data["targetname"] = "door_1"
+	dock.set_selection_nodes([entity])
+	dock.io_output_name.text = "OnPressed"
+	dock.io_target_name.text = "door_1"
+	dock.io_input_name.text = "Open"
+	var before_wire: Dictionary = root.capture_state()
+	dock._on_io_add()
+	await frame()
+	var after_wire: Dictionary = root.capture_state()
+	note("outputs on the entity", root.get_entity_outputs(entity).size())
+	note("Add Output registers an undo step", _undo_wrapped("on_io_add"))
+	if (
+		(
+			HFVibe.canonical(before_wire.get("entities", []))
+			!= HFVibe.canonical(after_wire.get("entities", []))
+		)
+		and not _undo_wrapped("on_io_add")
+	):
+		known(
+			473,
+			"Entity I/O add and remove are not undoable",
+			(
+				"on_io_add() and on_io_remove() call add_entity_output()/remove_entity_output()"
+				+ " directly. The connections are in capture_state() under the entity, so the"
+				+ " wrapper would carry them; Remove in particular destroys a connection with"
+				+ " nothing to get it back."
+			)
+		)
+
+	dock.queue_free()
+	await frame()
+
+
+func _paint_layers() -> void:
+	var root: Node3D = await fresh_root("PaintLevel")
+	var dock = await _dock(root)
+	await frame()
+	if not root.paint_layers:
+		note("no paint layer manager", "skipping")
+		dock.queue_free()
+		await frame()
+		return
+
+	dock._on_paint_layer_add()
+	await frame()
+	note("paint layers after Add", root.paint_layers.layers.size())
+	var layer = root.paint_layers.get_active_layer()
+	if layer:
+		layer.set_cell(Vector2i(0, 0), true)
+		layer.set_cell(Vector2i(1, 0), true)
+	var before_remove: Dictionary = root.capture_state()
+	var painted_before: int = (
+		(before_remove.get("paint_layers", []) as Array).size()
+		if before_remove.has("paint_layers")
+		else 0
+	)
+	dock._on_paint_layer_remove()
+	await frame()
+	var after_remove: Dictionary = root.capture_state()
+	var painted_after: int = (
+		(after_remove.get("paint_layers", []) as Array).size()
+		if after_remove.has("paint_layers")
+		else 0
+	)
+	note("captured paint layers, before and after Remove", [painted_before, painted_after])
+	note("Remove Layer registers an undo step", _undo_wrapped("on_paint_layer_remove"))
+	if painted_after < painted_before and not _undo_wrapped("on_paint_layer_remove"):
+		known(
+			474,
+			"Remove Paint Layer is not undoable",
+			(
+				"on_paint_layer_remove() calls remove_active_paint_layer() straight, and the"
+				+ " manager's remove_layer() frees the layer node and everything painted into"
+				+ " it. add_surface_paint_layer() on the face side of the same dock goes through"
+				+ " _commit_state_action(); this one does not, so a misclick on a terrain layer"
+				+ " is permanent."
+			)
+		)
+
+	var before_noise: Dictionary = root.capture_state()
+	dock._on_heightmap_generate()
+	await frame()
+	var after_noise: Dictionary = root.capture_state()
+	note("Generate Noise registers an undo step", _undo_wrapped("on_heightmap_generate"))
+	if (
+		(
+			HFVibe.canonical(before_noise.get("paint_layers", []))
+			!= HFVibe.canonical(after_noise.get("paint_layers", []))
+		)
+		and not _undo_wrapped("on_heightmap_generate")
+	):
+		known(
+			475,
+			"Generate Noise overwrites the heightmap with no undo step",
+			(
+				"on_heightmap_generate() calls generate_heightmap_noise() directly. It replaces"
+				+ " the active layer's heightmap wholesale -- sculpted terrain included -- and"
+				+ " nothing registers the state it replaced."
+			)
+		)
+
+	dock.queue_free()
+	await frame()

--- a/tools/vibe/scenarios/dock_undo.gd.uid
+++ b/tools/vibe/scenarios/dock_undo.gd.uid
@@ -1,0 +1,1 @@
+uid://cb6u26xqhnln3

--- a/tools/vibe/scenarios/entity_props.gd
+++ b/tools/vibe/scenarios/entity_props.gd
@@ -1,0 +1,175 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## What an entity property is after it has been through the file.
+##
+## `entities.json` gives a property a type, the Objects tab builds a control for
+## that type, and the control writes the value straight into `entity_data`. A
+## colour picker writes a `Color`, a vector row writes a `Vector3`. The level is
+## then saved as JSON, and JSON has neither.
+##
+## The property panel reads the values back the next time the entity is
+## selected, and the `.map` exporter writes them into the file a compiler reads,
+## so both ends of this matter.
+
+const DockScene = preload("res://addons/hammerforge/dock.tscn")
+const DraftEntity = preload("res://addons/hammerforge/draft_entity.gd")
+const HFEntityPropUtils = preload("res://addons/hammerforge/ui/hf_entity_prop_utils.gd")
+
+
+func id() -> String:
+	return "entity-props"
+
+
+func summary() -> String:
+	return "what a colour or vector entity property is after a save and a load"
+
+
+func run() -> void:
+	await _through_the_hflevel()
+	await _into_the_map_file()
+
+
+func _entity(root: Node3D, type_id: String) -> Node3D:
+	var entity = DraftEntity.new()
+	entity.name = "Probe_%s" % type_id
+	entity.entity_type = type_id
+	entity.entity_class = type_id
+	entity.set_meta("is_entity", true)
+	root.add_entity(entity)
+	return entity
+
+
+func _through_the_hflevel() -> void:
+	var root: Node3D = await fresh_root("EntityPropLevel")
+	var light := _entity(root, "light_point")
+	await frame()
+
+	# Exactly what the colour picker and the vector row in the Objects tab write.
+	HFEntityPropUtils.set_entity_property(light, "color", Color(0.2, 0.4, 0.8, 1.0))
+	HFEntityPropUtils.set_entity_vec3_axis(light, "offset", 0, 16.0)
+	HFEntityPropUtils.set_entity_vec3_axis(light, "offset", 1, 32.0)
+	HFEntityPropUtils.set_entity_property(light, "energy", 2.5)
+	HFEntityPropUtils.set_entity_property(light, "targetname", "lamp_1")
+	await frame()
+	note("colour as the picker left it", light.entity_data.get("color", null))
+	note("vector as the row left it", light.entity_data.get("offset", null))
+
+	var path := "user://vibe_entity_props.hflevel"
+	root.save_hflevel(path, true)
+	var settled: bool = await HFVibe.settle_save(_tree, root)
+	if not settled:
+		flag("the save never finished", path)
+		return
+	var other: Node3D = await fresh_root("EntityPropLevelB")
+	other.load_hflevel(path)
+	await frame()
+	var loaded: Node3D = null
+	for child in other.entities_node.get_children():
+		if child is DraftEntity:
+			loaded = child
+	if loaded == null:
+		flag("the entity did not survive the round trip at all", path)
+		return
+
+	var colour_back = loaded.entity_data.get("color", null)
+	var vector_back = loaded.entity_data.get("offset", null)
+	var energy_back = loaded.entity_data.get("energy", null)
+	var name_back = loaded.entity_data.get("targetname", null)
+	note("colour after load", "%s  (%s)" % [colour_back, type_string(typeof(colour_back))])
+	note("vector after load", "%s  (%s)" % [vector_back, type_string(typeof(vector_back))])
+	note("float after load", "%s  (%s)" % [energy_back, type_string(typeof(energy_back))])
+	note("string after load", "%s  (%s)" % [name_back, type_string(typeof(name_back))])
+
+	if typeof(colour_back) != TYPE_COLOR or typeof(vector_back) != TYPE_VECTOR3:
+		flag(
+			"colour and vector entity properties do not survive a .hflevel save",
+			(
+				(
+					"the Objects tab writes a Color from the colour picker and a Vector3 from the"
+					+ " vector row into entity_data, capture_entity_info() duplicates the dictionary"
+					+ " as it is, and hflevel_io writes it with JSON.stringify, which has no type"
+					+ " for either. They come back as %s and %s. The property panel then feeds that"
+					+ " to ColorPickerButton.color / the vector spins, and the .map exporter writes"
+					+ " the stringified form into the file a compiler reads."
+				)
+				% [type_string(typeof(colour_back)), type_string(typeof(vector_back))]
+			)
+		)
+
+	# What the panel does with whatever came back, which is the path a mapper
+	# actually walks: select the entity again and look at the controls.
+	var dock = DockScene.instantiate()
+	_tree.get_root().add_child(dock)
+	await frame()
+	dock.level_root = other
+	dock.set_selection_nodes([loaded])
+	dock._rebuild_entity_props(loaded)
+	await frame()
+	var picker: ColorPickerButton = null
+	for control in dock._entity_props_controls:
+		for child in control.get_children():
+			if child is ColorPickerButton:
+				picker = child
+	if picker != null:
+		note("what the colour control shows after the round trip", picker.color)
+		if picker.color != Color(0.2, 0.4, 0.8, 1.0):
+			flag(
+				"the colour control comes back a different colour",
+				(
+					(
+						"rebuild_entity_props() branches on `current_val is Color` and then"
+						+ " `is String`, so a value that is neither lands on Color.WHITE, and a"
+						+ " string Godot cannot read as a colour is black. The picker shows %s"
+						+ " where the mapper left %s."
+					)
+					% [picker.color, Color(0.2, 0.4, 0.8, 1.0)]
+				)
+			)
+	dock.queue_free()
+	await frame()
+
+
+func _into_the_map_file() -> void:
+	var root: Node3D = await fresh_root("EntityMapLevel")
+	var light := _entity(root, "light_point")
+	box(root, Vector3(64, 64, 64))
+	await frame()
+	HFEntityPropUtils.set_entity_property(light, "color", Color(0.2, 0.4, 0.8, 1.0))
+	HFEntityPropUtils.set_entity_property(light, "targetname", "lamp_1")
+	await frame()
+	var path := "user://vibe_entity_props.map"
+	var err: int = int(root.export_map(path, "valve220"))
+	note("export_map returned", err)
+	var text := FileAccess.get_file_as_string(path)
+	var colour_line := ""
+	for line in text.split("\n"):
+		if line.contains("color") or line.contains("targetname"):
+			note("map file line", line.strip_edges())
+		if line.contains('"color"'):
+			colour_line = line.strip_edges()
+	if colour_line.contains("(") or colour_line.contains(","):
+		known(
+			479,
+			"a colour entity property is written into the .map file in Godot's own notation",
+			(
+				(
+					"HFMapAdapter.format_entity_properties() writes str(value) for every property,"
+					+ " so the Color the Objects tab stored comes out as %s. A .map file exists to"
+					+ " be read by something else, and no Quake-family compiler or editor parses"
+					+ " that: the value they expect is numbers. The same text comes back through"
+					+ " import_map() as a plain String, so the type is gone on a round trip through"
+					+ " HammerForge's own importer as well."
+				)
+				% colour_line
+			)
+		)
+
+	# What HammerForge's own importer makes of what it just wrote.
+	var back: Node3D = await fresh_root("EntityMapLevelB")
+	back.import_map(path)
+	await frame()
+	for child in back.entities_node.get_children():
+		if child is DraftEntity and child.entity_data.has("color"):
+			var value = child.entity_data["color"]
+			note("colour after a .map round trip", "%s  (%s)" % [value, type_string(typeof(value))])

--- a/tools/vibe/scenarios/entity_props.gd.uid
+++ b/tools/vibe/scenarios/entity_props.gd.uid
@@ -1,0 +1,1 @@
+uid://5t7khwplqxh1

--- a/tools/vibe/scenarios/painted_faces.gd
+++ b/tools/vibe/scenarios/painted_faces.gd
@@ -176,6 +176,10 @@ func _painting_over_a_shader_material() -> void:
 		face.material_idx = idx
 	_paint_face(b, 0)
 	await frame()
+	# Without this the bake takes the CSG path and every surface carries one
+	# default material, face materials or not -- which says nothing about what
+	# painting did to the shader. That default is its own defect (#466).
+	root.set("bake_use_face_materials", true)
 	root.tag_full_reconcile()
 	await root.bake_dirty()
 	await frame()
@@ -191,14 +195,15 @@ func _painting_over_a_shader_material() -> void:
 	note("baked surfaces keeping the shader material", shader_surfaces)
 	note("baked surfaces replaced by a plain StandardMaterial3D", replaced)
 	if replaced > 0:
-		known(
-			413,
+		flag(
 			"painting on a face with a ShaderMaterial replaces it with a plain material",
 			(
-				"the painted branch builds a StandardMaterial3D and only copies from the base"
-				+ " when the base `is StandardMaterial3D`, so a shader material is dropped"
-				+ " outright: %d surface(s) came back plain. Nothing warns, and the face" % replaced
-				+ " renders unlit-flat next to its neighbours."
+				(
+					"#425 settled that a ShaderMaterial is refused rather than composited: the face"
+					+ " keeps its shader, the paint is not drawn, and a warning says so."
+					+ " %d baked surface(s) came back as a plain StandardMaterial3D instead."
+				)
+				% replaced
 			)
 		)
 

--- a/tools/vibe/scenarios/playtest_spawn.gd
+++ b/tools/vibe/scenarios/playtest_spawn.gd
@@ -1,0 +1,163 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## Where the playtest player is put, against where the spawn validator says a
+## player stands.
+##
+## Two pieces of code hold a model of the same player. `HFSpawnSystem` places a
+## 1.6 by 0.35 capsule with the spawn point at its **feet**: `validate_spawn()`
+## builds the capsule at `pos + height/2` and wants the spawn at
+## `floor + FEET_OFFSET + height_offset`, which is also where
+## `create_default_spawn()` puts it and where `auto_fix_spawn()` moves it back
+## to. `LevelRoot._start_playtest()` then adds `height_offset` a second time and
+## assigns the result to the `CharacterBody3D`'s `global_position`, which is the
+## **centre** of that capsule.
+
+const PLAYER_HEIGHT := 1.6  # HFSpawnSystem.PLAYER_HEIGHT, and playtest_fps.gd's capsule
+const FEET_OFFSET := 0.1
+
+
+func id() -> String:
+	return "playtest-spawn"
+
+
+func summary() -> String:
+	return "where the playtest player's feet end up against the spawn the validator approved"
+
+
+func run() -> void:
+	await _a_spawn_the_validator_is_happy_with()
+	await _a_spawn_asked_to_sit_on_the_floor()
+	await _what_crouch_does()
+
+
+func physics_frame() -> void:
+	await _tree.physics_frame
+
+
+## A floor with its top at y = 0, baked so the validator's rays have something
+## to hit, and a spawn standing exactly where the spawn system puts one.
+func _level_with_spawn(height_offset: float) -> Dictionary:
+	var root: Node3D = await fresh_root()
+	root.create_brush_from_info(
+		{"shape": 0, "size": Vector3(512, 16, 512), "center": Vector3(0, -8, 0)}
+	)
+	await frame()
+	var spawn: Node3D = root.spawn_system.create_default_spawn()
+	if spawn == null:
+		flag("create_default_spawn() returned nothing")
+		return {}
+	spawn.entity_data["height_offset"] = height_offset
+	spawn.global_position = Vector3(0, FEET_OFFSET + height_offset, 0)
+	await frame()
+	var baked: bool = await root.bake(true, false, 0)
+	await frame()
+	await physics_frame()
+	await physics_frame()
+	note("bake succeeded", baked)
+	return {"root": root, "spawn": spawn}
+
+
+func _a_spawn_the_validator_is_happy_with() -> void:
+	var level: Dictionary = await _level_with_spawn(1.0)
+	if level.is_empty():
+		return
+	var root: Node3D = level["root"]
+	var spawn: Node3D = level["spawn"]
+	var validation: Dictionary = root.spawn_system.validate_spawn(spawn, 0)
+	note("spawn position", spawn.global_position)
+	note("validator severity", validation.get("severity", 0))
+	note("validator issues", validation.get("issues", PackedStringArray()))
+
+	var pose: Dictionary = root._resolve_playtest_spawn()
+	var centre: Vector3 = pose["position"]
+	var feet: float = float(centre.y) - PLAYER_HEIGHT * 0.5
+	note("where _start_playtest() puts the body (capsule centre)", centre)
+	note("so the player's feet start at", feet)
+	note("the spawn point, which the validator reads as the feet", spawn.global_position.y)
+	note("the floor is at", 0.0)
+
+	if (
+		int(validation.get("severity", 0)) == 0
+		and absf(feet - float(spawn.global_position.y)) > 0.05
+	):
+		known(
+			468,
+			"the playtest player does not start on the spawn the validator approved",
+			(
+				(
+					"the spawn passes validation at y %.2f, and HFSpawnSystem reads that point as"
+					+ " the player's feet: validate_spawn() puts the test capsule at pos +"
+					+ " height/2, and both create_default_spawn() and auto_fix_spawn() place the"
+					+ " spawn at floor + %.2f + height_offset. _resolve_playtest_spawn() then adds"
+					+ " height_offset again (%.2f -> %.2f) and _start_playtest() assigns that to"
+					+ " the body's global_position, which is the capsule centre. Feet land at %.2f,"
+					+ " %.2f above the point the mapper placed, so every playtest opens with the"
+					+ " player dropping."
+				)
+				% [
+					spawn.global_position.y,
+					FEET_OFFSET,
+					spawn.global_position.y,
+					centre.y,
+					feet,
+					feet - float(spawn.global_position.y),
+				]
+			)
+		)
+
+
+## The offset a mapper sets when they want the marker on the floor rather than
+## floating above it. The validator still approves the placement.
+func _a_spawn_asked_to_sit_on_the_floor() -> void:
+	var level: Dictionary = await _level_with_spawn(0.0)
+	if level.is_empty():
+		return
+	var root: Node3D = level["root"]
+	var spawn: Node3D = level["spawn"]
+	var validation: Dictionary = root.spawn_system.validate_spawn(spawn, 0)
+	note("spawn position with height_offset 0", spawn.global_position)
+	note("validator severity", validation.get("severity", 0))
+	note("validator issues", validation.get("issues", PackedStringArray()))
+	var pose: Dictionary = root._resolve_playtest_spawn()
+	var feet: float = float(pose["position"].y) - PLAYER_HEIGHT * 0.5
+	note("player feet", feet)
+	if feet < 0.0:
+		known(
+			468,
+			"a spawn with height_offset 0 starts the player inside the floor",
+			(
+				(
+					"the marker sits at the height the spawn system itself would choose for that"
+					+ " offset, and the playtest centres the 1.6 capsule on it: the feet are at"
+					+ " %.2f against a floor at 0.00, so the body starts %.2f units inside the"
+					+ " geometry it was meant to stand on. Whether it is pushed out, falls through"
+					+ " or catches is left to move_and_slide()."
+				)
+				% [feet, -feet]
+			)
+		)
+
+
+## Crouch is on the playtest HUD. What it does to the body.
+func _what_crouch_does() -> void:
+	var source := FileAccess.get_file_as_string("res://addons/hammerforge/playtest_fps.gd")
+	var mentions := source.count("is_crouching")
+	note("times playtest_fps.gd names is_crouching", mentions)
+	note("the pause overlay advertises crouch", source.contains("Ctrl crouch"))
+	note("the collider is built once in", "_ensure_collider(), from capsule_height")
+	if mentions <= 2:
+		known(
+			469,
+			"Crouch only slows the player down; the capsule never shrinks",
+			(
+				(
+					"_physics_process() sets is_crouching and picks crouch_speed, and the name is"
+					+ " never read again -- _ensure_collider() builds one %s capsule at _ready()"
+					+ ' and nothing touches its shape afterwards. The pause overlay lists "Ctrl'
+					+ ' crouch", so a mapper testing a crawl space finds the player will not fit'
+					+ " and cannot tell whether the gap is wrong or the crouch is."
+				)
+				% "1.6"
+			)
+		)

--- a/tools/vibe/scenarios/playtest_spawn.gd.uid
+++ b/tools/vibe/scenarios/playtest_spawn.gd.uid
@@ -1,0 +1,1 @@
+uid://dukrygfd4s0fu

--- a/tools/vibe/scenarios/prefs.gd
+++ b/tools/vibe/scenarios/prefs.gd
@@ -95,16 +95,18 @@ func _prefs_that_will_not_parse() -> void:
 	prefs.persistence_enabled = false
 	note("grid_snap after loading a truncated file", prefs.get_pref("grid_snap"))
 	note("recent files after loading a truncated file", prefs.get_recent_files())
-	if float(prefs.get_pref("grid_snap")) == 16.0:
-		known(
-			409,
-			"a prefs file that does not parse is replaced by the defaults with no warning",
+	# #423 kept the defaults for an unreadable file -- which is right -- and added
+	# the two things that were missing: the damaged file is set aside rather than
+	# overwritten, and the loader says why. Both are what this checks now.
+	var kept := UserPrefs.PREFS_PATH + ".unreadable"
+	note("the unreadable file was kept as", kept if FileAccess.file_exists(kept) else "nothing")
+	if not FileAccess.file_exists(kept):
+		flag(
+			"a prefs file that will not parse is discarded rather than set aside",
 			(
-				"load_prefs() falls through to _defaults() when JSON.parse_string() fails --"
-				+ " no push_warning, no backup of the unreadable file, and the next save()"
-				+ " overwrites it. Recent files, collapsed sections, dismissed hints and the"
-				+ " grid size are all gone, and the user is told nothing. save() is also not"
-				+ " atomic, which is how the file gets into this state."
+				"load_prefs() falls back to the defaults, which is right, but the file it could"
+				+ " not read is the only copy of the user's recent files, collapsed sections and"
+				+ " dismissed hints. #423 kept it as <prefs>.unreadable; nothing is there now."
 			)
 		)
 	_restore_prefs()
@@ -122,16 +124,24 @@ func _a_rebind_onto_a_key_already_in_use() -> void:
 	km.set_binding("hollow", KEY_G, true)
 	var both := km.matches("group", event) and km.matches("hollow", event)
 	note("after binding 'hollow' to Ctrl+G, both match", both)
-	if both:
-		known(
-			410,
-			"a rebind onto a combination another action already uses is accepted silently",
+	# Two actions sharing a chord is still what the keymap stores -- #428 made it
+	# reportable rather than refused, so the question is whether the report names
+	# the pair. The dialog, the loader and set_binding() all read this.
+	var reported: Array = []
+	if km.has_method("conflicts_for"):
+		reported = Array(km.conflicts_for("hollow"))
+	note("conflicts_for('hollow') after the rebind", reported)
+	if both and not reported.has("group"):
+		flag(
+			"a rebind onto a chord another action already uses is not reported",
 			(
-				"set_binding() writes the binding with no check against the other actions, and"
-				+ " matches() then answers true for both. plugin_input_router tests the actions"
-				+ " one at a time and returns STOP on the first hit, so the one checked earlier"
-				+ " wins and the other becomes unreachable -- decided by the order of the ifs in"
-				+ " the router, with nothing in the UI saying the key was already taken."
+				(
+					"set_binding() wrote the binding and matches() answers true for both, which is"
+					+ " what #428 settled on -- but conflicts_for() is the report that makes it"
+					+ " visible in the shortcut dialog, and it does not name the action that was"
+					+ " already there: %s"
+				)
+				% str(reported)
 			)
 		)
 

--- a/tools/vibe/scenarios/settings.gd
+++ b/tools/vibe/scenarios/settings.gd
@@ -73,12 +73,19 @@ func _assigning_out_of_range_values() -> void:
 	note("accepted out of %d" % OUT_OF_RANGE.size(), accepted.size())
 	if not accepted.is_empty():
 		known(
-			373,
+			480,
 			(
 				"LevelRoot takes %d of %d out-of-range settings without a word"
 				% [accepted.size(), OUT_OF_RANGE.size()]
 			),
-			"; ".join(PackedStringArray(accepted))
+			(
+				(
+					"#373 gave the numeric settings clamping setters; what is left is the two whose"
+					+ " legal values are an enum -- bake_connector_mode has no setter at all and"
+					+ " bake_collision_mode relies on @export_range, which is an inspector hint. %s"
+				)
+				% "; ".join(PackedStringArray(accepted))
+			)
 		)
 
 
@@ -115,11 +122,15 @@ func _through_a_state_round_trip() -> void:
 			landed.append("%s = %s" % [key, poisoned[key]])
 	if not landed.is_empty():
 		known(
-			373,
-			"apply_hflevel_settings writes every value a .hflevel carries straight onto the property",
+			480,
+			"apply_hflevel_settings writes a .hflevel's enum settings straight onto the property",
 			(
-				"%d of 7 poisoned settings landed unchanged: %s -- the dock SpinBoxes have ranges, this path has none"
-				% [landed.size(), "; ".join(PackedStringArray(landed))]
+				(
+					"%d of 7 poisoned settings landed unchanged: %s -- the numeric ones are clamped"
+					% [landed.size(), "; ".join(PackedStringArray(landed))]
+				)
+				+ " by their setters since #373; bake_collision_mode and bake_connector_mode"
+				+ " have no setter to clamp them"
 			)
 		)
 

--- a/tools/vibe/scenarios/status_board.gd
+++ b/tools/vibe/scenarios/status_board.gd
@@ -109,17 +109,27 @@ func _a_palette_whose_files_have_moved() -> void:
 		if mat != null:
 			live += 1
 	note("slots that actually resolved", live)
-	if loaded and live == 0:
-		known(
-			414,
-			"loading a palette whose files have all moved reports success and says nothing",
+	# #426 kept the null slots -- the indices have to stay stable -- and added the
+	# report that was missing: every path that did not resolve is named on load
+	# and available to a caller afterwards.
+	var missing_paths: Array = []
+	if mm.has_method("get_missing_library_paths"):
+		missing_paths = Array(mm.get_missing_library_paths())
+	note("paths the loader says it could not resolve", missing_paths)
+	note(
+		"slots the loader counts as missing",
+		mm.get_missing_count() if mm.has_method("get_missing_count") else -1
+	)
+	if loaded and live == 0 and missing_paths.size() != 3:
+		flag(
+			"a palette whose files have all moved loads without naming what it dropped",
 			(
-				"load_library() appends a null for every path it cannot resolve -- right, since"
-				+ " the indices have to stay stable -- and then returns true with no count of"
-				+ (
-					" what was dropped and no warning. The palette has %d slots and %d materials."
-					% [mm.materials.size(), live]
+				(
+					"load_library() appends a null for every path it cannot resolve and returns"
+					+ " true. #426 made it name each one; get_missing_library_paths() reports %s"
+					+ " for a library of three paths that have all moved."
 				)
+				% str(missing_paths)
 			)
 		)
 

--- a/tools/vibe/scenarios/surface_paint.gd
+++ b/tools/vibe/scenarios/surface_paint.gd
@@ -1,0 +1,163 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## Where a surface paint stroke lands on the face the mapper clicked.
+##
+## The path is three steps: `pick_face_from_ray()` returns the face and the UV
+## under the cursor, `HFPaintSystem.paint_surface_at()` clamps that UV to 0..1,
+## and `SurfacePaint.paint_at_uv()` turns it into a pixel in the layer's weight
+## image. This drives all three with a ray aimed at a known spot on a known
+## face, and then reads the image back to see which texels moved.
+##
+## The UV a face carries is the projected one, and `_project_uvs_for_vertices()`
+## projects world coordinates -- a 128 unit wall spans 128 in U, not 1.
+
+const FaceSelector = preload("res://addons/hammerforge/face_selector.gd")
+
+
+func id() -> String:
+	return "surface-paint"
+
+
+func summary() -> String:
+	return "where a surface paint stroke lands against where the cursor was"
+
+
+func run() -> void:
+	await _where_the_stroke_lands()
+	await _what_a_stroke_costs()
+
+
+## The pixels above zero in a weight image, as a bounding box in texels.
+func _painted_bounds(image: Image) -> Dictionary:
+	var lo := Vector2i(1 << 30, 1 << 30)
+	var hi := Vector2i(-1, -1)
+	var count := 0
+	for y in image.get_height():
+		for x in image.get_width():
+			if image.get_pixel(x, y).r > 0.01:
+				count += 1
+				lo.x = mini(lo.x, x)
+				lo.y = mini(lo.y, y)
+				hi.x = maxi(hi.x, x)
+				hi.y = maxi(hi.y, y)
+	return {"count": count, "from": lo, "to": hi}
+
+
+func _where_the_stroke_lands() -> void:
+	var root: Node3D = await fresh_root("PaintLevel")
+	var b = box(root, Vector3(128, 64, 32))
+	await frame()
+
+	# A ray at the +Z face, three quarters of the way along it and above centre:
+	# the cursor is plainly not in a corner.
+	var target := Vector3(40.0, 20.0, 16.0)
+	var hit: Dictionary = root.brush_system.pick_face_from_ray(
+		target + Vector3(0, 0, 200), Vector3(0, 0, -1)
+	)
+	if hit.is_empty():
+		flag("the face picker missed a face the ray passes through", target)
+		return
+	note("picked face index", hit.get("face_idx", -1))
+	note("hit position", hit.get("position", Vector3.ZERO))
+	note("UV the picker reports", hit.get("uv", Vector2.ZERO))
+
+	var face_idx := int(hit.get("face_idx", 0))
+	var face = b.faces[face_idx]
+	root.add_surface_paint_layer(str(b.get_meta("brush_id", "")), face_idx)
+	await frame()
+	var uv: Vector2 = hit.get("uv", Vector2.ZERO)
+	# The two lines HFPaintSystem.paint_surface_at() runs before painting.
+	var clamped := Vector2(clampf(uv.x, 0.0, 1.0), clampf(uv.y, 0.0, 1.0))
+	note("UV after the clamp paint_surface_at applies", clamped)
+	root.surface_paint.paint_at_uv(face, 0, clamped, 0.1, 1.0)
+	await frame()
+
+	var layer = face.paint_layers[0] if face.paint_layers.size() > 0 else null
+	if layer == null or layer.weight_image == null:
+		flag("no weight image after a stroke", "paint_at_uv made no layer to paint into")
+		return
+	var image: Image = layer.weight_image
+	var bounds: Dictionary = _painted_bounds(image)
+	note("weight image size", image.get_size())
+	note("texels the stroke moved", bounds["count"])
+	note("painted region, in texels", "%s .. %s" % [bounds["from"], bounds["to"]])
+	var expected := Vector2i(
+		int(clamped.x * image.get_width()), int(clamped.y * image.get_height())
+	)
+	note("texel the clamped UV points at", expected)
+
+	if not is_equal_approx(uv.x, clamped.x) or not is_equal_approx(uv.y, clamped.y):
+		known(
+			464,
+			"a surface paint stroke always lands in one corner of the face",
+			(
+				(
+					"pick_face_from_ray() reports the face's own UV, and a face's UVs are the"
+					+ " projection of its world coordinates -- this hit at %s came back as UV %s."
+					+ " paint_surface_at() then clamps that to 0..1, so every stroke anywhere on a"
+					+ " face larger than one unit lands at the same clamped corner (%s here) no"
+					+ " matter where the cursor was. The stroke moved %d texels, all inside %s..%s"
+					+ " of a %s image."
+				)
+				% [
+					hit.get("position", Vector3.ZERO),
+					uv,
+					clamped,
+					int(bounds["count"]),
+					bounds["from"],
+					bounds["to"],
+					image.get_size(),
+				]
+			)
+		)
+
+	# Second stroke, at the opposite end of the same face. If the clamp is
+	# collapsing them, both land in the same texels.
+	var far_target := Vector3(-40.0, -20.0, 16.0)
+	var far_hit: Dictionary = root.brush_system.pick_face_from_ray(
+		far_target + Vector3(0, 0, 200), Vector3(0, 0, -1)
+	)
+	var far_uv: Vector2 = far_hit.get("uv", Vector2.ZERO)
+	var far_clamped := Vector2(clampf(far_uv.x, 0.0, 1.0), clampf(far_uv.y, 0.0, 1.0))
+	note("UV at the far end of the same face", far_uv)
+	note("the same after the clamp", far_clamped)
+	if far_clamped == clamped and far_target != target:
+		note(
+			"two clicks %s apart clamp to the same UV" % far_target.distance_to(target), far_clamped
+		)
+
+
+func _what_a_stroke_costs() -> void:
+	var root: Node3D = await fresh_root("PaintCostLevel")
+	var b = box(root, Vector3(128, 64, 32))
+	await frame()
+	root.add_surface_paint_layer(str(b.get_meta("brush_id", "")), 4)
+	await frame()
+	var face = b.faces[4]
+	if face.paint_layers.is_empty():
+		note("no layer to paint into", "skipping the cost half")
+		return
+	var started := Time.get_ticks_usec()
+	for _i in 10:
+		root.surface_paint.paint_at_uv(face, 0, Vector2(0.5, 0.5), 0.5, 1.0)
+	var per_sample := float(Time.get_ticks_usec() - started) / 10000.0
+	note("ms per paint sample at the dock's largest radius", per_sample)
+	if per_sample > 10.0:
+		known(
+			465,
+			"one paint sample at the dock's largest radius costs %.1f ms" % per_sample,
+			(
+				"paint_at_uv() scans a square of (2r+1)^2 texels with get_pixel/set_pixel, and"
+				+ " HFPaintSystem.handle_paint_input() calls it on every mouse-motion event"
+				+ " while the button is held. At the top of the dock's 0.01..0.5 radius range"
+				+ " that is a 257x257 pass over a 256x256 image on the main thread, per sample."
+			)
+		)
+	var rebuild_started := Time.get_ticks_usec()
+	for _i in 10:
+		b.rebuild_preview()
+	note(
+		"ms per rebuild_preview, which paint_surface_at also runs per sample",
+		float(Time.get_ticks_usec() - rebuild_started) / 10000.0
+	)

--- a/tools/vibe/scenarios/surface_paint.gd.uid
+++ b/tools/vibe/scenarios/surface_paint.gd.uid
@@ -1,0 +1,1 @@
+uid://b78u371c4btke

--- a/tools/vibe/scenarios/transform.gd
+++ b/tools/vibe/scenarios/transform.gd
@@ -10,6 +10,8 @@ extends "res://tools/vibe/hf_vibe_scenario.gd"
 ## winding after a mirror (a negative-determinant basis inverts face winding
 ## invisibly until the bake).
 
+const FaceData = preload("res://addons/hammerforge/face_data.gd")
+
 const AXIS_X := 0
 const AXIS_Y := 1
 const AXIS_Z := 2
@@ -167,38 +169,85 @@ func _reset_rotation_keeps_scale() -> void:
 		flag("reset_rotation left a rotation behind", "euler %s" % euler)
 
 
-## Texture lock claims the texture stays where it was in the world while the
-## brush turns under it. Verified independently: the world direction along which
-## U increases on a given face must not move.
+## What texture lock does to a face under a yaw, against what #355 settled it
+## should do: a face whose projection plane the turn keeps holds its world
+## texture direction, and a face the turn swings out from under its projection
+## carries its texture round with it, upright.
+##
+## The projection decides which of the two a face is, so the faces are given the
+## Box UV projection the dock's re-project button applies -- a face left on the
+## PLANAR_Z default is neither, and that is #463 rather than this.
 func _texture_lock_world_direction() -> void:
 	var root: Node3D = await fresh_root()
 	var b = box(root, Vector3(128, 64, 32))
 	var ids := _ids([b])
 	note("texture lock enabled", root.transform_system._texture_lock_enabled())
+
+	# First, the brush exactly as the Draw tool makes it.
+	var default_locked: bool = b.faces[2].adjust_uvs_for_rotation(
+		Basis(Vector3.UP, deg_to_rad(90.0))
+	)
+	note("a default (PLANAR_Z) top face is compensated under a yaw", default_locked)
+	if not default_locked:
+		known(
+			463,
+			"texture lock declines every face of a brush nobody has re-projected",
+			(
+				"FaceData.uv_projection defaults to PLANAR_Z on all six faces, and"
+				+ " adjust_uvs_for_rotation() refuses any face whose projection plane the turn"
+				+ " takes away -- which under a yaw is every face of a default box. Texture"
+				+ " lock therefore does nothing at all until the mapper re-projects."
+			)
+		)
+
+	for face in b.faces:
+		face.uv_projection = FaceData.UVProjection.BOX_UV
+		face.custom_uvs = PackedVector2Array()
+	b.rebuild_preview()
+	await frame()
+
 	var before: Array = []
+	var normals: Array = []
 	for i in range(b.faces.size()):
 		before.append(_u_direction(b, i))
+		normals.append((b.global_transform.basis * b.faces[i].normal).normalized())
 	root.rotate_managed_nodes(ids, [], AXIS_Y, 90.0, Vector3.ZERO)
 	await frame()
+	var turn := Basis(Vector3.UP, deg_to_rad(90.0))
 	for i in range(b.faces.size()):
 		var n0: Vector3 = before[i]
 		var n1: Vector3 = _u_direction(b, i)
 		if n0 == Vector3.ZERO or n1 == Vector3.ZERO:
 			note("face %d" % i, "no measurable U direction (before %s after %s)" % [n0, n1])
 			continue
-		var moved := rad_to_deg(n0.angle_to(n1))
-		var normal: Vector3 = (b.global_transform.basis * b.faces[i].normal).normalized()
+		var normal: Vector3 = normals[i]
+		var turns_in_its_own_plane: bool = absf(normal.dot(Vector3.UP)) > 0.9
+		var locked: bool = n1.dot(n0) > 0.999
+		var carried: bool = n1.dot((turn * n0).normalized()) > 0.999
 		note(
 			"face %d (world normal %s)" % [i, normal.snapped(Vector3.ONE * 0.01)],
-			"U direction moved %.1f deg" % moved
+			"locked %s, carried %s" % [locked, carried]
 		)
-		if moved > 1.0:
-			known(
-				333,
-				"texture lock moves the U direction on face %d by %.1f deg" % [i, moved],
+		if turns_in_its_own_plane and not locked:
+			flag(
+				"a yaw moves the texture on face %d, which turns in its own plane" % i,
 				(
-					"world normal %s: a 90 deg yaw should leave the texture on a vertical wall alone"
-					% normal.snapped(Vector3.ONE * 0.01)
+					(
+						"world normal %s: the projection plane is the one the turn keeps, so the"
+						+ " compensation should hold the texture where it was. U went from %s to %s."
+					)
+					% [normal.snapped(Vector3.ONE * 0.01), n0, n1]
+				)
+			)
+		elif not turns_in_its_own_plane and not carried:
+			flag(
+				"a yaw tips the texture on face %d" % i,
+				(
+					(
+						"world normal %s: the wall swings round, so its texture should go with it"
+						+ " upright. U went from %s to %s, and carrying it would be %s."
+					)
+					% [normal.snapped(Vector3.ONE * 0.01), n0, n1, (turn * n0).normalized()]
 				)
 			)
 

--- a/tools/vibe/scenarios/uv_defaults.gd
+++ b/tools/vibe/scenarios/uv_defaults.gd
@@ -1,0 +1,158 @@
+@tool
+extends "res://tools/vibe/hf_vibe_scenario.gd"
+
+## The UVs a brush is born with, measured face by face.
+##
+## Every other scenario that touches texturing sets a projection first. This one
+## never does: it makes the brushes the Draw tool makes and asks what the
+## texture on each face would look like, by measuring the UV parallelogram each
+## triangle is mapped onto. A face whose triangles have world area and no UV
+## area cannot show a texture -- one row of texels is stretched across the whole
+## face, which is what "smeared" means when a mapper says it.
+##
+## `FaceData.uv_projection` defaults to `PLANAR_Z`, and `_build_box_faces()`
+## hands every face a `FaceData.new()`.
+
+const DraftBrush = preload("res://addons/hammerforge/brush_instance.gd")
+const FaceData = preload("res://addons/hammerforge/face_data.gd")
+
+## shape id -> label, from LevelRoot.BrushShape.
+const SHAPES := {
+	0: "box",
+	1: "cylinder",
+	2: "sphere",
+	4: "wedge",
+	5: "pyramid",
+}
+
+
+func id() -> String:
+	return "uv-defaults"
+
+
+func summary() -> String:
+	return "whether a brush's faces are born with a projection that can show a texture"
+
+
+func run() -> void:
+	await _every_shape_as_drawn()
+	await _what_the_box_uv_button_does()
+
+
+## The UV area a face's triangles cover, against the world area they cover.
+##
+## The ratio is texels per square unit. Zero means the projection is edge on to
+## the face: every point of the face samples the same line of the texture.
+func _uv_against_world(face) -> Dictionary:
+	var tri: Dictionary = face.triangulate()
+	var verts: PackedVector3Array = tri.get("verts", PackedVector3Array())
+	var uvs: PackedVector2Array = tri.get("uvs", PackedVector2Array())
+	var world_area := 0.0
+	var uv_area := 0.0
+	if verts.size() < 3 or uvs.size() != verts.size():
+		return {"world": 0.0, "uv": 0.0}
+	for t in range(verts.size() / 3):
+		var i := t * 3
+		world_area += 0.5 * (verts[i + 1] - verts[i]).cross(verts[i + 2] - verts[i]).length()
+		var a: Vector2 = uvs[i + 1] - uvs[i]
+		var b: Vector2 = uvs[i + 2] - uvs[i]
+		uv_area += 0.5 * absf(a.x * b.y - a.y * b.x)
+	return {"world": world_area, "uv": uv_area}
+
+
+func _flat_faces(root: Node3D, shape: int) -> Array:
+	var brush = root.create_brush_from_info({"shape": shape, "size": Vector3(128, 64, 32)})
+	await frame()
+	var out: Array = []
+	if brush == null:
+		return out
+	for i in range(brush.get_faces().size()):
+		var face = brush.get_faces()[i]
+		var measured: Dictionary = _uv_against_world(face)
+		(
+			out
+			. append(
+				{
+					"index": i,
+					"normal": face.normal,
+					"projection": face.uv_projection,
+					"world": measured["world"],
+					"uv": measured["uv"],
+				}
+			)
+		)
+	return out
+
+
+func _every_shape_as_drawn() -> void:
+	var root: Node3D = await fresh_root("UVLevel")
+	note("FaceData.uv_projection default", FaceData.new().uv_projection)
+	for shape in SHAPES:
+		var faces: Array = await _flat_faces(root, int(shape))
+		var flat := 0
+		var total := 0
+		var examples: Array = []
+		for entry in faces:
+			if float(entry["world"]) <= 0.0001:
+				continue
+			total += 1
+			if float(entry["uv"]) <= 0.0001:
+				flat += 1
+				if examples.size() < 3:
+					examples.append(
+						(
+							"face %d (normal %s)"
+							% [entry["index"], entry["normal"].snapped(Vector3.ONE * 0.01)]
+						)
+					)
+		note("%s: faces with no UV area" % SHAPES[shape], "%d of %d  %s" % [flat, total, examples])
+		if flat > 0:
+			known(
+				463,
+				"a new %s has %d face(s) no texture can be seen on" % [SHAPES[shape], flat],
+				(
+					"FaceData.uv_projection defaults to PLANAR_Z -- (x, y) -> (u, v) -- and"
+					+ " nothing sets a projection when a brush is made. A mesh-built shape keeps"
+					+ " the source mesh's UVs wherever _face_from_ids() can carry them, which is"
+					+ " why a sphere is fine; every face that falls back to the projection gets"
+					+ " PLANAR_Z. On any such face whose plane contains the Z axis, or that lies"
+					+ " flat in Y, one of the two UV axes is constant across the whole face, so"
+					+ " it samples a single line of the texture and renders as streaks. It is on the baked"
+					+ " mesh, not only in the preview: baker._build_face_groups() takes the"
+					+ " same triangulate() UVs. The dock has a Box UV re-projection the mapper"
+					+ " can apply by hand afterwards, per face, which is the fix being done"
+					+ " manually. Examples: "
+					+ str(examples)
+				)
+			)
+
+
+## The same box with the projection the dock's re-project button applies, to
+## show the defect is the default rather than the projector.
+func _what_the_box_uv_button_does() -> void:
+	var root: Node3D = await fresh_root("UVLevelB")
+	var brush = root.create_brush_from_info({"shape": 0, "size": Vector3(128, 64, 32)})
+	await frame()
+	var before := 0
+	var after := 0
+	for face in brush.get_faces():
+		if float(_uv_against_world(face)["uv"]) <= 0.0001:
+			before += 1
+	for face in brush.get_faces():
+		face.uv_projection = FaceData.UVProjection.BOX_UV
+		face.custom_uvs = PackedVector2Array()
+	for face in brush.get_faces():
+		if float(_uv_against_world(face)["uv"]) <= 0.0001:
+			after += 1
+	note("box faces with no UV area, as drawn", before)
+	note("box faces with no UV area, after Box UV", after)
+
+	# Texture lock reads the same field. A projection that does not contain the
+	# face cannot be world locked through a turn either, so the lock declines.
+	var top = brush.get_faces()[2]
+	top.uv_projection = FaceData.UVProjection.PLANAR_Z
+	var locked: bool = top.adjust_uvs_for_rotation(Basis(Vector3.UP, deg_to_rad(90.0)))
+	note("texture lock compensates the top face of a default box under a yaw", locked)
+	top.uv_projection = FaceData.UVProjection.BOX_UV
+	var locked_box: bool = top.adjust_uvs_for_rotation(Basis(Vector3.UP, deg_to_rad(90.0)))
+	note("the same face with Box UV", locked_box)

--- a/tools/vibe/scenarios/uv_defaults.gd.uid
+++ b/tools/vibe/scenarios/uv_defaults.gd.uid
@@ -1,0 +1,1 @@
+uid://cejthh7h146qc

--- a/tools/vibe/scenarios/vertex.gd
+++ b/tools/vibe/scenarios/vertex.gd
@@ -257,12 +257,28 @@ func _splitting_an_edge() -> void:
 		var cross: Vector3 = (fv[2] - fv[0]).normalized().cross((fv[1] - fv[0]).normalized())
 		if cross.length() <= 0.0001:
 			collinear += 1
-			known(
-				367,
-				"split_edge leaves a face whose first three vertices are collinear",
+		# Since #387 the normal comes from Newell's method over the whole polygon
+		# rather than the opening triple, so a collinear triple is allowed to exist
+		# as long as the normal it produces is still the face's own plane. That is
+		# the thing worth checking, and it is checkable independently.
+		var newell := Vector3.ZERO
+		for i in fv.size():
+			var current: Vector3 = fv[i]
+			var next: Vector3 = fv[(i + 1) % fv.size()]
+			newell += Vector3(
+				(current.y - next.y) * (current.z + next.z),
+				(current.z - next.z) * (current.x + next.x),
+				(current.x - next.x) * (current.y + next.y)
+			)
+		# Newell as written here follows the counter-clockwise convention; HammerForge
+		# winds clockwise from outside, so the two agree up to sign. The plane is
+		# what is being checked, and inward-facing geometry has its own probe below.
+		if newell.length() > 0.0001 and absf(face.normal.dot(newell.normalized())) < 0.999:
+			flag(
+				"a face's stored normal is not the plane its vertices lie in",
 				(
-					"_compute_normal() measures only local_verts[0..2], gets a zero cross and falls back to Vector3.UP -- this face now reports normal %s"
-					% face.normal
+					"after split_edge, face normal %s against %s measured over the whole polygon"
+					% [face.normal, newell.normalized()]
 				)
 			)
 	note("faces with a collinear opening triple after one split", collinear)


### PR DESCRIPTION
The scaffolding from the 2026-09-13 vibe session. Ten new scenarios in `tools/vibe/`, bringing the sweep to 57.

| scenario | covers | issues |
|---|---|---|
| `dock-undo` | which dock commands change the level without registering an undo step | #470 #471 #472 #473 #474 #475 #476 |
| `dock-settings` | what an exported settings file carries back onto the level, and what a hand-edited one does | #477 #478 |
| `uv-defaults` | whether a brush's faces are born with a projection that can show a texture | #463 |
| `surface-paint` | where a stroke lands against where the cursor was, and what one costs | #464 #465 |
| `dock-cordon` | whether the cordon spins can hold the cordon the level was given | #467 |
| `playtest-spawn` | where the playtest player's feet end up against the spawn the validator approved | #468 #469 |
| `entity-props` | what a colour or vector entity property is after a save, a load and a `.map` export | #479 |
| `bake-materials` | whether per-face materials reach the baked mesh with the settings a level starts with | #466 |
| `dock-ranges` | whether each dock spin and the level property behind it agree about the legal range | #481 |
| `brush-sides` | whether a cylinder or a cone is built with the number of sides it was asked for | #482 |

Everything filed is recorded as `known(<issue>, ...)` rather than deleted, so each scenario keeps exercising its defect and goes red if a fix regresses.

**The baseline sweep found seven `known()` entries pointing at closed issues.** Six were the probe being out of date and are rewritten here to check what the fix actually settled:

- `transform` — #333/#355 made a yaw hold the texture on a face whose projection plane the turn keeps and carry it, upright, on one the turn swings away. The probe asserted the old blanket rule. It now checks both cases separately, on Box UV faces, and records the default-projection case as #463.
- `painted-faces` — the #413 probe never set `bake_use_face_materials`, so every surface it measured was the CSG path's single default material. With the flag on, the shader material comes back untouched as #425 intended.
- `vertex` — #367/#387 moved the normal onto Newell's method over the whole polygon, so a collinear opening triple is no longer a wrong normal. The probe now measures the polygon's own plane and compares.
- `cost` — #322/#328 merged coplanar triangles. A flat byte budget flagged the curved shapes for being curved; the check is now a per-shape face budget at the counts the fix landed on.
- `prefs` — #409/#423 keeps an unreadable prefs file as `.unreadable` and says why, and #410/#428 reports a chord clash through `conflicts_for()` rather than refusing the rebind. Both probes now check for those.

The seventh was real and is filed as **#480**: #373 gave the numeric settings clamping setters and left `bake_collision_mode` and `bake_connector_mode`, whose legal values are an enum — `@export_range` is an inspector hint and does not clamp an assignment from code.

The whole sweep is clean: 57 of 57 scenarios, no new flags.
