### PR TITLE
Commit the seven missing test .uid files

### DIFF
--- a/tests/test_example_load_guard.gd.uid
+++ b/tests/test_example_load_guard.gd.uid
@@ -1,0 +1,1 @@
+uid://dt0cwg203sh31

--- a/tests/test_paint_grid_follows_root.gd.uid
+++ b/tests/test_paint_grid_follows_root.gd.uid
@@ -1,0 +1,1 @@
+uid://cawbiw118g311

--- a/tests/test_paint_layer_manager.gd.uid
+++ b/tests/test_paint_layer_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://ds2ukx4oi5x26

--- a/tests/test_quick_property_ranges.gd.uid
+++ b/tests/test_quick_property_ranges.gd.uid
@@ -1,0 +1,1 @@
+uid://bc2eemivxqevd

--- a/tests/test_selection_filter_coverage.gd.uid
+++ b/tests/test_selection_filter_coverage.gd.uid
@@ -1,0 +1,1 @@
+uid://c0hfimvxwkfce

--- a/tests/test_shortcut_surfaces.gd.uid
+++ b/tests/test_shortcut_surfaces.gd.uid
@@ -1,0 +1,1 @@
+uid://bpl1o6d0x688p

--- a/tests/test_tool_setting_bounds.gd.uid
+++ b/tests/test_tool_setting_bounds.gd.uid
@@ -1,0 +1,1 @@
+uid://cdflq3xpf761o


### PR DESCRIPTION
The tests added with #453 through #461 went in without the `.uid` file Godot writes beside a script, so an import regenerates all seven and a fresh checkout goes dirty on the first editor launch. Same gap as #451, same fix.

```
tests/test_example_load_guard.gd.uid
tests/test_paint_grid_follows_root.gd.uid
tests/test_paint_layer_manager.gd.uid
tests/test_quick_property_ranges.gd.uid
tests/test_selection_filter_coverage.gd.uid
tests/test_shortcut_surfaces.gd.uid
tests/test_tool_setting_bounds.gd.uid
```

The ids are the ones `godot --headless --import` generated for the files as they stand on main.