### PR TITLE
Register an undo step for every dock command that changes the level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,42 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   fall out of a missing check.
 
 ### Fixed
+- **Every dock command that changes the level now registers an undo step**
+  (#470, #471, #472, #473, #474, #475). Thirteen of them called `level_root`
+  directly: New, Add Sel, Rem Sel and Delete on the visgroup list, Group and
+  Ungroup, Create Entity, Add and Remove on the entity I/O list, Add Layer and
+  Remove Layer, Generate Noise and Import Heightmap. Ctrl+Z after any of them
+  undid whatever
+  came before instead, so a misclick on Delete Visgroup lost the membership of
+  every brush in it and the keystroke that should have taken it back removed
+  something else. Group and Ungroup were the worst of the set because they
+  recorded a row in the History panel, which is where a mapper looks to see what
+  can be stepped back. All of them go through `_commit_state_action()` now, and
+  the History panel entry comes from the same wrapper. Convert to Heightmap
+  builds its layer inline, so it registers the work it already did.
+  `capture_state()` already carried the visgroups, the groups, the entities and
+  the paint layers; nothing about the data was in the way.
+- **A redo no longer reaches for a node the undo freed.** `restore_state()`
+  clears the brushes and entities and rebuilds them from their captured info, so
+  a command registered with a live node in its arguments had a dangling
+  reference waiting in the redo. `_commit_state_action()` takes an
+  `absolute_redo` flag for those, which registers the resulting state as the do
+  operation instead of the call. Every command above that takes a selection or
+  an entity uses it.
+- **The wiring panel's connections and presets are undoable** (#473). The panel
+  holds the entity system rather than the dock's undo manager, so it could not
+  register its own step. It now says when it is about to change something, the
+  dock takes the before state, and the done signal commits the pair - which
+  matters most for a preset, where the alternative to one Ctrl+Z was deleting a
+  dozen connections by hand. A preset that applies nothing says so, rather than
+  leaving a before state to pair with whatever happened next.
+- **Add Sel leaves the visgroup row it just used selected** (#476). All three
+  visgroup commands end in `refresh_visgroup_ui()`, which clears the ItemList
+  and rebuilds it, so the highlight was gone and the next Add Sel, Rem Sel or
+  Delete was a silent no-op until the mapper clicked the visgroup again - which
+  dropped every click after the first in the natural workflow. The row goes back
+  after the refresh, the way the visibility toggle on the same list already did
+  it, and a command that finds no visgroup highlighted now says so.
 - **The live auto-connector path costs the stroke instead of the level**
   (#441). `defs_for_touched_cells()` is documented as the cheap path that "does
   not scan or rebuild geometry", and its first statement was a full

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,755 tests across 199 test scripts (3,748 passing plus seven intentional no-assert safety tests; 18,686 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,766 tests across 200 test scripts (3,759 passing plus seven intentional no-assert safety tests; 18,764 assertions; verified in CI on September 13, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,755 tests** across **199 scripts** (**3,748 passing** plus seven intentional no-assert safety tests; **18,686 assertions**).
+Full suite (verified in CI on September 13, 2026): **3,766 tests** across **200 scripts** (**3,759 passing** plus seven intentional no-assert safety tests; **18,764 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3748%20passing-brightgreen" alt="3748 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3759%20passing-brightgreen" alt="3759 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,755 tests across 199 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,766 tests across 200 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/dock.gd
+++ b/addons/hammerforge/dock.gd
@@ -534,6 +534,9 @@ var io_add_btn: Button = null
 var io_list: ItemList = null
 var io_remove_btn: Button = null
 var _io_wiring_panel = null  # HFIOWiringPanel
+## Level state from just before the wiring panel changed something. The panel
+## does the work itself, so the undo step is registered after the fact.
+var _wiring_before_state: Dictionary = {}
 # Entity I/O sections (context-hidden when no entity selected)
 var _entity_io_section: VBoxContainer = null
 var _io_wiring_section: VBoxContainer = null
@@ -3059,7 +3062,15 @@ func _log(message: String, force: bool = false) -> void:
 	print("[HammerForge Dock] %s" % message)
 
 
-func _commit_state_action(action_name: String, method_name: String, args: Array = []) -> void:
+## Register one level-changing command as an undo step.
+##
+## Set `absolute_redo` when any argument is a live node. `restore_state()` clears
+## the brushes and entities and rebuilds them from their captured info, so a node
+## an undo passed over is freed and the reference the redo holds is dangling. With
+## it on, the do operation becomes a snapshot of the result instead of the call.
+func _commit_state_action(
+	action_name: String, method_name: String, args: Array = [], absolute_redo: bool = false
+) -> void:
 	if not level_root:
 		return
 	HFUndoHelper.commit(
@@ -3069,7 +3080,9 @@ func _commit_state_action(action_name: String, method_name: String, args: Array 
 		method_name,
 		args,
 		false,
-		Callable(self, "record_history")
+		Callable(self, "record_history"),
+		"",
+		absolute_redo
 	)
 
 
@@ -5640,6 +5653,14 @@ func _on_wiring_connection_added(
 
 func _on_wiring_preset_applied(source: Node, preset_name: String, count: int) -> void:
 	HFDockEntityHandler.on_wiring_preset_applied(self, source, preset_name, count)
+
+
+func _on_wiring_will_change(action_name: String) -> void:
+	HFDockEntityHandler.on_wiring_will_change(self, action_name)
+
+
+func _on_wiring_change_abandoned() -> void:
+	HFDockEntityHandler.on_wiring_change_abandoned(self)
 
 
 func _on_wiring_highlight_toggled(enabled: bool) -> void:

--- a/addons/hammerforge/dock_entity_handler.gd
+++ b/addons/hammerforge/dock_entity_handler.gd
@@ -194,7 +194,7 @@ static func on_create_entity(dock: Object) -> void:
 		if type_id != "":
 			entity.entity_type = type_id
 			entity.entity_class = type_id
-	dock.level_root.add_entity(entity)
+	dock._commit_state_action("Create Entity", "add_entity", [entity], true)
 	focus_entity_selection(dock, entity)
 
 
@@ -235,8 +235,11 @@ static func on_io_add(dock: Object) -> void:
 	var parameter = dock.io_parameter.text.strip_edges() if dock.io_parameter else ""
 	var delay = dock.io_delay.value if dock.io_delay else 0.0
 	var fire_once = dock.io_fire_once.button_pressed if dock.io_fire_once else false
-	dock.level_root.add_entity_output(
-		entity, output_name, target_name, input_name, parameter, delay, fire_once
+	dock._commit_state_action(
+		"Add Entity Output",
+		"add_entity_output",
+		[entity, output_name, target_name, input_name, parameter, delay, fire_once],
+		true
 	)
 	refresh_io_list(dock, entity)
 	dock._set_status("Added output: %s → %s.%s" % [output_name, target_name, input_name])
@@ -259,7 +262,7 @@ static func on_io_remove(dock: Object) -> void:
 		dock._set_status("Select a connection to remove", true)
 		return
 	var index = selected_items[0]
-	dock.level_root.remove_entity_output(entity, index)
+	dock._commit_state_action("Remove Entity Output", "remove_entity_output", [entity, index], true)
 	refresh_io_list(dock, entity)
 	dock._set_status("Removed output connection")
 
@@ -313,6 +316,7 @@ static func on_wiring_connection_added(
 ) -> void:
 	if dock == null:
 		return
+	commit_wiring_change(dock, "Add Entity Output")
 	refresh_io_list(dock, source)
 	dock._set_status("Wired: %s → %s.%s" % [output_name, target_name, input_name])
 
@@ -322,8 +326,31 @@ static func on_wiring_preset_applied(
 ) -> void:
 	if dock == null:
 		return
+	commit_wiring_change(dock, "Apply I/O Preset: %s" % preset_name)
 	refresh_io_list(dock, source)
 	dock._set_status("Applied preset '%s' (%d connections)" % [preset_name, count])
+
+
+## The wiring panel holds the entity system, not the dock's undo manager, so it
+## cannot register its own step. It says when it is about to change something and
+## the dock takes the before state here; the panel's done signal commits the pair.
+static func on_wiring_will_change(dock: Object, _action_name: String) -> void:
+	if dock == null or not dock.level_root:
+		return
+	dock._wiring_before_state = dock.level_root.capture_full_state()
+
+
+static func on_wiring_change_abandoned(dock: Object) -> void:
+	if dock:
+		dock._wiring_before_state = {}
+
+
+static func commit_wiring_change(dock: Object, action_name: String) -> void:
+	if dock == null or dock._wiring_before_state.is_empty():
+		return
+	var before: Dictionary = dock._wiring_before_state
+	dock._wiring_before_state = {}
+	dock._commit_done_state_action(action_name, before)
 
 
 static func on_wiring_highlight_toggled(dock: Object, enabled: bool) -> void:

--- a/addons/hammerforge/dock_paint_handler.gd
+++ b/addons/hammerforge/dock_paint_handler.gd
@@ -22,7 +22,7 @@ static func on_paint_layer_selected(dock: Object, index: int) -> void:
 static func on_paint_layer_add(dock: Object) -> void:
 	if dock == null or not dock.level_root:
 		return
-	dock.level_root.add_paint_layer()
+	dock._commit_state_action("Add Paint Layer", "add_paint_layer")
 	dock._refresh_paint_layers()
 
 
@@ -60,7 +60,7 @@ static func on_paint_layer_rename(dock: Object) -> void:
 static func on_paint_layer_remove(dock: Object) -> void:
 	if dock == null or not dock.level_root:
 		return
-	dock.level_root.remove_active_paint_layer()
+	dock._commit_state_action("Remove Paint Layer", "remove_active_paint_layer")
 	dock._refresh_paint_layers()
 
 
@@ -72,13 +72,13 @@ static func on_heightmap_import(dock: Object) -> void:
 static func on_heightmap_import_selected(dock: Object, path: String) -> void:
 	if dock == null or not dock.level_root:
 		return
-	dock.level_root.import_heightmap(path)
+	dock._commit_state_action("Import Heightmap", "import_heightmap", [path])
 
 
 static func on_heightmap_generate(dock: Object) -> void:
 	if dock == null or not dock.level_root:
 		return
-	dock.level_root.generate_heightmap_noise()
+	dock._commit_state_action("Generate Noise", "generate_heightmap_noise")
 
 
 static func on_heightmap_convert(dock: Object) -> void:
@@ -119,6 +119,9 @@ static func on_heightmap_convert(dock: Object) -> void:
 			result.layer.grid = grid
 	result.layer.chunk_size = mgr.chunk_size
 	result.layer.name = "Layer_%s" % str(result.layer.layer_id)
+	# Taken here, past every early return, so an abandoned convert leaves no
+	# half-registered step behind.
+	var before_convert: Dictionary = dock.level_root.capture_full_state()
 	mgr.add_child(result.layer)
 	mgr.layers.append(result.layer)
 	mgr.active_layer_index = mgr.layers.size() - 1
@@ -129,6 +132,7 @@ static func on_heightmap_convert(dock: Object) -> void:
 		and dock.level_root.paint_system.has_method("regenerate_paint_layers")
 	):
 		dock.level_root.paint_system.regenerate_paint_layers()
+	dock._commit_done_state_action("Convert to Heightmap", before_convert)
 	dock.level_root.emit_signal(
 		"user_message",
 		(

--- a/addons/hammerforge/dock_visgroup_handler.gd
+++ b/addons/hammerforge/dock_visgroup_handler.gd
@@ -82,6 +82,32 @@ static func refresh_visgroup_ui(dock: Object) -> void:
 		dock.visgroup_list.add_item(prefix + visgroup_name)
 
 
+## The highlighted row, or -1. `refresh_visgroup_ui()` clears the list and
+## rebuilds it, so a command that refreshes has to put the highlight back or the
+## next one reads no visgroup and does nothing.
+static func get_selected_visgroup_index(dock: Object) -> int:
+	if dock == null or not dock.visgroup_list:
+		return -1
+	var selected = dock.visgroup_list.get_selected_items()
+	return -1 if selected.is_empty() else int(selected[0])
+
+
+static func reselect_visgroup_row(dock: Object, index: int) -> void:
+	if dock == null or not dock.visgroup_list or index < 0:
+		return
+	if index < dock.visgroup_list.item_count:
+		dock.visgroup_list.select(index)
+
+
+## The name on the highlighted row, or "". Commands that need one report the
+## miss rather than returning quietly, which used to read as a dead button.
+static func require_visgroup_name(dock: Object, action: String) -> String:
+	var visgroup_name := get_selected_visgroup_name(dock)
+	if visgroup_name == "" and dock:
+		dock._set_status("%s: select a visgroup first" % action, true)
+	return visgroup_name
+
+
 static func get_selected_visgroup_name(dock: Object) -> String:
 	if dock == null or not dock.visgroup_list:
 		return ""
@@ -100,7 +126,7 @@ static func on_visgroup_add(dock: Object) -> void:
 	var visgroup_name = dock.visgroup_name_input.text.strip_edges()
 	if visgroup_name == "" or not dock.level_root:
 		return
-	dock.level_root.create_visgroup(visgroup_name)
+	dock._commit_state_action("New Visgroup", "create_visgroup", [visgroup_name])
 	dock.visgroup_name_input.text = ""
 	refresh_visgroup_ui(dock)
 
@@ -131,34 +157,48 @@ static func on_visgroup_item_clicked(
 static func on_visgroup_add_selection(dock: Object) -> void:
 	if dock == null:
 		return
-	var visgroup_name = get_selected_visgroup_name(dock)
+	var visgroup_name = require_visgroup_name(dock, "Add to Visgroup")
 	if visgroup_name == "" or not dock.level_root:
 		return
 	if not dock._guard_selection_action("Add to Visgroup"):
 		return
-	dock.level_root.add_selection_to_visgroup(visgroup_name, dock._selection_nodes)
+	var row := get_selected_visgroup_index(dock)
+	dock._commit_state_action(
+		"Add to Visgroup",
+		"add_selection_to_visgroup",
+		[visgroup_name, dock._selection_nodes.duplicate()],
+		true
+	)
 	refresh_visgroup_ui(dock)
+	reselect_visgroup_row(dock, row)
 
 
 static func on_visgroup_remove_selection(dock: Object) -> void:
 	if dock == null:
 		return
-	var visgroup_name = get_selected_visgroup_name(dock)
+	var visgroup_name = require_visgroup_name(dock, "Remove from Visgroup")
 	if visgroup_name == "" or not dock.level_root:
 		return
 	if not dock._guard_selection_action("Remove from Visgroup"):
 		return
-	dock.level_root.remove_selection_from_visgroup(visgroup_name, dock._selection_nodes)
+	var row := get_selected_visgroup_index(dock)
+	dock._commit_state_action(
+		"Remove from Visgroup",
+		"remove_selection_from_visgroup",
+		[visgroup_name, dock._selection_nodes.duplicate()],
+		true
+	)
 	refresh_visgroup_ui(dock)
+	reselect_visgroup_row(dock, row)
 
 
 static func on_visgroup_delete(dock: Object) -> void:
 	if dock == null:
 		return
-	var visgroup_name = get_selected_visgroup_name(dock)
+	var visgroup_name = require_visgroup_name(dock, "Delete Visgroup")
 	if visgroup_name == "" or not dock.level_root:
 		return
-	dock.level_root.remove_visgroup(visgroup_name)
+	dock._commit_state_action("Delete Visgroup", "remove_visgroup", [visgroup_name])
 	refresh_visgroup_ui(dock)
 
 
@@ -167,8 +207,12 @@ static func on_group_selection(dock: Object) -> void:
 		return
 	if not dock._guard_selection_action("Group Selection"):
 		return
-	dock.level_root.group_selection("group_%d" % Time.get_ticks_usec(), dock._selection_nodes)
-	dock.record_history("Group Selection")
+	dock._commit_state_action(
+		"Group Selection",
+		"group_selection",
+		["group_%d" % Time.get_ticks_usec(), dock._selection_nodes.duplicate()],
+		true
+	)
 
 
 static func on_ungroup_selection(dock: Object) -> void:
@@ -176,8 +220,9 @@ static func on_ungroup_selection(dock: Object) -> void:
 		return
 	if not dock._guard_selection_action("Ungroup Selection"):
 		return
-	dock.level_root.ungroup_nodes(dock._selection_nodes)
-	dock.record_history("Ungroup Selection")
+	dock._commit_state_action(
+		"Ungroup Selection", "ungroup_nodes", [dock._selection_nodes.duplicate()], true
+	)
 
 
 static func setup_cordon_ui(dock: Object) -> void:

--- a/addons/hammerforge/ui/entity_tab_builder.gd
+++ b/addons/hammerforge/ui/entity_tab_builder.gd
@@ -118,4 +118,6 @@ func connect_signals() -> void:
 	if dock._io_wiring_panel:
 		dock._io_wiring_panel.connection_added.connect(dock._on_wiring_connection_added)
 		dock._io_wiring_panel.preset_applied.connect(dock._on_wiring_preset_applied)
+		dock._io_wiring_panel.will_change.connect(dock._on_wiring_will_change)
+		dock._io_wiring_panel.change_abandoned.connect(dock._on_wiring_change_abandoned)
 		dock._io_wiring_panel.highlight_toggled.connect(dock._on_wiring_highlight_toggled)

--- a/addons/hammerforge/ui/hf_io_wiring_panel.gd
+++ b/addons/hammerforge/ui/hf_io_wiring_panel.gd
@@ -16,6 +16,12 @@ signal connection_added(
 	fire_once: bool
 )
 signal connection_removed(source: Node, index: int)
+## Emitted immediately before the panel changes the level, so whoever owns the
+## undo manager can take the before state. The matching done signal commits it.
+signal will_change(action_name: String)
+## Emitted when a `will_change` came to nothing, so the before state taken for it
+## is dropped rather than left to pair with whatever happens next.
+signal change_abandoned
 signal preset_applied(source: Node, preset_name: String, count: int)
 signal highlight_toggled(enabled: bool)
 
@@ -352,6 +358,7 @@ func _on_wire_pressed() -> void:
 	var parameter = _wire_param.text.strip_edges()
 	var delay = _wire_delay.value
 	var fire_once = _wire_once.button_pressed
+	will_change.emit("Add Entity Output")
 	_entity_system.add_entity_output(
 		_source_entity, output_name, target_name, input_name, parameter, delay, fire_once
 	)
@@ -379,10 +386,13 @@ func _on_preset_apply() -> void:
 		var edit: LineEdit = _target_map_edits[tag]
 		if edit and edit.text.strip_edges() != "":
 			target_map[tag] = edit.text.strip_edges()
+	will_change.emit("Apply I/O Preset")
 	var count = _io_presets.apply_preset(_source_entity, preset, target_map)
 	if count > 0:
 		preset_applied.emit(_source_entity, str(preset.get("name", "")), count)
 		_refresh()
+	else:
+		change_abandoned.emit()
 
 
 func _on_preset_save() -> void:

--- a/addons/hammerforge/undo_helper.gd
+++ b/addons/hammerforge/undo_helper.gd
@@ -19,12 +19,19 @@ static var _last_collation_full := false
 
 ## Register one undoable action, optionally merging it with the last one.
 ##
-## `absolute_redo` is for commands that step rather than set: rotate by fifteen
-## degrees, nudge by one grid square. Godot's MERGE_ENDS keeps the first action's
-## undo and the last action's do, which is only right when that last do names the
-## final result. A third quick rotate would otherwise redo fifteen degrees where
-## undo had removed forty-five. When it is on, the method runs first and the
-## action's do method is a snapshot of the result instead of the step.
+## `absolute_redo` turns the do operation into a snapshot of the result: the
+## method runs first, and what gets registered is the state it produced rather
+## than the call that produced it. Two kinds of command need that.
+##
+## Commands that step rather than set: rotate by fifteen degrees, nudge by one
+## grid square. Godot's MERGE_ENDS keeps the first action's undo and the last
+## action's do, which is only right when that last do names the final result. A
+## third quick rotate would otherwise redo fifteen degrees where undo had removed
+## forty-five.
+##
+## Commands whose arguments are live nodes. `restore_state()` clears the brushes
+## and entities and rebuilds them from their captured info, so a node an undo
+## passed over is freed and the reference held for the redo is dangling.
 static func commit(
 	undo_redo: EditorUndoRedoManager,
 	root: Node,

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,755 tests across 199 scripts**: **3,748 passing tests**, seven intentional no-assert safety tests, and **18,686 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 13, 2026 contains **3,766 tests across 200 scripts**: **3,759 passing tests**, seven intentional no-assert safety tests, and **18,764 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_dock_undo_coverage.gd
+++ b/tests/test_dock_undo_coverage.gd
@@ -114,6 +114,33 @@ func test_create_entity_redo_survives_the_undo_that_freed_the_entity() -> void:
 	)
 
 
+func test_without_an_absolute_redo_the_same_command_redoes_a_dead_node() -> void:
+	# Why the flag is not optional on these commands. Registered the ordinary way,
+	# the do operation names the call and carries the node, and the undo in
+	# between is what takes that node out of the tree.
+	var root := _fresh_root()
+	var fake = _fake_undo()
+	var entity := DraftEntity.new()
+	entity.name = "DraftEntity"
+	entity.set_meta("is_entity", true)
+
+	_commit(fake, root, "Create Entity", "add_entity", [entity], false)
+	var do_calls: Array = fake.entries[-1]["do"]
+	assert_eq(do_calls[0]["method"], "add_entity", "The ordinary path registers the call itself")
+	assert_eq(
+		do_calls[0]["args"][0],
+		entity,
+		"and holds the node, which is the reference the undo invalidates"
+	)
+
+	fake.undo()
+	assert_eq(root.entities_node.get_child_count(), 0)
+	assert_false(
+		root.entities_node.get_children().has(entity),
+		"The undo removed the node the redo would be handed"
+	)
+
+
 func test_delete_visgroup_undo_restores_the_record_and_the_membership() -> void:
 	var root := _fresh_root()
 	var fake = _fake_undo()

--- a/tests/test_dock_undo_coverage.gd
+++ b/tests/test_dock_undo_coverage.gd
@@ -1,0 +1,312 @@
+extends GutTest
+
+## Which dock commands register an undo step, and what their redo is made of.
+##
+## Two halves, for the same reason `test_undo_collation.gd` has two: an
+## `EditorUndoRedoManager` cannot be constructed outside the editor. What a
+## command redoes is driven through `register_action()` against the stand-in that
+## file already carries, replayed against a real `LevelRoot`. Which wrapper a
+## button reaches for is read off the handler source, because that is the part a
+## null `undo_redo` in a test would hide.
+##
+## The invariant behind the whole set: `restore_state()` clears the brushes and
+## entities and rebuilds them from their captured info, so any command holding a
+## live node has to redo from a state snapshot rather than from the call.
+
+const CollationTests = preload("res://tests/test_undo_collation.gd")
+const DraftEntity = preload("res://addons/hammerforge/draft_entity.gd")
+const DraftBrush = preload("res://addons/hammerforge/brush_instance.gd")
+
+const HANDLER_SOURCES := [
+	"res://addons/hammerforge/dock_visgroup_handler.gd",
+	"res://addons/hammerforge/dock_entity_handler.gd",
+	"res://addons/hammerforge/dock_paint_handler.gd",
+]
+
+const MERGE_DISABLE := 0
+
+
+func _fresh_root() -> LevelRoot:
+	var root := LevelRoot.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	return root
+
+
+func _fake_undo():
+	return CollationTests.FakeUndoRedo.new()
+
+
+## Register one command the way the dock now does, against the stand-in.
+func _commit(fake, root: LevelRoot, name: String, method: String, args: Array, absolute: bool):
+	var before: Dictionary = root.capture_state()
+	HFUndoHelper.register_action(
+		fake, root, name, MERGE_DISABLE, method, args, before, false, absolute
+	)
+
+
+func _body(function_name: String) -> String:
+	for path in HANDLER_SOURCES:
+		var source := FileAccess.get_file_as_string(path)
+		var start := source.find("\nstatic func %s(" % function_name)
+		if start < 0:
+			continue
+		var rest := source.substr(start + 1)
+		var end := rest.find("\n\n\n")
+		return rest if end < 0 else rest.substr(0, end)
+	return ""
+
+
+func _box(root: LevelRoot, brush_id: String, center: Vector3) -> Node:
+	return (
+		root
+		. create_brush_from_info(
+			{
+				"shape": LevelRoot.BrushShape.BOX,
+				"size": Vector3(64, 64, 64),
+				"center": center,
+				"operation": CSGShape3D.OPERATION_UNION,
+				"brush_id": brush_id,
+			}
+		)
+	)
+
+
+func _first_child(parent: Node) -> Node:
+	return parent.get_child(0) if parent and parent.get_child_count() > 0 else null
+
+
+# ---------------------------------------------------------------------------
+# What the redo is made of
+# ---------------------------------------------------------------------------
+
+
+func test_create_entity_redo_survives_the_undo_that_freed_the_entity() -> void:
+	var root := _fresh_root()
+	var fake = _fake_undo()
+	var entity := DraftEntity.new()
+	entity.name = "DraftEntity"
+	entity.set_meta("is_entity", true)
+
+	_commit(fake, root, "Create Entity", "add_entity", [entity], true)
+	assert_eq(root.entities_node.get_child_count(), 1, "Create Entity must add the entity")
+
+	var do_calls: Array = fake.entries[-1]["do"]
+	assert_eq(do_calls.size(), 1)
+	assert_eq(
+		do_calls[0]["method"],
+		"restore_state",
+		"A command holding a live node must redo from a state snapshot, not the call"
+	)
+
+	fake.undo()
+	assert_eq(root.entities_node.get_child_count(), 0, "Undo must take the entity back out")
+	# The undo took the node the call was made with out of the tree and queued it
+	# for release. The redo has to rebuild from the snapshot rather than re-add
+	# that node: before the fix it handed add_entity() a reference on its way out.
+	fake.redo()
+	assert_eq(root.entities_node.get_child_count(), 1, "Redo must put the entity back")
+	assert_ne(
+		_first_child(root.entities_node),
+		entity,
+		"Redo must rebuild the entity from the snapshot, not re-add the original node"
+	)
+
+
+func test_delete_visgroup_undo_restores_the_record_and_the_membership() -> void:
+	var root := _fresh_root()
+	var fake = _fake_undo()
+	var brush := _box(root, "undo_brush", Vector3.ZERO)
+	root.create_visgroup("Lights")
+	root.add_selection_to_visgroup("Lights", [brush])
+	assert_eq(Array(brush.get_meta("visgroups", PackedStringArray())), ["Lights"])
+
+	_commit(fake, root, "Delete Visgroup", "remove_visgroup", ["Lights"], false)
+	assert_eq(Array(root.visgroup_system.get_visgroup_names()), [], "Delete must remove the record")
+
+	fake.undo()
+	assert_eq(
+		Array(root.visgroup_system.get_visgroup_names()),
+		["Lights"],
+		"Undo must bring the visgroup record back"
+	)
+	var restored := _first_child(root.draft_brushes_node)
+	assert_not_null(restored, "Undo must leave the brush in place")
+	assert_eq(
+		Array(restored.get_meta("visgroups", PackedStringArray())),
+		["Lights"],
+		"Undo must bring the membership back, not just the record"
+	)
+
+
+func test_group_selection_undo_clears_the_group_and_its_member_meta() -> void:
+	var root := _fresh_root()
+	var fake = _fake_undo()
+	var brush_a := _box(root, "undo_brush_a", Vector3.ZERO)
+	var brush_b := _box(root, "undo_brush_b", Vector3(128, 0, 0))
+
+	_commit(fake, root, "Group Selection", "group_selection", ["group_1", [brush_a, brush_b]], true)
+	assert_true(root.capture_state().get("groups", {}).has("group_1"), "Group must be recorded")
+
+	fake.undo()
+	assert_false(
+		root.capture_state().get("groups", {}).has("group_1"), "Undo must remove the group"
+	)
+	for child in root.draft_brushes_node.get_children():
+		assert_false(child.has_meta("group_id"), "Undo must clear group_id from the members")
+
+
+func test_remove_entity_output_undo_restores_the_connection() -> void:
+	var root := _fresh_root()
+	var fake = _fake_undo()
+	var entity := DraftEntity.new()
+	entity.name = "DraftEntity"
+	entity.set_meta("is_entity", true)
+	root.add_entity(entity)
+	entity.entity_data["targetname"] = "door_1"
+	root.add_entity_output(entity, "OnPressed", "door_1", "Open", "", 0.0, false)
+	assert_eq(root.get_entity_outputs(entity).size(), 1)
+
+	_commit(fake, root, "Remove Entity Output", "remove_entity_output", [entity, 0], true)
+	assert_eq(root.get_entity_outputs(entity).size(), 0, "Remove must drop the connection")
+
+	fake.undo()
+	var restored := _first_child(root.entities_node)
+	assert_not_null(restored, "Undo must rebuild the entity")
+	assert_eq(root.get_entity_outputs(restored).size(), 1, "Undo must bring the connection back")
+
+
+func test_remove_paint_layer_undo_restores_the_layer_and_what_was_painted() -> void:
+	var root := _fresh_root()
+	if not root.paint_layers:
+		pass_test("no paint layer manager on this build")
+		return
+	var fake = _fake_undo()
+	root.add_paint_layer()
+	var layer = root.paint_layers.get_active_layer()
+	assert_not_null(layer, "Add Paint Layer must produce an active layer")
+	layer.set_cell(Vector2i(0, 0), true)
+	layer.set_cell(Vector2i(1, 0), true)
+	var layers_before: int = root.paint_layers.layers.size()
+
+	_commit(fake, root, "Remove Paint Layer", "remove_active_paint_layer", [], false)
+	assert_eq(root.paint_layers.layers.size(), layers_before - 1, "Remove must take the layer out")
+
+	fake.undo()
+	assert_eq(root.paint_layers.layers.size(), layers_before, "Undo must bring the layer back")
+	var back = root.paint_layers.get_active_layer()
+	assert_not_null(back)
+	assert_true(back.get_cell(Vector2i(0, 0)), "Undo must bring back what was painted into it")
+
+
+# ---------------------------------------------------------------------------
+# Which wrapper each button reaches for
+# ---------------------------------------------------------------------------
+
+
+func test_every_level_changing_dock_command_registers_an_undo_step() -> void:
+	# The handler, and the level method it must no longer call straight.
+	var commands := {
+		"on_visgroup_add": "create_visgroup",
+		"on_visgroup_delete": "remove_visgroup",
+		"on_visgroup_add_selection": "add_selection_to_visgroup",
+		"on_visgroup_remove_selection": "remove_selection_from_visgroup",
+		"on_group_selection": "group_selection",
+		"on_ungroup_selection": "ungroup_nodes",
+		"on_create_entity": "add_entity",
+		"on_io_add": "add_entity_output",
+		"on_io_remove": "remove_entity_output",
+		"on_paint_layer_remove": "remove_active_paint_layer",
+		"on_heightmap_generate": "generate_heightmap_noise",
+		"on_heightmap_import_selected": "import_heightmap",
+	}
+	for function_name in commands:
+		var body := _body(function_name)
+		assert_ne(body, "", "%s must exist in a handler source" % function_name)
+		assert_true(
+			body.contains("_commit_state_action"),
+			"%s changes the level and must register an undo step" % function_name
+		)
+		assert_false(
+			body.contains("dock.level_root.%s(" % commands[function_name]),
+			(
+				"%s must not call level_root.%s() outside the undo wrapper"
+				% [function_name, commands[function_name]]
+			)
+		)
+
+
+func test_commands_holding_live_nodes_ask_for_an_absolute_redo() -> void:
+	# Anything passing dock._selection_nodes or an entity into the wrapper: the
+	# redo cannot be a re-call, because the undo freed what it would be handed.
+	for function_name in [
+		"on_visgroup_add_selection",
+		"on_visgroup_remove_selection",
+		"on_group_selection",
+		"on_ungroup_selection",
+		"on_create_entity",
+		"on_io_add",
+		"on_io_remove",
+	]:
+		var flat := _body(function_name).replace("\n", " ").replace("\t", "")
+		while flat.contains("  "):
+			flat = flat.replace("  ", " ")
+		assert_true(
+			flat.contains(", true )") or flat.contains(", true)"),
+			"%s passes a live node and must commit with absolute_redo" % function_name
+		)
+
+
+func test_convert_to_heightmap_registers_the_work_it_already_did() -> void:
+	var body := _body("on_heightmap_convert")
+	assert_true(
+		body.contains("capture_full_state()"),
+		"Convert builds the layer itself, so it must take a before state"
+	)
+	assert_true(
+		body.contains("_commit_done_state_action"),
+		"Convert must register the work it already did as one step"
+	)
+
+
+func test_wiring_panel_announces_a_change_before_it_makes_one() -> void:
+	var source := FileAccess.get_file_as_string("res://addons/hammerforge/ui/hf_io_wiring_panel.gd")
+	var wire := source.find("func _on_wire_pressed")
+	var announce := source.find("will_change.emit", wire)
+	var mutate := source.find("_entity_system.add_entity_output", wire)
+	assert_true(announce > wire and announce < mutate, "The panel must announce before it wires")
+
+	var preset := source.find("func _on_preset_apply")
+	assert_true(
+		source.find("change_abandoned.emit", preset) > preset,
+		"A preset that applies nothing must drop the before state it asked for"
+	)
+
+
+func test_add_selection_to_visgroup_leaves_the_row_it_used_selected() -> void:
+	var root := _fresh_root()
+	var dock := preload("res://addons/hammerforge/dock.tscn").instantiate()
+	add_child_autoqfree(dock)
+	dock.level_root = root
+	var brush := _box(root, "undo_brush", Vector3.ZERO)
+	root.create_visgroup("Lights")
+	HFDockVisgroupHandler.refresh_visgroup_ui(dock)
+	dock.visgroup_list.select(0)
+	dock._selection_nodes = [brush]
+
+	dock._on_visgroup_add_selection()
+	assert_eq(
+		Array(brush.get_meta("visgroups", PackedStringArray())),
+		["Lights"],
+		"Add Sel must add the selection to the highlighted visgroup"
+	)
+	assert_false(
+		dock.visgroup_list.get_selected_items().is_empty(),
+		"Add Sel must leave the row selected so the next press is not a no-op"
+	)
+	assert_eq(
+		HFDockVisgroupHandler.get_selected_visgroup_name(dock),
+		"Lights",
+		"The same visgroup must still be the one a second Add Sel would use"
+	)

--- a/tools/vibe/scenarios/dock_undo.gd
+++ b/tools/vibe/scenarios/dock_undo.gd
@@ -106,8 +106,7 @@ func _visgroups_and_groups() -> void:
 	var selected_after: PackedInt32Array = dock.visgroup_list.get_selected_items()
 	note("visgroup list selection after Add Sel", selected_after)
 	if selected_after.is_empty():
-		known(
-			476,
+		flag(
 			"Add Sel clears the visgroup it just added to",
 			(
 				"HFDockVisgroupHandler.on_visgroup_add_selection() ends in refresh_visgroup_ui(),"
@@ -134,8 +133,7 @@ func _visgroups_and_groups() -> void:
 		!= HFVibe.canonical(after_delete.get("visgroups", []))
 	)
 	if state_moved and not _undo_wrapped("on_visgroup_delete"):
-		known(
-			470,
+		flag(
 			"Delete Visgroup is not undoable",
 			(
 				"on_visgroup_delete() calls level_root.remove_visgroup() directly. That erases"
@@ -160,8 +158,7 @@ func _visgroups_and_groups() -> void:
 		)
 		and not _undo_wrapped("on_group_selection")
 	):
-		known(
-			471,
+		flag(
 			"Group Selection and Ungroup are not undoable",
 			(
 				"Both call record_history(), which only appends a row to the dock's own history"
@@ -190,8 +187,7 @@ func _entities_and_their_wiring() -> void:
 	note("entities added by Create Entity", created)
 	note("Create Entity registers an undo step", _undo_wrapped("on_create_entity"))
 	if created > 0 and not _undo_wrapped("on_create_entity"):
-		known(
-			472,
+		flag(
 			"Create Entity is not undoable",
 			(
 				"on_create_entity() calls level_root.add_entity() straight. Placing a brush"
@@ -229,8 +225,7 @@ func _entities_and_their_wiring() -> void:
 		)
 		and not _undo_wrapped("on_io_add")
 	):
-		known(
-			473,
+		flag(
 			"Entity I/O add and remove are not undoable",
 			(
 				"on_io_add() and on_io_remove() call add_entity_output()/remove_entity_output()"
@@ -278,8 +273,7 @@ func _paint_layers() -> void:
 	note("captured paint layers, before and after Remove", [painted_before, painted_after])
 	note("Remove Layer registers an undo step", _undo_wrapped("on_paint_layer_remove"))
 	if painted_after < painted_before and not _undo_wrapped("on_paint_layer_remove"):
-		known(
-			474,
+		flag(
 			"Remove Paint Layer is not undoable",
 			(
 				"on_paint_layer_remove() calls remove_active_paint_layer() straight, and the"
@@ -302,8 +296,7 @@ func _paint_layers() -> void:
 		)
 		and not _undo_wrapped("on_heightmap_generate")
 	):
-		known(
-			475,
+		flag(
 			"Generate Noise overwrites the heightmap with no undo step",
 			(
 				"on_heightmap_generate() calls generate_heightmap_noise() directly. It replaces"


### PR DESCRIPTION
Thirteen dock commands changed the level without registering an undo step, so
Ctrl+Z after any of them undid whatever came before instead.

- Visgroup New, Add Sel, Rem Sel and Delete, Group and Ungroup, Create Entity,
  entity I/O Add and Remove, Add Layer and Remove Layer, Generate Noise and
  Import Heightmap all go through `_commit_state_action()` now. Convert to
  Heightmap builds its layer inline, so it registers the work it already did.
- `restore_state()` clears the brushes and entities and rebuilds them from their
  captured info, so a command registered with a live node in its arguments had a
  dangling reference waiting in the redo. `_commit_state_action()` takes an
  `absolute_redo` flag for those, which registers the resulting state as the do
  operation instead of the call. The helper already supported it.
- The wiring panel holds the entity system rather than the undo manager, so it
  could not register its own step. It announces a change before making one, the
  dock takes the before state, and the done signal commits the pair. A preset
  that applies nothing says so rather than leaving that state behind.
- Add Sel, Rem Sel and Delete put the visgroup row back after the refresh that
  cleared it, and say so when no visgroup is highlighted.

The dock-undo vibe scenario's seven `known()` entries are `flag()` now, so the
scenario fails if any of this comes back.

Full suite: 3758 passing, 7 risky (the intentional no-assert set), 0 failing.

Fixes #470
Fixes #471
Fixes #472
Fixes #473
Fixes #474
Fixes #475
Fixes #476
