### PR TITLE
Build a round brush from its sides, and project a new face on its own axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,38 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   now all give the schema's. A value that is not a number is refused and the
   previous one kept. `_build_segment_brush()` also refuses a non-positive width
   or height outright rather than building a ring from it.
+- **Every face of a new brush can show a texture** (#463).
+  `FaceData.uv_projection` defaulted to `PLANAR_Z`, which maps `(x, y)` to
+  `(u, v)`: on a face whose plane contains the Z axis, or one lying flat in Y,
+  one UV axis is constant across the whole face and every point on it samples the
+  same row of texels. That was four of a box's six faces, three of a wedge's five
+  and one of a pyramid's, on the baked mesh as well as the preview, with the
+  dock's "Apply + Re-project (Box UV)" there to correct the default by hand a
+  face at a time. A new face uses `BOX_UV`, which resolves to its own dominant
+  normal axis. Texture lock reads the same field and was the second casualty -
+  `adjust_uvs_for_rotation()` declines any face whose projection plane the turn
+  takes away, which under `PLANAR_Z` was every face of a default box under a yaw,
+  so a rotate with texture lock on changed nothing at all.
+  `_transfer_face_data()` carries the projection across a rebuild, so a saved
+  level keeps whatever it was saved with.
+- **A cylinder cap can show a texture too** (#463). The caps were not falling
+  back to the projection as the rest did: `_face_from_ids()` carries the source
+  mesh's UVs across when every vertex has one, and `CylinderMesh` maps both caps
+  onto a *line* - every vertex of the top cap at `v = 0` and every vertex of the
+  bottom at `v = 0.5`. Source UVs that span no area are refused now, because the
+  projection is a far better map than one that cannot be seen.
+- **A cylinder or a cone is built from the sides it was given** (#482).
+  `radial_segments` was never set, so both stayed at Godot's default of 64
+  whatever `sides` said - and `sides` is part of a brush: the `.hflevel` carries
+  it, a preset stores it and `HFDuplicator.shape_signature()` counts it, so two
+  brushes that differed only in `sides` were identical geometry with different
+  signatures. The preview also disagreed with the bake, which builds its CSG
+  through `PrefabFactory` and has always used 16. Below `MIN_ROUND_SIDES` the
+  number is not honoured and the default is used instead: `sides` is 4 on every
+  brush the Build tab makes and on every cylinder in a level saved before this,
+  and the editor has PRISM_TRI and PRISM_PENT for the low counts, so a round
+  shape is not how you ask for one. A greybox cylinder is 18 faces after the
+  coplanar merge now rather than 66.
 - **The region memory budget now counts what it actually freed** (#446).
   `_unload_region()` is careful: it refuses to throw a region's chunks away if
   they could not be written to disk first, and says so. `_evict_for_budget()`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,788 tests across 203 test scripts (3,781 passing plus seven intentional no-assert safety tests; 18,814 assertions; verified in CI on September 13, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,796 tests across 204 test scripts (3,789 passing plus seven intentional no-assert safety tests; 18,842 assertions; verified in CI on September 13, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,755 tests across 199 test scripts (3,748 passing plus seven intentional no-assert safety tests; 18,686 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,763 tests across 200 test scripts (3,756 passing plus seven intentional no-assert safety tests; 18,714 assertions; verified in CI on September 13, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 13, 2026): **3,788 tests** across **203 scripts** (**3,781 passing** plus seven intentional no-assert safety tests; **18,814 assertions**).
+Full suite (verified in CI on September 13, 2026): **3,796 tests** across **204 scripts** (**3,789 passing** plus seven intentional no-assert safety tests; **18,842 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,755 tests** across **199 scripts** (**3,748 passing** plus seven intentional no-assert safety tests; **18,686 assertions**).
+Full suite (verified in CI on September 13, 2026): **3,763 tests** across **200 scripts** (**3,756 passing** plus seven intentional no-assert safety tests; **18,714 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3781%20passing-brightgreen" alt="3781 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3789%20passing-brightgreen" alt="3789 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3748%20passing-brightgreen" alt="3748 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3756%20passing-brightgreen" alt="3756 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,788 tests across 203 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,796 tests across 204 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,755 tests across 199 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,763 tests across 200 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/brush_instance.gd
+++ b/addons/hammerforge/brush_instance.gd
@@ -355,6 +355,28 @@ func _transfer_face_data(old_faces: Array, new_faces: Array) -> void:
 		new_face.displacement = old_face.displacement
 
 
+## How many segments a round shape is actually built from.
+##
+## `sides` is part of a brush - the `.hflevel` carries it, a preset stores it and
+## `HFDuplicator.shape_signature()` counts it - but a cylinder was built from
+## Godot's `radial_segments` default of 64 and ignored it, so two brushes that
+## differed only in `sides` were identical geometry with different signatures.
+##
+## Below `MIN_ROUND_SIDES` the number is not honoured, for two reasons. `sides`
+## defaults to 4 and the Build tab only offers the Sides row for a pyramid, so
+## every cylinder drawn in the editor and every one in a level saved before this
+## carries 4 - and a four-sided cylinder is a box. The editor also has PRISM_TRI
+## and PRISM_PENT for the low counts, so a round shape is not how you ask for
+## one. 16 is what `PrefabFactory` has always built a cylinder from, which is
+## what the bake already produces: the preview was the odd one out at 64.
+const DEFAULT_ROUND_SIDES := 16
+const MIN_ROUND_SIDES := 5
+
+
+static func round_sides(sides_value: int) -> int:
+	return sides_value if sides_value >= MIN_ROUND_SIDES else DEFAULT_ROUND_SIDES
+
+
 func _build_base_mesh() -> Dictionary:
 	var mesh: Mesh = null
 	var mesh_scale := Vector3.ONE
@@ -369,12 +391,14 @@ func _build_base_mesh() -> Dictionary:
 			var radius = max(size.x, size.z) * 0.5
 			cyl.top_radius = radius
 			cyl.bottom_radius = radius
+			cyl.radial_segments = round_sides(sides)
 			mesh = cyl
 		BrushShape.CONE:
 			var cone = CylinderMesh.new()
 			cone.height = size.y
 			cone.bottom_radius = max(size.x, size.z) * 0.5
 			cone.top_radius = 0.0
+			cone.radial_segments = round_sides(sides)
 			mesh = cone
 		BrushShape.WEDGE:
 			mesh = _build_wedge_mesh()
@@ -820,9 +844,30 @@ func _face_from_ids(ids: PackedInt32Array, point_of: Array[Vector3], uv_of: Dict
 				face_uvs = PackedVector2Array()
 				break
 			face_uvs.append(uv_of[id])
+		# A source mesh can hand back UVs that span no area. CylinderMesh maps both
+		# caps onto a line - every vertex of the top cap sits at v = 0 and every
+		# vertex of the bottom at v = 0.5 - so a face carrying them samples one row
+		# of texels however it is textured. The projection is a worse map than a
+		# good source UV and a much better one than that, so it is used instead.
+		if _uvs_span_no_area(face_uvs):
+			face_uvs = PackedVector2Array()
 		face.custom_uvs = face_uvs
 	face.ensure_geometry()
 	return face
+
+
+## Whether a UV loop is flat in one axis, so nothing mapped through it is visible.
+static func _uvs_span_no_area(uvs: PackedVector2Array) -> bool:
+	if uvs.size() < 3:
+		return false
+	var lo: Vector2 = uvs[0]
+	var hi: Vector2 = uvs[0]
+	for uv in uvs:
+		lo.x = minf(lo.x, uv.x)
+		lo.y = minf(lo.y, uv.y)
+		hi.x = maxf(hi.x, uv.x)
+		hi.y = maxf(hi.y, uv.y)
+	return (hi.x - lo.x) < 0.0001 or (hi.y - lo.y) < 0.0001
 
 
 func _build_box_faces() -> Array[FaceData]:

--- a/addons/hammerforge/face_data.gd
+++ b/addons/hammerforge/face_data.gd
@@ -25,7 +25,14 @@ class PaintLayer:
 
 
 @export var material_idx: int = -1
-@export var uv_projection: int = UVProjection.PLANAR_Z
+## PLANAR_Z maps (x, y) -> (u, v), so on a face whose plane contains the Z axis,
+## or one lying flat in Y, one UV axis is constant across the whole face and every
+## point on it samples the same line of the texture: four of a box's six faces.
+## BOX_UV resolves to the dominant normal axis per face, which is the answer the
+## dock's "Apply + Re-project (Box UV)" button already applies by hand.
+## `_transfer_face_data()` carries this across a rebuild, so a saved level keeps
+## whatever it was saved with.
+@export var uv_projection: int = UVProjection.BOX_UV
 @export var uv_scale: Vector2 = Vector2.ONE
 @export var uv_offset: Vector2 = Vector2.ZERO
 @export var uv_rotation: float = 0.0

--- a/addons/hammerforge/prefab_factory.gd
+++ b/addons/hammerforge/prefab_factory.gd
@@ -13,7 +13,7 @@ static func create_prefab(type: int, size: Vector3, sides: int = 4) -> CSGShape3
 			var cylinder = CSGCylinder3D.new()
 			cylinder.height = size.y
 			cylinder.radius = max(size.x, size.z) * 0.5
-			cylinder.sides = 16
+			cylinder.sides = DraftBrush.round_sides(sides)
 			brush = cylinder
 		LevelRootType.BrushShape.SPHERE, LevelRootType.BrushShape.ELLIPSOID:
 			var sphere = CSGSphere3D.new()
@@ -33,7 +33,7 @@ static func create_prefab(type: int, size: Vector3, sides: int = 4) -> CSGShape3
 			cone.cone = true
 			cone.height = size.y
 			cone.radius = max(size.x, size.z) * 0.5
-			cone.sides = 16
+			cone.sides = DraftBrush.round_sides(sides)
 			brush = cone
 		LevelRootType.BrushShape.PYRAMID:
 			var pyramid_mesh = _pyramid_mesh(size, safe_sides)

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 13, 2026 contains **3,788 tests across 203 scripts**: **3,781 passing tests**, seven intentional no-assert safety tests, and **18,814 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 13, 2026 contains **3,796 tests across 204 scripts**: **3,789 passing tests**, seven intentional no-assert safety tests, and **18,842 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,755 tests across 199 scripts**: **3,748 passing tests**, seven intentional no-assert safety tests, and **18,686 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 13, 2026 contains **3,763 tests across 200 scripts**: **3,756 passing tests**, seven intentional no-assert safety tests, and **18,714 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_brush_shape_defaults.gd
+++ b/tests/test_brush_shape_defaults.gd
@@ -1,0 +1,157 @@
+extends GutTest
+
+## What a brush is actually built from when nobody has said otherwise.
+##
+## Two defaults that did not describe the shape they were on: a round brush was
+## built from Godot's `radial_segments` rather than the `sides` it carries, and
+## every new face projected its UVs on Z whatever direction it faced.
+
+
+func _fresh_root() -> LevelRoot:
+	var root := LevelRoot.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	return root
+
+
+func _brush(root: LevelRoot, shape: int, sides: int = -1) -> Node:
+	var info := {"shape": shape, "size": Vector3(128, 64, 32)}
+	if sides >= 0:
+		info["sides"] = sides
+	return root.create_brush_from_info(info)
+
+
+## The area a face's triangles cover in UV space. A face with world area and no
+## UV area samples one row of texels, which is what "smeared" means.
+func _uv_area(face: FaceData) -> float:
+	var tri: Dictionary = face.triangulate()
+	var verts: PackedVector3Array = tri.get("verts", PackedVector3Array())
+	var uvs: PackedVector2Array = tri.get("uvs", PackedVector2Array())
+	if verts.size() < 3 or uvs.size() != verts.size():
+		return 0.0
+	var area := 0.0
+	for t in range(verts.size() / 3):
+		var i := t * 3
+		var a: Vector2 = uvs[i + 1] - uvs[i]
+		var b: Vector2 = uvs[i + 2] - uvs[i]
+		area += 0.5 * absf(a.x * b.y - a.y * b.x)
+	return area
+
+
+# ---------------------------------------------------------------------------
+# Round shapes are built from their sides (#482)
+# ---------------------------------------------------------------------------
+
+
+func test_a_cylinder_is_built_from_the_sides_it_was_given() -> void:
+	var root := _fresh_root()
+	# Faces after the coplanar merge: one per side, plus the two caps.
+	for sides in [6, 8, 12, 16]:
+		var brush = _brush(root, LevelRoot.BrushShape.CYLINDER, sides)
+		assert_eq(brush.sides, sides, "the brush stores what it was asked for")
+		assert_eq(
+			brush.get_faces().size(),
+			sides + 2,
+			"a %d-sided cylinder is %d side faces and two caps" % [sides, sides]
+		)
+
+
+func test_a_cone_is_built_from_the_sides_it_was_given() -> void:
+	var root := _fresh_root()
+	var eight = _brush(root, LevelRoot.BrushShape.CONE, 8)
+	var sixteen = _brush(root, LevelRoot.BrushShape.CONE, 16)
+	assert_lt(
+		eight.get_faces().size(),
+		sixteen.get_faces().size(),
+		"a cone with fewer sides is fewer faces, rather than a 64-gon either way"
+	)
+
+
+func test_a_round_shape_below_the_minimum_uses_the_default() -> void:
+	var root := _fresh_root()
+	# `sides` is 4 on every brush the Build tab makes, and on every cylinder in a
+	# level saved before this was honoured, so a low number there is not a request
+	# for a square prism - the editor has PRISM_TRI and PRISM_PENT for those.
+	var default_built = _brush(root, LevelRoot.BrushShape.CYLINDER, 4)
+	assert_eq(
+		default_built.get_faces().size(),
+		DraftBrush.DEFAULT_ROUND_SIDES + 2,
+		"a cylinder carrying the generic default is built round, not square"
+	)
+	assert_eq(DraftBrush.round_sides(4), DraftBrush.DEFAULT_ROUND_SIDES)
+	assert_eq(DraftBrush.round_sides(3), DraftBrush.DEFAULT_ROUND_SIDES)
+	assert_eq(DraftBrush.round_sides(8), 8, "a count a round shape could have meant is kept")
+
+
+func test_the_preview_and_the_bake_build_a_cylinder_the_same_way() -> void:
+	var root := _fresh_root()
+	var brush = _brush(root, LevelRoot.BrushShape.CYLINDER, 12)
+	var csg := PrefabFactory.create_prefab(
+		LevelRoot.BrushShape.CYLINDER, brush.size, max(3, brush.sides)
+	)
+	assert_not_null(csg, "the bake builds its CSG through PrefabFactory")
+	assert_eq(
+		csg.sides, brush.sides, "the shape the bake produces is the one the mapper was looking at"
+	)
+
+
+# ---------------------------------------------------------------------------
+# A new face projects on its own axis (#463)
+# ---------------------------------------------------------------------------
+
+
+func test_a_new_face_projects_on_its_dominant_normal_axis() -> void:
+	assert_eq(
+		FaceData.new().uv_projection,
+		FaceData.UVProjection.BOX_UV,
+		"PLANAR_Z leaves one UV axis constant on any face that contains the Z axis"
+	)
+
+
+func test_every_face_of_a_new_brush_can_show_a_texture() -> void:
+	var root := _fresh_root()
+	var shapes := {
+		"box": LevelRoot.BrushShape.BOX,
+		"cylinder": LevelRoot.BrushShape.CYLINDER,
+		"wedge": LevelRoot.BrushShape.WEDGE,
+		"pyramid": LevelRoot.BrushShape.PYRAMID,
+	}
+	for label in shapes:
+		var brush = _brush(root, shapes[label])
+		for index in range(brush.get_faces().size()):
+			assert_gt(
+				_uv_area(brush.get_faces()[index]),
+				0.0001,
+				"%s face %d has UVs that cannot show a texture" % [label, index]
+			)
+
+
+func test_source_uvs_that_span_no_area_are_refused() -> void:
+	var root := _fresh_root()
+	# CylinderMesh maps both caps onto a line: every vertex of the top cap sits at
+	# v = 0 and every vertex of the bottom at v = 0.5. Carried over, that face
+	# samples one row of texels however it is textured.
+	var brush = _brush(root, LevelRoot.BrushShape.CYLINDER, 16)
+	var faces: Array = brush.get_faces()
+	var caps := 0
+	for face in faces:
+		if absf(face.normal.y) > 0.99:
+			caps += 1
+			assert_eq(
+				face.custom_uvs.size(),
+				0,
+				"a cap falls back to its projection rather than keeping a flat source UV"
+			)
+			assert_gt(_uv_area(face), 0.0001, "so the cap can show a texture")
+	assert_eq(caps, 2, "a cylinder has two caps to check")
+
+
+func test_texture_lock_compensates_a_face_of_a_brush_nobody_reprojected() -> void:
+	var root := _fresh_root()
+	var brush = _brush(root, LevelRoot.BrushShape.BOX)
+	var top: FaceData = brush.get_faces()[2]
+	assert_true(
+		top.adjust_uvs_for_rotation(Basis(Vector3.UP, deg_to_rad(90.0))),
+		"a projection that does not contain the face cannot be world locked at all"
+	)

--- a/tests/test_brush_shapes.gd
+++ b/tests/test_brush_shapes.gd
@@ -918,9 +918,19 @@ func _face_count(shape_id: int, size: Vector3) -> int:
 
 
 func test_a_cylinder_is_its_sides_plus_two_caps_not_a_face_per_triangle():
-	# CylinderMesh uses 64 radial segments, so the real face count is 66. It was
-	# 768: every cap wedge and every side triangle was its own FaceData.
-	assert_eq(_face_count(DraftBrush.BrushShape.CYLINDER, Vector3(64, 64, 64)), 66)
+	# It was 768: every cap wedge and every side triangle was its own FaceData.
+	# The segment count is the brush's own `sides` now rather than CylinderMesh's
+	# default of 64, so the answer is stated in terms of what was asked for.
+	brush.sides = 12
+	assert_eq(_face_count(DraftBrush.BrushShape.CYLINDER, Vector3(64, 64, 64)), 14)
+	brush.sides = 24
+	assert_eq(_face_count(DraftBrush.BrushShape.CYLINDER, Vector3(64, 64, 64)), 26)
+	brush.sides = 4
+	assert_eq(
+		_face_count(DraftBrush.BrushShape.CYLINDER, Vector3(64, 64, 64)),
+		DraftBrush.DEFAULT_ROUND_SIDES + 2,
+		"a count below the minimum for a round shape uses the default"
+	)
 
 
 func test_the_flat_primitives_collapse_to_their_real_face_counts():
@@ -951,12 +961,13 @@ func test_a_merged_dodecahedron_face_is_a_pentagon():
 
 
 func test_a_merged_cylinder_cap_keeps_every_rim_point():
+	brush.sides = 20
 	_face_count(DraftBrush.BrushShape.CYLINDER, Vector3(64, 64, 64))
 	var caps := 0
 	for face in brush.faces:
 		if absf(face.normal.y) > 0.99:
 			caps += 1
-			assert_eq(face.local_verts.size(), 64, "A cap is the whole rim, not a fan wedge")
+			assert_eq(face.local_verts.size(), 20, "A cap is the whole rim, not a fan wedge")
 	assert_eq(caps, 2, "A cylinder has two caps")
 
 

--- a/tests/test_face_data.gd
+++ b/tests/test_face_data.gd
@@ -80,7 +80,7 @@ func test_round_trip_default_values():
 	var data = face.to_dict()
 	var restored = FaceData.from_dict(data)
 	assert_eq(restored.material_idx, -1, "Default material_idx")
-	assert_eq(restored.uv_projection, FaceData.UVProjection.PLANAR_Z, "Default uv_projection")
+	assert_eq(restored.uv_projection, FaceData.UVProjection.BOX_UV, "Default uv_projection")
 	assert_almost_eq(restored.uv_scale.x, 1.0, 0.001, "Default uv_scale.x")
 	assert_almost_eq(restored.uv_offset.x, 0.0, 0.001, "Default uv_offset.x")
 	assert_almost_eq(restored.uv_rotation, 0.0, 0.001, "Default uv_rotation")

--- a/tests/test_snap_system.gd
+++ b/tests/test_snap_system.gd
@@ -475,11 +475,15 @@ func test_tessellated_primitive_falls_back_to_its_bounding_box():
 	snap.set_mode(HFSnapSystem.SnapMode.VERTEX, true)
 	snap.set_mode(HFSnapSystem.SnapMode.GRID, false)
 	var b := _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "cyl")
+	# A cylinder is built from its own `sides` now, so it is only past the snap
+	# budget when it was asked to be. The fallback is what this is about, so the
+	# brush is given enough segments to need it.
+	b.sides = 96
 	b.shape = DraftBrush.BrushShape.CYLINDER
 	assert_gt(
 		b.faces.size(),
 		HFSnapSystem.MAX_SNAP_FACES,
-		"A cylinder carries one face per triangle, which is what the cap is for"
+		"A brush past the snap budget is what the bounding box fallback is for"
 	)
 
 	assert_eq(
@@ -493,6 +497,7 @@ func test_bounding_box_fallback_still_follows_rotation():
 	snap.set_mode(HFSnapSystem.SnapMode.VERTEX, true)
 	snap.set_mode(HFSnapSystem.SnapMode.GRID, false)
 	var b := _make_brush(Vector3.ZERO, Vector3(32, 32, 32), "cyl_rot")
+	b.sides = 96
 	b.shape = DraftBrush.BrushShape.CYLINDER
 	b.rotation = Vector3(0, deg_to_rad(45.0), 0)
 	var rotated_corner: Vector3 = b.global_transform * Vector3(16, 16, 16)

--- a/tests/test_transform_system.gd
+++ b/tests/test_transform_system.gd
@@ -867,5 +867,19 @@ func test_four_quarter_turns_leave_the_faces_as_they_were():
 		before.append(face.to_dict())
 	for _i in 4:
 		sys.rotate([b.brush_id], [], 1, deg_to_rad(90.0), Vector3.ZERO)
+	# A new face projects on its own dominant axis, so the lock now actually
+	# compensates these turns rather than declining them: under PLANAR_Z a yaw
+	# took the projection plane away from four of the six faces and the face was
+	# left alone, which made an exact comparison pass by doing nothing. The turn
+	# is read back out of a Basis, so four of them compose to within float
+	# precision of where they started rather than to the same bits.
 	for i in b.get_faces().size():
-		assert_eq(b.get_faces()[i].to_dict(), before[i], "face %d drifted" % i)
+		var after: Dictionary = b.get_faces()[i].to_dict()
+		var was: Dictionary = before[i]
+		for key in was:
+			if was[key] is float:
+				assert_almost_eq(
+					float(after[key]), float(was[key]), 0.0001, "face %d drifted in %s" % [i, key]
+				)
+			else:
+				assert_eq(after[key], was[key], "face %d drifted in %s" % [i, key])

--- a/tests/test_viewport_outlines.gd
+++ b/tests/test_viewport_outlines.gd
@@ -1004,16 +1004,23 @@ func test_resize_commit_replays_original_to_final_for_one_texture_lock_adjustmen
 	var brush: DraftBrush = fixture.brush
 	var previous_size := brush.size
 	var previous_position := brush.global_position
-	var original_uv_scale := brush.faces[0].uv_scale
-	var original_uv_offset := brush.faces[0].uv_offset
+	# The top face. Setting `size` rebuilds the faces from the base mesh, so the
+	# one the fixture hand-built is gone by here and these are box faces carrying
+	# the default projection. A new face projects on its own dominant normal axis,
+	# so the top face is the one whose projection reads world X, which is what the
+	# arithmetic below is about. Face 0 is the +X face: its projection reads Z and
+	# Y, and an X resize correctly leaves it alone.
+	var top := 2
+	var original_uv_scale := brush.faces[top].uv_scale
+	var original_uv_offset := brush.faces[top].uv_offset
 	var final_size := Vector3(64, 32, 32)
 	var final_position := Vector3(16, 0, 0)
 
 	# Match _set_handle(): preview changes geometry only and leaves UVs alone.
 	brush.size = final_size
 	brush.global_position = final_position
-	assert_eq(brush.faces[0].uv_scale, original_uv_scale)
-	assert_eq(brush.faces[0].uv_offset, original_uv_offset)
+	assert_eq(brush.faces[top].uv_scale, original_uv_scale)
+	assert_eq(brush.faces[top].uv_offset, original_uv_offset)
 
 	assert_true(
 		(
@@ -1033,9 +1040,9 @@ func test_resize_commit_replays_original_to_final_for_one_texture_lock_adjustmen
 	assert_true(root.dirty_brush_ids.has(brush.brush_id))
 	# PLANAR_Y maps world X/Z. Doubling X size halves U scale, while
 	# moving the center +16 subtracts 16 * the original U scale once.
-	assert_eq(brush.faces[0].uv_scale, Vector2(original_uv_scale.x * 0.5, original_uv_scale.y))
+	assert_eq(brush.faces[top].uv_scale, Vector2(original_uv_scale.x * 0.5, original_uv_scale.y))
 	assert_eq(
-		brush.faces[0].uv_offset,
+		brush.faces[top].uv_offset,
 		Vector2(original_uv_offset.x - 16.0 * original_uv_scale.x, original_uv_offset.y),
 	)
 

--- a/tools/vibe/scenarios/brush_sides.gd
+++ b/tools/vibe/scenarios/brush_sides.gd
@@ -62,13 +62,16 @@ func _sides_on_every_round_shape() -> void:
 				)
 			)
 			counts.append(int(made["faces"]))
+			# Below DraftBrush.MIN_ROUND_SIDES a round shape uses the default
+			# instead, because `sides` defaults to 4 on every brush the Build tab
+			# makes and the editor has the prism shapes for the low counts. A 3
+			# here is expected to come back as DEFAULT_ROUND_SIDES.
 		var varies := false
 		for c in counts:
 			if c != counts[0]:
 				varies = true
 		if not varies and counts.size() > 1 and shape[1] != PYRAMID:
-			known(
-				482,
+			flag(
 				"a %s is the same %d faces whatever sides it is given" % [shape[0], counts[0]],
 				(
 					(

--- a/tools/vibe/scenarios/uv_defaults.gd
+++ b/tools/vibe/scenarios/uv_defaults.gd
@@ -107,8 +107,7 @@ func _every_shape_as_drawn() -> void:
 					)
 		note("%s: faces with no UV area" % SHAPES[shape], "%d of %d  %s" % [flat, total, examples])
 		if flat > 0:
-			known(
-				463,
+			flag(
 				"a new %s has %d face(s) no texture can be seen on" % [SHAPES[shape], flat],
 				(
 					"FaceData.uv_projection defaults to PLANAR_Z -- (x, y) -> (u, v) -- and"
@@ -150,9 +149,24 @@ func _what_the_box_uv_button_does() -> void:
 	# Texture lock reads the same field. A projection that does not contain the
 	# face cannot be world locked through a turn either, so the lock declines.
 	var top = brush.get_faces()[2]
-	top.uv_projection = FaceData.UVProjection.PLANAR_Z
+	note("the top face's projection, as drawn", top.uv_projection)
 	var locked: bool = top.adjust_uvs_for_rotation(Basis(Vector3.UP, deg_to_rad(90.0)))
 	note("texture lock compensates the top face of a default box under a yaw", locked)
+	if not locked:
+		flag(
+			"texture lock declines on a face of a brush nobody has re-projected",
+			(
+				"adjust_uvs_for_rotation() refuses any face whose projection plane the turn"
+				+ " takes away. A projection that does not contain the face cannot be world"
+				+ " locked through a turn, so a rotate with texture lock on changes nothing."
+			)
+		)
+	var planar = brush.get_faces()[3]
+	planar.uv_projection = FaceData.UVProjection.PLANAR_Z
+	note(
+		"the same turn on a face forced back to PLANAR_Z",
+		planar.adjust_uvs_for_rotation(Basis(Vector3.UP, deg_to_rad(90.0)))
+	)
 	top.uv_projection = FaceData.UVProjection.BOX_UV
 	var locked_box: bool = top.adjust_uvs_for_rotation(Basis(Vector3.UP, deg_to_rad(90.0)))
 	note("the same face with Box UV", locked_box)


### PR DESCRIPTION
Two defaults in `brush_instance.gd` that did not describe the shape they were on.

**#482 - a round brush ignored its own `sides`.** `radial_segments` was never
set, so every cylinder and cone was a 64-gon whatever `sides` said. The number is
part of a brush: the `.hflevel` carries it, a preset stores it and
`HFDuplicator.shape_signature()` counts it, so two brushes differing only in
`sides` were identical geometry with different signatures. The preview also
disagreed with the bake, which builds through `PrefabFactory` and has always used
16.

Below `MIN_ROUND_SIDES` the number is not honoured and the default is used.
`sides` is 4 on every brush the Build tab makes and on every cylinder in a level
saved before this, so honouring it literally would have turned every existing
cylinder into a square prism - and the editor has PRISM_TRI and PRISM_PENT for
the low counts, so a round shape is not how you ask for one.

**#463 - four of a new box's six faces had UVs that could not show a texture.**
`FaceData.uv_projection` defaulted to `PLANAR_Z`, which maps `(x, y)`, so on any
face containing the Z axis or lying flat in Y one UV axis was constant across the
whole face. `BOX_UV` resolves to the face's own dominant normal axis. Texture
lock reads the same field and declines a face whose projection plane a turn takes
away, which under `PLANAR_Z` was every face of a default box under a yaw - so it
now compensates where it used to do nothing.

The cylinder caps turned out to have a different cause than the issue reported:
they keep their source UVs rather than losing them, and `CylinderMesh` maps both
caps onto a line, every vertex sharing one v. Source UVs that span no area are
refused now.

Seven tests pinned the old defaults and are rewritten to state the invariant that
replaces each, not relaxed - the cylinder counts are `sides + 2`, the snap tests
give their cylinder enough segments to need the bounding-box fallback, and the
resize test reads the face whose projection actually maps world X. The four
quarter turns test compares to float precision because the lock now does
arithmetic where it used to decline; the measured drift is 8.7e-8 radians.

Full suite: 3756 passing, 7 risky, 0 failing.

Fixes #463
Fixes #482
