### PR TITLE
Validate the settings a file can apply to a level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,46 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   walks the touched cells and their four neighbours directly, and a test
   asserts it gives the same answer as filtering the full scan so the two cannot
   drift apart.
+- **Import Settings validates what it reads instead of casting it** (#478). The
+  parsed `.hfsettings` dictionary went into the level through bare `float()`,
+  `int()` and `bool()` calls. `float("sixteen")` is `0.0` in GDScript, so a
+  hand-edited file, or one from a writer that quotes its numbers, turned
+  snapping off in silence; `int({})` raises at the cast, so a value of the wrong
+  container type aborted the rest of the block rather than being reported. All
+  26 reads go through validating readers now, which keep the setting in force
+  and name the key that was refused, in the shape `HFUserPrefs` got in #423.
+  `_apply_grid_snap()` also writes the value the SpinBox ended up holding rather
+  than the one it was handed, so an imported 4096 no longer leaves the dock
+  reading 128 while the level snaps to 4096 and the out-of-range number goes
+  into the prefs file to come back next session.
+- **Import Settings writes the connector mode to the level** (#477).
+  `OptionButton.select()` does not emit `item_selected`, and that signal was the
+  only thing that wrote `bake_connector_mode`. The dropdown said Auto and the
+  bake ran Ramp, with nothing to say which was in force, until the mapper
+  happened to touch the dropdown or reselect the LevelRoot - which made the
+  wrong state come and go. The import goes through a `_select_option_notifying()`
+  helper now, so the one place that knows what to write is still the only place
+  that writes it. A test pins the `select()` behaviour, because the class
+  reference does not state it.
+- **`bake_collision_mode` and `bake_connector_mode` clamp to the modes that
+  exist** (#480). #373 gave the unbounded bake and grid settings clamping
+  setters and missed the two whose legal values are an enum rather than a range.
+  `bake_connector_mode` had no setter at all, and `@export_range` is an
+  inspector hint that does not clamp an assignment from code, so both took
+  anything a `.hflevel` settings block or a settings import handed them. Both
+  are read as a mode with `match` or index arithmetic at bake time, so an
+  out-of-range value baked as whichever branch the default happened to be and
+  the level baked differently from what its own file said.
+- **A bake chunk size of 0 is the "off" the bake already understands** (#481).
+  `bake()` reads `if root.bake_chunk_size > 0.0` and 0 is the bottom of the dock
+  spin's own range, but the property clamped it up to `MIN_BAKE_CHUNK_SIZE`.
+  Turning the spin all the way down gave the opposite of what it said: one-unit
+  chunks, which is the finest chunking the editor can do and the slowest bake
+  available, where the mapper had asked for none. A negative value means off as
+  well, for the same reason - clamping it up to 1 was the worst answer on offer.
+  Import Settings also reads the chunk size once and lets the spin clamp it,
+  rather than reading it twice with different fallbacks, which could leave the
+  spin and the level saying different things about the chunking.
 - **The HUD, the coach marks and the tooltips read the keymap instead of
   spelling chords out** (#439, #440). `HFKeymap` is rebindable, and three of the
   surfaces that tell a mapper which key does what held their chords as string

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,755 tests across 199 test scripts (3,748 passing plus seven intentional no-assert safety tests; 18,686 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,764 tests across 200 test scripts (3,757 passing plus seven intentional no-assert safety tests; 18,708 assertions; verified in CI on September 13, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,766 tests across 200 test scripts (3,759 passing plus seven intentional no-assert safety tests; 18,764 assertions; verified in CI on September 13, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,775 tests across 201 test scripts (3,768 passing plus seven intentional no-assert safety tests; 18,786 assertions; verified in CI on September 13, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 13, 2026): **3,766 tests** across **200 scripts** (**3,759 passing** plus seven intentional no-assert safety tests; **18,764 assertions**).
+Full suite (verified in CI on September 13, 2026): **3,775 tests** across **201 scripts** (**3,768 passing** plus seven intentional no-assert safety tests; **18,786 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,755 tests** across **199 scripts** (**3,748 passing** plus seven intentional no-assert safety tests; **18,686 assertions**).
+Full suite (verified in CI on September 13, 2026): **3,764 tests** across **200 scripts** (**3,757 passing** plus seven intentional no-assert safety tests; **18,708 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3759%20passing-brightgreen" alt="3759 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3768%20passing-brightgreen" alt="3768 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3748%20passing-brightgreen" alt="3748 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3757%20passing-brightgreen" alt="3757 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,766 tests across 200 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,775 tests across 201 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,755 tests across 199 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,764 tests across 200 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/dock.gd
+++ b/addons/hammerforge/dock.gd
@@ -2864,11 +2864,16 @@ func _apply_grid_snap(value: float) -> void:
 	syncing_snap = true
 	grid_snap.value = value
 	syncing_snap = false
-	_sync_snap_buttons(value)
+	# The SpinBox clamps to the range the control declares. Everything below has
+	# to use what it ended up holding rather than what it was handed, or an
+	# imported 4096 leaves the dock reading 128 while the level snaps to 4096 and
+	# the out-of-range number goes into the prefs file to come back next session.
+	var applied: float = grid_snap.value
+	_sync_snap_buttons(applied)
 	if level_root and _root_has_property("grid_snap"):
-		level_root.set("grid_snap", value)
-	_save_user_pref("grid_snap", value)
-	grid_snap_applied.emit(value)
+		level_root.set("grid_snap", applied)
+	_save_user_pref("grid_snap", applied)
+	grid_snap_applied.emit(applied)
 
 
 func _sync_snap_buttons(value: float) -> void:
@@ -4964,16 +4969,59 @@ func _collect_editor_settings() -> Dictionary:
 	}
 
 
+## A number out of a settings file, or the setting that is already in force.
+##
+## `float("sixteen")` is 0.0 in GDScript and `int({})` raises at the cast, so a
+## hand-edited file, or one from a writer that quotes its numbers, used to turn a
+## setting off in silence or abort the import part way through. A value that is
+## not a number is reported once, naming the key, and the current setting is kept.
+func _setting_number(source: Dictionary, key: String, fallback: float) -> float:
+	if not source.has(key):
+		return fallback
+	var value: Variant = source[key]
+	if (value is float or value is int) and is_finite(float(value)):
+		return float(value)
+	_reject_setting(key, value)
+	return fallback
+
+
+func _setting_int(source: Dictionary, key: String, fallback: int) -> int:
+	return int(round(_setting_number(source, key, float(fallback))))
+
+
+## A flag out of a settings file. A writer that stores 0 and 1 is not a writer
+## getting it wrong, so a number counts; anything else does not.
+func _setting_bool(source: Dictionary, key: String, fallback: bool) -> bool:
+	if not source.has(key):
+		return fallback
+	var value: Variant = source[key]
+	if value is bool:
+		return value
+	if value is float or value is int:
+		return float(value) != 0.0
+	_reject_setting(key, value)
+	return fallback
+
+
+func _reject_setting(key: String, value: Variant) -> void:
+	var message := (
+		"Settings: '%s' is a %s, not a value this setting takes. The current one is kept."
+		% [key, type_string(typeof(value))]
+	)
+	HFLog.warn(message)
+	_set_status_warning(message)
+
+
 func _apply_editor_settings(data: Dictionary) -> void:
 	if data.has("grid_snap"):
-		_apply_grid_snap(float(data.get("grid_snap", grid_snap.value)))
+		_apply_grid_snap(_setting_number(data, "grid_snap", grid_snap.value))
 	if data.has("snap_presets") and data["snap_presets"] is Array:
 		_apply_snap_presets(data["snap_presets"])
 	if data.has("brush_size") and data["brush_size"] is Dictionary:
 		var size = data["brush_size"]
-		size_x.value = float(size.get("x", size_x.value))
-		size_y.value = float(size.get("y", size_y.value))
-		size_z.value = float(size.get("z", size_z.value))
+		size_x.value = _setting_number(size, "x", size_x.value)
+		size_y.value = _setting_number(size, "y", size_y.value)
+		size_z.value = _setting_number(size, "z", size_z.value)
 		if level_root:
 			level_root.drag_size_default = Vector3(size_x.value, size_y.value, size_z.value)
 			if _root_has_property("brush_size_default"):
@@ -4983,73 +5031,90 @@ func _apply_editor_settings(data: Dictionary) -> void:
 	if data.has("bake") and data["bake"] is Dictionary:
 		var bake = data["bake"]
 		if bake_merge_meshes:
-			bake_merge_meshes.button_pressed = bool(
-				bake.get("merge_meshes", bake_merge_meshes.button_pressed)
+			bake_merge_meshes.button_pressed = _setting_bool(
+				bake, "merge_meshes", bake_merge_meshes.button_pressed
 			)
 		if bake_generate_lods:
-			bake_generate_lods.button_pressed = bool(
-				bake.get("generate_lods", bake_generate_lods.button_pressed)
+			bake_generate_lods.button_pressed = _setting_bool(
+				bake, "generate_lods", bake_generate_lods.button_pressed
 			)
 		if bake_unwrap_uv0:
-			bake_unwrap_uv0.button_pressed = bool(
-				bake.get("unwrap_uv0", bake_unwrap_uv0.button_pressed)
+			bake_unwrap_uv0.button_pressed = _setting_bool(
+				bake, "unwrap_uv0", bake_unwrap_uv0.button_pressed
 			)
 		if bake_lightmap_uv2:
-			bake_lightmap_uv2.button_pressed = bool(
-				bake.get("lightmap_uv2", bake_lightmap_uv2.button_pressed)
+			bake_lightmap_uv2.button_pressed = _setting_bool(
+				bake, "lightmap_uv2", bake_lightmap_uv2.button_pressed
 			)
 		if bake_lightmap_texel:
-			bake_lightmap_texel.value = float(
-				bake.get("lightmap_texel_size", bake_lightmap_texel.value)
+			bake_lightmap_texel.value = _setting_number(
+				bake, "lightmap_texel_size", bake_lightmap_texel.value
 			)
 		if bake_use_face_materials:
-			bake_use_face_materials.button_pressed = bool(
-				bake.get("use_face_materials", bake_use_face_materials.button_pressed)
+			bake_use_face_materials.button_pressed = _setting_bool(
+				bake, "use_face_materials", bake_use_face_materials.button_pressed
 			)
 		if bake_navmesh:
-			bake_navmesh.button_pressed = bool(bake.get("navmesh", bake_navmesh.button_pressed))
+			bake_navmesh.button_pressed = _setting_bool(
+				bake, "navmesh", bake_navmesh.button_pressed
+			)
 		if bake_navmesh_cell_size:
-			bake_navmesh_cell_size.value = float(
-				bake.get("navmesh_cell_size", bake_navmesh_cell_size.value)
+			bake_navmesh_cell_size.value = _setting_number(
+				bake, "navmesh_cell_size", bake_navmesh_cell_size.value
 			)
 		if bake_navmesh_cell_height:
-			bake_navmesh_cell_height.value = float(
-				bake.get("navmesh_cell_height", bake_navmesh_cell_height.value)
+			bake_navmesh_cell_height.value = _setting_number(
+				bake, "navmesh_cell_height", bake_navmesh_cell_height.value
 			)
 		if bake_navmesh_agent_height:
-			bake_navmesh_agent_height.value = float(
-				bake.get("navmesh_agent_height", bake_navmesh_agent_height.value)
+			bake_navmesh_agent_height.value = _setting_number(
+				bake, "navmesh_agent_height", bake_navmesh_agent_height.value
 			)
 		if bake_navmesh_agent_radius:
-			bake_navmesh_agent_radius.value = float(
-				bake.get("navmesh_agent_radius", bake_navmesh_agent_radius.value)
+			bake_navmesh_agent_radius.value = _setting_number(
+				bake, "navmesh_agent_radius", bake_navmesh_agent_radius.value
 			)
 		if collision_layer_opt and bake.has("collision_mask"):
-			_select_option_by_id(collision_layer_opt, int(bake.get("collision_mask", 1)))
-		if level_root and bake.has("chunk_size") and _root_has_property("bake_chunk_size"):
-			level_root.set("bake_chunk_size", float(bake.get("chunk_size", 0.0)))
-		if bake_chunk_size_spin and bake.has("chunk_size"):
-			bake_chunk_size_spin.value = float(bake.get("chunk_size", 32.0))
+			_select_option_by_id(collision_layer_opt, _setting_int(bake, "collision_mask", 1))
+		if bake.has("chunk_size"):
+			# Read once and let the spin clamp it, then give the level what the
+			# control ended up holding. Read twice with different fallbacks, a
+			# value the file could not supply left the two saying different
+			# things about the chunking, which is the fault this pair had.
+			var chunk_size := _setting_number(
+				bake, "chunk_size", bake_chunk_size_spin.value if bake_chunk_size_spin else 32.0
+			)
+			if bake_chunk_size_spin:
+				bake_chunk_size_spin.value = chunk_size
+				chunk_size = bake_chunk_size_spin.value
+			if level_root and _root_has_property("bake_chunk_size"):
+				level_root.set("bake_chunk_size", chunk_size)
 		if bake_visible_only_check and bake.has("visible_only"):
-			bake_visible_only_check.button_pressed = bool(bake.get("visible_only", false))
+			bake_visible_only_check.button_pressed = _setting_bool(bake, "visible_only", false)
 		if bake_use_multimesh_check and bake.has("use_multimesh"):
-			bake_use_multimesh_check.button_pressed = bool(bake.get("use_multimesh", false))
+			bake_use_multimesh_check.button_pressed = _setting_bool(bake, "use_multimesh", false)
 		if bake_use_atlas_check and bake.has("use_atlas"):
-			bake_use_atlas_check.button_pressed = bool(bake.get("use_atlas", false))
+			bake_use_atlas_check.button_pressed = _setting_bool(bake, "use_atlas", false)
 		if bake_auto_connectors_check and bake.has("auto_connectors"):
-			bake_auto_connectors_check.button_pressed = bool(bake.get("auto_connectors", false))
+			bake_auto_connectors_check.button_pressed = _setting_bool(
+				bake, "auto_connectors", false
+			)
 		if bake_generate_occluders_check and bake.has("generate_occluders"):
-			bake_generate_occluders_check.button_pressed = bool(
-				bake.get("generate_occluders", false)
+			bake_generate_occluders_check.button_pressed = _setting_bool(
+				bake, "generate_occluders", false
 			)
 		if bake_occluder_min_area_spin and bake.has("occluder_min_area"):
-			bake_occluder_min_area_spin.value = float(bake.get("occluder_min_area", 4.0))
+			bake_occluder_min_area_spin.value = _setting_number(bake, "occluder_min_area", 4.0)
 		if bake_connector_mode_opt and bake.has("connector_mode"):
-			bake_connector_mode_opt.select(int(bake.get("connector_mode", 0)))
+			_select_option_notifying(
+				bake_connector_mode_opt, _setting_int(bake, "connector_mode", 0)
+			)
 		if bake_connector_stair_height_spin and bake.has("connector_stair_height"):
-			bake_connector_stair_height_spin.value = float(bake.get("connector_stair_height", 0.25))
+			bake_connector_stair_height_spin.value = _setting_number(
+				bake, "connector_stair_height", 0.25
+			)
 		if bake_connector_width_spin and bake.has("connector_width"):
-			bake_connector_width_spin.value = int(bake.get("connector_width", 2))
+			bake_connector_width_spin.value = _setting_int(bake, "connector_width", 2)
 		_sync_bake_option_visibility()
 
 
@@ -5077,6 +5142,19 @@ func _apply_snap_presets(values: Array) -> void:
 		button.text = str(preset)
 	_sync_snap_buttons(grid_snap.value)
 	_apply_all_tooltips()
+
+
+## Select an item and tell the listeners, which `OptionButton.select()` does not.
+##
+## `item_selected` is documented as emitted when the item is changed *by the
+## user*, so a programmatic select leaves every listener holding the old value.
+## For the connector mode that listener is the only thing that writes
+## `bake_connector_mode`, so the dropdown said Auto and the bake ran Ramp.
+func _select_option_notifying(option: OptionButton, index: int) -> void:
+	if not option or index < 0 or index >= option.get_item_count():
+		return
+	option.select(index)
+	option.item_selected.emit(index)
 
 
 func _select_option_by_id(option: OptionButton, id: int) -> void:

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -80,6 +80,13 @@ const MIN_GRID_PLANE_SIZE := 1.0
 const MAX_GRID_PLANE_SIZE := 100000.0
 const MIN_ROTATE_SNAP_DEGREES := 1.0
 const MAX_ROTATE_SNAP_DEGREES := 180.0
+## Both bake mode settings are three-value enums, and both are read with a
+## `match` or index arithmetic at bake time, so an out-of-range one falls through
+## to whichever branch the default happens to be and the level bakes differently
+## from what its own file says. `@export_range` is an inspector hint and does not
+## clamp an assignment from code.
+const MIN_BAKE_MODE := 0
+const MAX_BAKE_MODE := 2
 const MIN_BAKE_CHUNK_SIZE := 1.0
 const MAX_BAKE_CHUNK_SIZE := 16384.0
 const MIN_LIGHTMAP_TEXEL_SIZE := 0.001
@@ -118,9 +125,17 @@ var _grid_snap: float = 16.0
 var _bake_chunk_size: float = 32.0
 @export var bake_chunk_size: float = 32.0:
 	set(value):
-		_bake_chunk_size = _bounded(
-			value, MIN_BAKE_CHUNK_SIZE, MAX_BAKE_CHUNK_SIZE, _bake_chunk_size
-		)
+		# 0 is the bake's own "do not chunk" - `bake()` reads `> 0.0` - and it is
+		# the bottom of the dock spin's range. Clamping it up to the minimum gave
+		# the opposite of what the control said: the finest chunking there is,
+		# where the mapper had asked for none. Anything below 0 is not a size
+		# either, so it means off as well.
+		if is_finite(value) and value <= 0.0:
+			_bake_chunk_size = 0.0
+		else:
+			_bake_chunk_size = _bounded(
+				value, MIN_BAKE_CHUNK_SIZE, MAX_BAKE_CHUNK_SIZE, _bake_chunk_size
+			)
 	get:
 		return _bake_chunk_size
 @export var bake_merge_meshes: bool = false
@@ -178,7 +193,13 @@ var _bake_navmesh_agent_radius: float = 0.4
 ## Minimum face-group area (world units²) to generate an occluder.  Smaller
 ## surfaces rarely block enough pixels to justify the culling overhead.
 @export var bake_occluder_min_area: float = 4.0
-@export var bake_connector_mode: int = 0  # HFAutoConnector.ConnectorMode (RAMP=0, STAIRS=1, AUTO=2)
+var _bake_connector_mode: int = 0
+## HFAutoConnector.ConnectorMode (RAMP=0, STAIRS=1, AUTO=2).
+@export var bake_connector_mode: int = 0:
+	set(value):
+		_bake_connector_mode = clampi(value, MIN_BAKE_MODE, MAX_BAKE_MODE)
+	get:
+		return _bake_connector_mode
 var _bake_connector_stair_height: float = 0.25
 @export var bake_connector_stair_height: float = 0.25:
 	set(value):
@@ -199,7 +220,12 @@ var _bake_connector_width: int = 2
 @export var bake_use_thread_pool: bool = true
 ## Collision shape strategy: 0 = single trimesh (legacy), 1 = per-brush convex hulls,
 ## 2 = per-visgroup partitioned bodies.
-@export_range(0, 2, 1) var bake_collision_mode: int = 0
+var _bake_collision_mode: int = 0
+@export_range(0, 2, 1) var bake_collision_mode: int = 0:
+	set(value):
+		_bake_collision_mode = clampi(value, MIN_BAKE_MODE, MAX_BAKE_MODE)
+	get:
+		return _bake_collision_mode
 ## When bake_collision_mode >= 1, generate a convex hull per brush instead of one
 ## monolithic ConcavePolygonShape3D.  Per-brush convex shapes are faster for physics
 ## broadphase and produce better navigation meshes.

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 13, 2026 contains **3,766 tests across 200 scripts**: **3,759 passing tests**, seven intentional no-assert safety tests, and **18,764 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 13, 2026 contains **3,775 tests across 201 scripts**: **3,768 passing tests**, seven intentional no-assert safety tests, and **18,786 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,755 tests across 199 scripts**: **3,748 passing tests**, seven intentional no-assert safety tests, and **18,686 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 13, 2026 contains **3,764 tests across 200 scripts**: **3,757 passing tests**, seven intentional no-assert safety tests, and **18,708 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_bake_and_grid_setting_bounds.gd
+++ b/tests/test_bake_and_grid_setting_bounds.gd
@@ -51,8 +51,16 @@ func test_no_bake_or_grid_setting_keeps_a_value_that_is_not_a_number():
 
 
 func test_the_settings_that_must_be_positive_are_floored():
+	# The legal chunk sizes are 0, which the bake reads as "do not chunk", and
+	# anything from MIN_BAKE_CHUNK_SIZE up. A negative number is neither, and the
+	# nearest legal value to it is off - not 1, which is the finest chunking the
+	# editor can do and the slowest bake there is (#481).
 	root.bake_chunk_size = -32.0
-	assert_gt(root.bake_chunk_size, 0.0, "a chunk size is a size")
+	assert_eq(
+		root.bake_chunk_size,
+		0.0,
+		"a negative chunk size means no chunking, not the finest chunking there is"
+	)
 	root.bake_lightmap_texel_size = 0.0
 	assert_gt(root.bake_lightmap_texel_size, 0.0, "a texel size is a size")
 	root.bake_navmesh_cell_size = 0.0
@@ -108,7 +116,7 @@ func test_a_poisoned_settings_block_from_a_file_does_not_land():
 	)
 	assert_true(is_finite(root.grid_snap), "grid snap is still a snap")
 	assert_gt(root.grid_snap, 0.0, "and not silently off")
-	assert_gt(root.bake_chunk_size, 0.0)
+	assert_eq(root.bake_chunk_size, 0.0, "-1 is not a chunk size; off is the nearest one")
 	assert_gt(root.bake_lightmap_texel_size, 0.0)
 	assert_true(is_finite(root.bake_navmesh_cell_size))
 	assert_lte(root.bake_convex_simplify, 1.0)

--- a/tests/test_settings_import_validation.gd
+++ b/tests/test_settings_import_validation.gd
@@ -1,0 +1,173 @@
+extends GutTest
+
+## What a `.hfsettings` file is allowed to do to a level.
+##
+## Import Settings pushes a parsed dictionary through the dock's controls and on
+## to the LevelRoot. Three things can go wrong on that path and all three used
+## to: a value that is not a number becomes 0 at the cast, a value outside a
+## control's range reaches the level anyway, and a dropdown moves without
+## anything writing what it now says.
+
+const DockScene = preload("res://addons/hammerforge/dock.tscn")
+
+
+func _fresh_root() -> LevelRoot:
+	var root := LevelRoot.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	return root
+
+
+## The dock wired to a root the way the plugin wires it. `_connect_root_signals()`
+## is what fills `root_properties`, and every write to the level is guarded by it,
+## so a dock that only has `level_root` set silently writes nothing.
+func _dock(root: LevelRoot) -> Node:
+	var dock := DockScene.instantiate()
+	add_child_autoqfree(dock)
+	dock.level_root = root
+	dock.connected_root = root
+	dock._connect_root_signals()
+	return dock
+
+
+# ---------------------------------------------------------------------------
+# The two enum settings #373 missed (#480)
+# ---------------------------------------------------------------------------
+
+
+func test_both_bake_mode_settings_clamp_to_the_modes_that_exist() -> void:
+	var root := _fresh_root()
+	# @export_range is an inspector hint. It does not clamp an assignment from
+	# code, from a .hflevel settings block or from a settings import, and both of
+	# these are read as a mode at bake time.
+	root.bake_collision_mode = 99
+	assert_eq(root.bake_collision_mode, 2, "a collision mode above the range is the last mode")
+	root.bake_collision_mode = -7
+	assert_eq(root.bake_collision_mode, 0, "and below it is the first")
+	root.bake_connector_mode = 99
+	assert_eq(root.bake_connector_mode, 2, "a connector mode above the range is the last mode")
+	root.bake_connector_mode = -7
+	assert_eq(root.bake_connector_mode, 0, "and below it is the first")
+
+
+func test_a_poisoned_hflevel_settings_block_cannot_set_a_mode_that_does_not_exist() -> void:
+	var root := _fresh_root()
+	root.state_system.apply_hflevel_settings({"bake_collision_mode": 99, "bake_connector_mode": -7})
+	assert_between(root.bake_collision_mode, 0, 2, "collision mode is a mode after a file load")
+	assert_between(root.bake_connector_mode, 0, 2, "connector mode is a mode after a file load")
+
+
+# ---------------------------------------------------------------------------
+# Chunk size: the spin's own minimum (#481)
+# ---------------------------------------------------------------------------
+
+
+func test_a_chunk_size_of_zero_is_the_off_the_bake_already_understands() -> void:
+	var root := _fresh_root()
+	# bake() reads `if root.bake_chunk_size > 0.0`, and the dock spin's range
+	# starts at 0. Clamping 0 up to 1 gave the mapper the opposite of the control
+	# they had just turned all the way down.
+	root.bake_chunk_size = 0.0
+	assert_eq(root.bake_chunk_size, 0.0, "0 is off, not the smallest chunk")
+	root.bake_chunk_size = 0.25
+	assert_eq(
+		root.bake_chunk_size,
+		LevelRoot.MIN_BAKE_CHUNK_SIZE,
+		"a size below the minimum is still a size, so it floors"
+	)
+	root.bake_chunk_size = 64.0
+	assert_eq(root.bake_chunk_size, 64.0, "an ordinary size is untouched")
+
+
+func test_the_chunk_size_spin_and_the_level_agree_at_both_ends_of_its_range() -> void:
+	var root := _fresh_root()
+	var dock := _dock(root)
+	if not dock.bake_chunk_size_spin:
+		pass_test("no chunk size spin on this build")
+		return
+	var spin: SpinBox = dock.bake_chunk_size_spin
+	for value in [spin.min_value, 32.0, spin.max_value]:
+		spin.value = value
+		root.bake_chunk_size = spin.value
+		assert_eq(
+			root.bake_chunk_size,
+			spin.value,
+			"the spin reading %s must be the chunking the level does" % str(spin.value)
+		)
+
+
+# ---------------------------------------------------------------------------
+# Import Settings (#477, #478)
+# ---------------------------------------------------------------------------
+
+
+func test_select_alone_does_not_notify_so_the_import_has_to() -> void:
+	# The behaviour the connector-mode bug rests on, pinned here because the
+	# OptionButton page does not state it: item_selected is documented as emitted
+	# when the item is changed by the user.
+	var option := OptionButton.new()
+	add_child_autoqfree(option)
+	option.add_item("Ramp", 0)
+	option.add_item("Stairs", 1)
+	option.add_item("Auto", 2)
+	var seen: Array = []
+	option.item_selected.connect(func(index: int) -> void: seen.append(index))
+	option.select(2)
+	assert_eq(option.selected, 2, "select moves the dropdown")
+	assert_eq(seen, [], "and tells nobody, which is why the import cannot rely on it")
+
+
+func test_importing_a_connector_mode_writes_it_to_the_level() -> void:
+	var root := _fresh_root()
+	var dock := _dock(root)
+	if not dock.bake_connector_mode_opt:
+		pass_test("no connector mode dropdown on this build")
+		return
+	root.bake_connector_mode = 0
+	dock._apply_editor_settings({"bake": {"connector_mode": 2}})
+	assert_eq(dock.bake_connector_mode_opt.selected, 2, "the dropdown shows the imported mode")
+	assert_eq(root.bake_connector_mode, 2, "and the level bakes the mode the dropdown is showing")
+
+
+func test_an_out_of_range_grid_snap_leaves_the_dock_and_the_level_saying_the_same_thing() -> void:
+	var root := _fresh_root()
+	var dock := _dock(root)
+	dock._apply_editor_settings({"grid_snap": 4096.0})
+	assert_eq(
+		root.grid_snap,
+		dock.grid_snap.value,
+		"the level must snap to what the dock is showing, not to the number in the file"
+	)
+	assert_lte(root.grid_snap, dock.grid_snap.max_value, "and not past the control's own range")
+
+
+func test_a_setting_that_is_not_a_number_keeps_the_one_in_force() -> void:
+	var root := _fresh_root()
+	var dock := _dock(root)
+	dock._apply_grid_snap(16.0)
+	var before: float = root.grid_snap
+	# float("sixteen") is 0.0 in GDScript, so this used to turn snapping off and
+	# say nothing about it.
+	dock._apply_editor_settings({"grid_snap": "sixteen"})
+	assert_eq(root.grid_snap, before, "a word is not a snap, so the snap does not change")
+	assert_gt(root.grid_snap, 0.0, "and snapping is certainly not switched off")
+
+
+func test_a_setting_of_the_wrong_container_type_does_not_abort_the_import() -> void:
+	var root := _fresh_root()
+	var dock := _dock(root)
+	# int({}) raises at the cast, which took the rest of the block with it.
+	dock._apply_editor_settings(
+		{"bake": {"connector_width": {}, "navmesh": true, "occluder_min_area": 12.0}}
+	)
+	assert_true(
+		dock.bake_navmesh.button_pressed if dock.bake_navmesh else true,
+		"a bad value earlier in the block must not stop the ones after it landing"
+	)
+	if dock.bake_occluder_min_area_spin:
+		assert_eq(
+			dock.bake_occluder_min_area_spin.value,
+			12.0,
+			"the settings after the bad one are still applied"
+		)

--- a/tools/vibe/scenarios/dock_ranges.gd
+++ b/tools/vibe/scenarios/dock_ranges.gd
@@ -78,8 +78,7 @@ func _both_ends_of_every_spin() -> void:
 				)
 	note("bindings where the two ends disagree", disagreements.size())
 	if not disagreements.is_empty():
-		known(
-			481,
+		flag(
 			"dock spins offer values the level refuses, and go on showing them",
 			(
 				(

--- a/tools/vibe/scenarios/dock_settings.gd
+++ b/tools/vibe/scenarios/dock_settings.gd
@@ -71,8 +71,7 @@ func _the_round_trip() -> void:
 		int(other_dock.bake_connector_mode_opt.get_selected_id())
 		!= int(other.get("bake_connector_mode"))
 	):
-		known(
-			477,
+		flag(
 			"Import Settings leaves the connector mode on the dropdown only",
 			(
 				"_apply_editor_settings() calls OptionButton.select(), which by design does not"
@@ -102,8 +101,7 @@ func _values_the_dock_would_never_write() -> void:
 	note("after grid_snap 4096: spin shows", dock.grid_snap.value)
 	note("after grid_snap 4096: level holds", root.get("grid_snap"))
 	if not is_equal_approx(float(dock.grid_snap.value), float(root.get("grid_snap"))):
-		known(
-			478,
+		flag(
 			"Import Settings puts a grid snap on the level that the dock refuses to show",
 			(
 				(
@@ -128,8 +126,7 @@ func _values_the_dock_would_never_write() -> void:
 	await frame()
 	note('after grid_snap "sixteen": level holds', root.get("grid_snap"))
 	if is_zero_approx(float(root.get("grid_snap"))):
-		known(
-			478,
+		flag(
 			"A non-numeric grid snap silently becomes zero",
 			(
 				'float("sixteen") is 0.0 in GDScript, and nothing between the file and the'

--- a/tools/vibe/scenarios/settings.gd
+++ b/tools/vibe/scenarios/settings.gd
@@ -72,8 +72,7 @@ func _assigning_out_of_range_values() -> void:
 		root.set(key, before)
 	note("accepted out of %d" % OUT_OF_RANGE.size(), accepted.size())
 	if not accepted.is_empty():
-		known(
-			480,
+		flag(
 			(
 				"LevelRoot takes %d of %d out-of-range settings without a word"
 				% [accepted.size(), OUT_OF_RANGE.size()]
@@ -121,8 +120,7 @@ func _through_a_state_round_trip() -> void:
 		if HFVibe.canonical(got) == HFVibe.canonical(poisoned[key]):
 			landed.append("%s = %s" % [key, poisoned[key]])
 	if not landed.is_empty():
-		known(
-			480,
+		flag(
 			"apply_hflevel_settings writes a .hflevel's enum settings straight onto the property",
 			(
 				(


### PR DESCRIPTION
Four settings defects on the path from a file to a LevelRoot.

- `_apply_editor_settings()` cast every value it read with `float()`, `int()` or
  `bool()`. `float("sixteen")` is `0.0`, so a quoted number turned snapping off
  in silence, and `int({})` raises at the cast, so a value of the wrong container
  type aborted the rest of the block. All 26 reads go through validating readers
  that keep the setting in force and name the key, in the shape `HFUserPrefs` got
  in #423.
- `_apply_grid_snap()` wrote its argument to the level and the prefs file after
  the SpinBox had clamped it, so the dock read 128 while the level snapped to
  4096. It writes what the control ended up holding.
- `OptionButton.select()` does not emit `item_selected`, which was the only thing
  writing `bake_connector_mode`. The import goes through
  `_select_option_notifying()`. A test pins the `select()` behaviour, since the
  class reference does not state it either way.
- `bake_collision_mode` and `bake_connector_mode` get clamping setters. Both are
  three-value enums read with `match` or index arithmetic at bake time, and
  `@export_range` does not clamp an assignment from code.
- `bake_chunk_size` keeps 0 as the "off" the bake already reads and the dock spin
  already offers, instead of clamping it up to the finest chunking available.

Two assertions in `test_bake_and_grid_setting_bounds.gd` pinned the old chunk
clamp and are rewritten to state the invariant that replaces it, not relaxed.

The four vibe scenarios covering these keep their checks and fail on regression
now. Full suite: 3757 passing, 7 risky, 0 failing.

Fixes #477
Fixes #478
Fixes #480
Fixes #481
