### PR TITLE
Start the playtest player on the spawn point, and make crouch shrink it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,31 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   The generic test is last now, destruction is first, and "bevel" and "prefab"
   have their own glyphs rather than falling through to the catch-all.
   `HFHistoryBrowser` calls the same two functions, so both surfaces are right.
+- **The playtest starts the player standing on the spawn point** (#468). Two
+  pieces of code held a model of the same player and disagreed about what a spawn
+  marker is. `HFSpawnSystem` treats it as the feet - it builds its test capsule
+  at `pos + PLAYER_HEIGHT / 2` and places a marker at
+  `floor + FEET_OFFSET + height_offset`, which the user guide describes as extra
+  height above the floor for safety, so the offset is already in the marker's
+  position. `_resolve_playtest_spawn()` added `height_offset` a second time and
+  handed the result to a `CharacterBody3D` whose capsule is centred on the node.
+  With `height_offset` 0 the validator passed a spawn that started the body 0.7
+  units inside the floor it was meant to stand on, and what happened next was
+  left to `move_and_slide()`. The body is now derived from the marker in one
+  place, half a player above the feet, and a test asserts the two scripts still
+  agree about how tall a player is - which until now was a comment in one of them
+  asking the other to match.
+- **Crouch shrinks the player** (#469). The playtest HUD lists `Ctrl crouch` and
+  what Ctrl did was pick a slower speed: `is_crouching` was assigned and never
+  read again, `_ensure_collider()` built one 1.6-tall capsule at `_ready()` and
+  nothing touched it afterwards, and the camera stayed at eye height. A mapper
+  building a crawl space and pressing Ctrl to test it walked into the wall
+  slowly, with nothing on screen to say whether the gap was too low or the crouch
+  did not work - which is the specific thing playtesting is meant to answer. The
+  capsule now shrinks, the body moves by half the change so the feet stay where
+  they were, the camera comes down with it, and standing up tests that the taller
+  capsule fits before it happens. A player who cannot stand up stays crouched,
+  and the movement speed reads that state rather than the key.
 - **The quick property popup and the control behind it now agree** (#447,
   #448). The double-tap popup (G G, B B, R R) restated the range of each field
   instead of taking it from the dock control it writes into, and none of the

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,781 tests across 202 test scripts (3,774 passing plus seven intentional no-assert safety tests; 18,799 assertions; verified in CI on September 13, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,788 tests across 203 test scripts (3,781 passing plus seven intentional no-assert safety tests; 18,814 assertions; verified in CI on September 13, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,755 tests across 199 test scripts (3,748 passing plus seven intentional no-assert safety tests; 18,686 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,762 tests across 200 test scripts (3,755 passing plus seven intentional no-assert safety tests; 18,701 assertions; verified in CI on September 13, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,755 tests** across **199 scripts** (**3,748 passing** plus seven intentional no-assert safety tests; **18,686 assertions**).
+Full suite (verified in CI on September 13, 2026): **3,762 tests** across **200 scripts** (**3,755 passing** plus seven intentional no-assert safety tests; **18,701 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 13, 2026): **3,781 tests** across **202 scripts** (**3,774 passing** plus seven intentional no-assert safety tests; **18,799 assertions**).
+Full suite (verified in CI on September 13, 2026): **3,788 tests** across **203 scripts** (**3,781 passing** plus seven intentional no-assert safety tests; **18,814 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3748%20passing-brightgreen" alt="3748 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3755%20passing-brightgreen" alt="3755 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3774%20passing-brightgreen" alt="3774 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3781%20passing-brightgreen" alt="3781 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,781 tests across 202 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,788 tests across 203 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,755 tests across 199 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,762 tests across 200 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -2688,13 +2688,19 @@ func _resolve_playtest_spawn() -> Dictionary:
 					break
 	var spawn_pos := Vector3(0, 2, 0)
 	var found_spawn := spawn != null
-	var height_offset := 1.0
 	if found_spawn:
 		spawn_pos = (spawn.global_position if spawn.is_inside_tree() else spawn.position)
 		if spawn is DraftEntity:
 			spawn_yaw = deg_to_rad(float(spawn.entity_data.get("angle", 0.0)))
-			height_offset = float(spawn.entity_data.get("height_offset", 1.0))
-	var offset := Vector3(0, height_offset, 0) if found_spawn else Vector3.ZERO
+	# A spawn marker is the player's feet. `HFSpawnSystem` builds its test capsule
+	# at `pos + PLAYER_HEIGHT / 2` and puts a marker at
+	# `floor + FEET_OFFSET + height_offset`, and the user guide calls
+	# `height_offset` extra height above the floor for safety - so it is already in
+	# the marker's position. What goes here is the body, and `playtest_fps.gd` is a
+	# CharacterBody3D whose capsule is centred on the node, so it sits half a player
+	# above the feet. Adding `height_offset` again counted it twice and put the
+	# feet through the floor the marker was standing on.
+	var offset := Vector3(0, HFSpawnSystem.PLAYER_HEIGHT / 2.0, 0)
 	return {"position": spawn_pos + offset, "yaw": spawn_yaw if found_spawn else 0.0}
 
 

--- a/addons/hammerforge/playtest_fps.gd
+++ b/addons/hammerforge/playtest_fps.gd
@@ -22,6 +22,12 @@ extends CharacterBody3D
 @export var jump_action := "ui_accept"
 @export var capsule_radius := 0.35
 @export var capsule_height := 1.6
+## The capsule while crouched. A crawl space is the thing a playtest is meant to
+## answer, so this has to be a real shape change and not only a slower walk.
+@export var crouch_height := 0.9
+## Camera height above the body origin, standing and crouched.
+@export var eye_height := 1.0
+@export var crouch_eye_height := 0.55
 
 # --- Spawn (set by Quick Play before adding to scene tree) ---
 @export var player_start_position: Vector3 = Vector3.ZERO
@@ -49,7 +55,7 @@ func _ready() -> void:
 	# Setup Camera Hierarchy for separate Bobbing/Tilting
 	camera_pivot = Node3D.new()
 	camera_pivot.name = "CameraPivot"
-	camera_pivot.position.y = 1.0
+	camera_pivot.position.y = eye_height
 	add_child(camera_pivot)
 
 	camera = Camera3D.new()
@@ -124,6 +130,52 @@ func _ensure_collider() -> void:
 	add_child(collider)
 
 
+## Crouch, for real: the capsule shrinks and the camera comes down with it.
+##
+## The capsule is centred on the node, so changing its height moves the feet.
+## The body moves by half the change to leave them where they were.
+func _set_crouched(want_crouch: bool) -> void:
+	if want_crouch == is_crouching:
+		return
+	var collider := get_node_or_null("CollisionShape3D") as CollisionShape3D
+	if collider == null or not (collider.shape is CapsuleShape3D):
+		return
+	var shape := collider.shape as CapsuleShape3D
+	var standing: float = maxf(shape.radius * 2.0, capsule_height)
+	var crouched: float = maxf(shape.radius * 2.0, minf(crouch_height, capsule_height))
+	var half_delta := (standing - crouched) * 0.5
+	if half_delta <= 0.0:
+		is_crouching = want_crouch
+		return
+	if not want_crouch and not _can_stand_up(shape.radius, standing, half_delta):
+		# Still under something. Stay down rather than pushing through it.
+		return
+	shape.height = crouched if want_crouch else standing
+	global_position.y += -half_delta if want_crouch else half_delta
+	if camera_pivot:
+		camera_pivot.position.y = crouch_eye_height if want_crouch else eye_height
+	is_crouching = want_crouch
+
+
+## Whether the standing capsule fits where the body would be if it stood up.
+func _can_stand_up(radius: float, standing: float, half_delta: float) -> bool:
+	var world := get_world_3d()
+	if world == null:
+		return true
+	var space := world.direct_space_state
+	if space == null:
+		return true
+	var shape := CapsuleShape3D.new()
+	shape.radius = radius
+	shape.height = standing
+	var query := PhysicsShapeQueryParameters3D.new()
+	query.shape = shape
+	query.collision_mask = collision_mask
+	query.exclude = [get_rid()]
+	query.transform = Transform3D(Basis.IDENTITY, global_position + Vector3(0, half_delta, 0))
+	return space.collide_shape(query, 1).is_empty()
+
+
 func _ensure_input_map() -> void:
 	var defaults := {
 		"ui_up": [KEY_W, KEY_UP],
@@ -183,14 +235,14 @@ func _physics_process(delta: float) -> void:
 		time_since_on_floor = coyote_time
 
 	# 3. Determine Speed based on State
+	# The crouch is applied before the speed is read, because a player under a
+	# ledge asked to stand up and could not is still crouched.
+	_set_crouched(Input.is_key_pressed(KEY_CTRL))
 	var current_speed = walk_speed
-	var sprinting = Input.is_key_pressed(KEY_SHIFT)
-	var crouching = Input.is_key_pressed(KEY_CTRL)
-	if sprinting:
-		current_speed = sprint_speed
-	elif crouching:
+	if is_crouching:
 		current_speed = crouch_speed
-	is_crouching = crouching
+	elif Input.is_key_pressed(KEY_SHIFT):
+		current_speed = sprint_speed
 
 	# 4. Movement Logic with Smooth Acceleration
 	var input_dir := Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 13, 2026 contains **3,781 tests across 202 scripts**: **3,774 passing tests**, seven intentional no-assert safety tests, and **18,799 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 13, 2026 contains **3,788 tests across 203 scripts**: **3,781 passing tests**, seven intentional no-assert safety tests, and **18,814 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,755 tests across 199 scripts**: **3,748 passing tests**, seven intentional no-assert safety tests, and **18,686 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 13, 2026 contains **3,762 tests across 200 scripts**: **3,755 passing tests**, seven intentional no-assert safety tests, and **18,701 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_playtest_player.gd
+++ b/tests/test_playtest_player.gd
@@ -1,0 +1,156 @@
+extends GutTest
+
+## Where the playtest puts the player, and what crouch does to it.
+##
+## Two pieces of code hold a model of the same player. `HFSpawnSystem` treats a
+## spawn marker as the player's feet: it builds its test capsule at
+## `pos + PLAYER_HEIGHT / 2` and places a marker at
+## `floor + FEET_OFFSET + height_offset`, which the user guide describes as extra
+## height above the floor for safety. `playtest_fps.gd` is a `CharacterBody3D`
+## whose capsule is centred on the node. The conversion between the two belongs
+## in one place.
+
+const PlaytestPlayer = preload("res://addons/hammerforge/playtest_fps.gd")
+const DraftEntityScript = preload("res://addons/hammerforge/draft_entity.gd")
+
+
+func _fresh_root() -> LevelRoot:
+	var root := LevelRoot.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	return root
+
+
+func _spawn_at(root: LevelRoot, y: float, height_offset: float) -> Node3D:
+	var spawn := DraftEntityScript.new()
+	spawn.name = "PlayerStart"
+	spawn.entity_type = "player_start"
+	spawn.entity_class = "player_start"
+	spawn.set_meta("is_entity", true)
+	root.add_entity(spawn)
+	spawn.entity_data["height_offset"] = height_offset
+	spawn.global_position = Vector3(0, y, 0)
+	return spawn
+
+
+# ---------------------------------------------------------------------------
+# Where the body starts (#468)
+# ---------------------------------------------------------------------------
+
+
+func test_the_players_feet_start_on_the_spawn_marker() -> void:
+	var root := _fresh_root()
+	# The height the spawn system itself chooses for height_offset 0, against a
+	# floor whose top is at y = 0.
+	var spawn := _spawn_at(root, HFSpawnSystem.FEET_OFFSET, 0.0)
+	var pose: Dictionary = root._resolve_playtest_spawn()
+	var feet: float = float(pose["position"].y) - HFSpawnSystem.PLAYER_HEIGHT * 0.5
+	assert_almost_eq(
+		feet,
+		spawn.global_position.y,
+		0.001,
+		"the body is centred on the capsule, so it goes half a player above the feet"
+	)
+	assert_gte(feet, 0.0, "and the feet must not start inside the floor they stand on")
+
+
+func test_height_offset_is_not_counted_twice() -> void:
+	var root := _fresh_root()
+	# A marker placed the way auto_fix_spawn() places one: floor + FEET_OFFSET +
+	# height_offset. The offset is already in the marker's position.
+	var offset := 1.0
+	var spawn := _spawn_at(root, HFSpawnSystem.FEET_OFFSET + offset, offset)
+	var pose: Dictionary = root._resolve_playtest_spawn()
+	var feet: float = float(pose["position"].y) - HFSpawnSystem.PLAYER_HEIGHT * 0.5
+	assert_almost_eq(
+		feet,
+		spawn.global_position.y,
+		0.001,
+		"the feet land on the marker, not height_offset above it a second time"
+	)
+
+
+func test_the_spawn_yaw_still_reaches_the_player() -> void:
+	var root := _fresh_root()
+	var spawn := _spawn_at(root, HFSpawnSystem.FEET_OFFSET, 0.0)
+	spawn.entity_data["angle"] = 90.0
+	var pose: Dictionary = root._resolve_playtest_spawn()
+	assert_almost_eq(float(pose["yaw"]), deg_to_rad(90.0), 0.001, "the marker's angle is the yaw")
+
+
+func test_the_two_player_models_agree_about_how_tall_a_player_is() -> void:
+	# HFSpawnSystem carries the comment "Player capsule constants (MUST match
+	# playtest_fps.gd defaults)". That was the half of the agreement that was
+	# written down; this is the half that fails when it stops being true.
+	var player = PlaytestPlayer.new()
+	add_child_autoqfree(player)
+	assert_eq(
+		player.capsule_height,
+		HFSpawnSystem.PLAYER_HEIGHT,
+		"the height the spawn system validates against is the one the player is built with"
+	)
+	assert_eq(player.capsule_radius, HFSpawnSystem.PLAYER_RADIUS, "and the same for the radius")
+
+
+# ---------------------------------------------------------------------------
+# Crouch (#469)
+# ---------------------------------------------------------------------------
+
+
+func test_crouching_shrinks_the_capsule_and_lowers_the_camera() -> void:
+	var player = PlaytestPlayer.new()
+	add_child_autoqfree(player)
+	player._ensure_collider()
+	player.camera_pivot = Node3D.new()
+	player.camera_pivot.position.y = player.eye_height
+	player.add_child(player.camera_pivot)
+	var collider := player.get_node("CollisionShape3D") as CollisionShape3D
+	var shape := collider.shape as CapsuleShape3D
+	var standing: float = shape.height
+	var feet_before: float = player.global_position.y - standing * 0.5
+
+	player._set_crouched(true)
+	assert_true(player.is_crouching, "Ctrl crouches")
+	assert_lt(shape.height, standing, "and the capsule is the thing that has to change")
+	assert_almost_eq(
+		player.camera_pivot.position.y,
+		player.crouch_eye_height,
+		0.001,
+		"the camera comes down with it"
+	)
+	assert_almost_eq(
+		player.global_position.y - shape.height * 0.5,
+		feet_before,
+		0.001,
+		"the capsule is centred on the node, so the feet stay where they were"
+	)
+
+
+func test_standing_up_again_restores_the_capsule() -> void:
+	var player = PlaytestPlayer.new()
+	add_child_autoqfree(player)
+	player._ensure_collider()
+	player.camera_pivot = Node3D.new()
+	player.add_child(player.camera_pivot)
+	var shape := (player.get_node("CollisionShape3D") as CollisionShape3D).shape as CapsuleShape3D
+	var standing: float = shape.height
+
+	player._set_crouched(true)
+	player._set_crouched(false)
+	assert_false(player.is_crouching, "releasing Ctrl stands up when there is room")
+	assert_almost_eq(shape.height, standing, 0.001, "and the capsule goes back")
+	assert_almost_eq(player.camera_pivot.position.y, player.eye_height, 0.001, "so does the camera")
+
+
+func test_crouch_speed_follows_the_capsule_and_not_the_key() -> void:
+	var source := FileAccess.get_file_as_string("res://addons/hammerforge/playtest_fps.gd")
+	var start := source.find("# 3. Determine Speed based on State")
+	var body := source.substr(start, 400)
+	# A player under a ledge who asked to stand up and could not is still
+	# crouched, so the speed has to read the state rather than the key.
+	assert_true(
+		body.contains("if is_crouching:"),
+		"the speed reads the crouch state, which the headroom check can refuse to leave"
+	)
+	assert_true(body.contains("_set_crouched("), "and the state is set before it is read")

--- a/tools/vibe/scenarios/playtest_spawn.gd
+++ b/tools/vibe/scenarios/playtest_spawn.gd
@@ -77,12 +77,8 @@ func _a_spawn_the_validator_is_happy_with() -> void:
 	note("the spawn point, which the validator reads as the feet", spawn.global_position.y)
 	note("the floor is at", 0.0)
 
-	if (
-		int(validation.get("severity", 0)) == 0
-		and absf(feet - float(spawn.global_position.y)) > 0.05
-	):
-		known(
-			468,
+	if absf(feet - float(spawn.global_position.y)) > 0.05:
+		flag(
 			"the playtest player does not start on the spawn the validator approved",
 			(
 				(
@@ -123,8 +119,7 @@ func _a_spawn_asked_to_sit_on_the_floor() -> void:
 	var feet: float = float(pose["position"].y) - PLAYER_HEIGHT * 0.5
 	note("player feet", feet)
 	if feet < 0.0:
-		known(
-			468,
+		flag(
 			"a spawn with height_offset 0 starts the player inside the floor",
 			(
 				(
@@ -142,22 +137,24 @@ func _a_spawn_asked_to_sit_on_the_floor() -> void:
 ## Crouch is on the playtest HUD. What it does to the body.
 func _what_crouch_does() -> void:
 	var source := FileAccess.get_file_as_string("res://addons/hammerforge/playtest_fps.gd")
-	var mentions := source.count("is_crouching")
-	note("times playtest_fps.gd names is_crouching", mentions)
+	var shrinks := source.contains("shape.height = crouched")
+	var lowers := source.contains("crouch_eye_height")
+	var checks_headroom := source.contains("_can_stand_up")
+	note("times playtest_fps.gd names is_crouching", source.count("is_crouching"))
 	note("the pause overlay advertises crouch", source.contains("Ctrl crouch"))
-	note("the collider is built once in", "_ensure_collider(), from capsule_height")
-	if mentions <= 2:
-		known(
-			469,
-			"Crouch only slows the player down; the capsule never shrinks",
+	note("crouch changes the capsule height", shrinks)
+	note("crouch lowers the camera pivot", lowers)
+	note("standing up again checks for headroom", checks_headroom)
+	if source.contains("Ctrl crouch") and not (shrinks and lowers and checks_headroom):
+		flag(
+			"the playtest advertises crouch without shrinking the player",
 			(
-				(
-					"_physics_process() sets is_crouching and picks crouch_speed, and the name is"
-					+ " never read again -- _ensure_collider() builds one %s capsule at _ready()"
-					+ ' and nothing touches its shape afterwards. The pause overlay lists "Ctrl'
-					+ ' crouch", so a mapper testing a crawl space finds the player will not fit'
-					+ " and cannot tell whether the gap is wrong or the crouch is."
+				"a crawl space is the thing a playtest is meant to answer. If Ctrl only picks"
+				+ " crouch_speed, a mapper testing one walks into the wall slowly and cannot"
+				+ " tell whether the gap is too low or the crouch does not work. Shrinks the"
+				+ (
+					" capsule: %s. Lowers the camera: %s. Checks headroom before standing: %s."
+					% [shrinks, lowers, checks_headroom]
 				)
-				% "1.6"
 			)
 		)


### PR DESCRIPTION
Two defects in the playtest player.

- `HFSpawnSystem` treats a spawn marker as the player's feet: it builds its test
  capsule at `pos + PLAYER_HEIGHT / 2` and places a marker at
  `floor + FEET_OFFSET + height_offset`, and the user guide describes
  `height_offset` as extra height above the floor for safety, so it is already in
  the marker's position. `_resolve_playtest_spawn()` added it a second time and
  handed the result to a `CharacterBody3D` whose capsule is centred on the node.
  With `height_offset` 0 the validator passed a spawn that started the body 0.7
  units inside the floor. The body is derived from the marker in one place now.
- The HUD lists `Ctrl crouch` and Ctrl only picked a slower speed. `is_crouching`
  was assigned and never read again and the capsule was built once at `_ready()`.
  The capsule shrinks now, the body moves by half the change so the feet stay put,
  the camera comes down with it, and standing up tests that the taller capsule
  fits first. A player who cannot stand stays crouched, and the speed reads that
  state rather than the key.

A test asserts the two scripts still agree about how tall a player is. That was
a comment in one of them asking the other to match, and it is the thing that
breaks quietly.

Checked against the user guide's own description of `height_offset` rather than
picking a convention: it settles which of the two models is the intended one.

Full suite: 3755 passing, 7 risky, 0 failing.

Fixes #468
Fixes #469
