### PR TITLE
Keep the cordon Set from Selection produced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,20 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   unclamped and the dock spins clamped, so the dock said 256 while the next
   brush drawn was 500.5 across; the controls are written first and the size is
   read back out of them, so there is one answer.
+- **Set Cordon from Selection leaves a cordon that contains the selection**
+  (#467). The button put the right AABB on the level and then copied the six
+  numbers into the cordon spins, which were built with a range of +/-9999. Each
+  assignment clamps to that range *and* fires `value_changed`, and
+  `on_cordon_value_changed()` reads the six clamped spins straight back onto
+  `cordon_aabb` - so a room at x = 12000 collapsed the cordon to a zero-width
+  slab at the limit, the button left the cordon switched on, and the next bake
+  produced an empty level with the control reading 9999 as though that were the
+  number the mapper chose. The write-back is guarded with `syncing_grid` now, the
+  way `_sync_grid_settings_from_root()` already guards the same six, and the
+  range covers the coordinates a level actually holds: one structure builder
+  piece can be 4096 across on its own, and Quake-family maps run well past that
+  per axis. A cordon that still will not fit says so rather than being clamped in
+  silence.
 - **A tool setting is now held to its own schema, wherever the value comes
   from** (#450). `HFEditorTool.set_setting()` wrote whatever it was handed. The
   schema's `min`/`max` was read in exactly two places - `get_setting()` for the

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,755 tests across 199 test scripts (3,748 passing plus seven intentional no-assert safety tests; 18,686 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,759 tests across 200 test scripts (3,752 passing plus seven intentional no-assert safety tests; 18,696 assertions; verified in CI on September 13, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,796 tests across 204 test scripts (3,789 passing plus seven intentional no-assert safety tests; 18,842 assertions; verified in CI on September 13, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,800 tests across 205 test scripts (3,793 passing plus seven intentional no-assert safety tests; 18,852 assertions; verified in CI on September 13, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 13, 2026): **3,796 tests** across **204 scripts** (**3,789 passing** plus seven intentional no-assert safety tests; **18,842 assertions**).
+Full suite (verified in CI on September 13, 2026): **3,800 tests** across **205 scripts** (**3,793 passing** plus seven intentional no-assert safety tests; **18,852 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,755 tests** across **199 scripts** (**3,748 passing** plus seven intentional no-assert safety tests; **18,686 assertions**).
+Full suite (verified in CI on September 13, 2026): **3,759 tests** across **200 scripts** (**3,752 passing** plus seven intentional no-assert safety tests; **18,696 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3748%20passing-brightgreen" alt="3748 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3752%20passing-brightgreen" alt="3752 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3789%20passing-brightgreen" alt="3789 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3793%20passing-brightgreen" alt="3793 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,796 tests across 204 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,800 tests across 205 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,755 tests across 199 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,759 tests across 200 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/dock_visgroup_handler.gd
+++ b/addons/hammerforge/dock_visgroup_handler.gd
@@ -5,6 +5,17 @@ extends RefCounted
 
 const HFCollapsibleSection = preload("ui/collapsible_section.gd")
 
+## How far a cordon bound may sit from the origin.
+##
+## The old limit was 9999, which is narrower than the coordinates a level holds:
+## a structure builder takes a width or a radius up to 4096 for one piece of
+## geometry, and Quake-family maps run well past 4096 per axis. Set from
+## Selection on a room outside it clamped the cordon to a zero-width slab at the
+## limit and, because the assignment fires `value_changed`, wrote that back onto
+## the level - so the next bake produced an empty level and the control that
+## caused it read 9999 as though that were the number the mapper chose.
+const CORDON_LIMIT := 131072.0
+
 
 static func setup_visgroup_ui(dock: Object) -> void:
 	if dock == null or not dock.manage_tab:
@@ -201,9 +212,9 @@ static func setup_cordon_ui(dock: Object) -> void:
 	min_label.text = "Min (X, Y, Z):"
 	content.add_child(min_label)
 	var min_row = HBoxContainer.new()
-	dock.cordon_min_x = make_cordon_spin(dock, -9999, 9999, -128)
-	dock.cordon_min_y = make_cordon_spin(dock, -9999, 9999, -128)
-	dock.cordon_min_z = make_cordon_spin(dock, -9999, 9999, -128)
+	dock.cordon_min_x = make_cordon_spin(dock, -CORDON_LIMIT, CORDON_LIMIT, -128)
+	dock.cordon_min_y = make_cordon_spin(dock, -CORDON_LIMIT, CORDON_LIMIT, -128)
+	dock.cordon_min_z = make_cordon_spin(dock, -CORDON_LIMIT, CORDON_LIMIT, -128)
 	min_row.add_child(dock.cordon_min_x)
 	min_row.add_child(dock.cordon_min_y)
 	min_row.add_child(dock.cordon_min_z)
@@ -213,9 +224,9 @@ static func setup_cordon_ui(dock: Object) -> void:
 	max_label.text = "Max (X, Y, Z):"
 	content.add_child(max_label)
 	var max_row = HBoxContainer.new()
-	dock.cordon_max_x = make_cordon_spin(dock, -9999, 9999, 128)
-	dock.cordon_max_y = make_cordon_spin(dock, -9999, 9999, 128)
-	dock.cordon_max_z = make_cordon_spin(dock, -9999, 9999, 128)
+	dock.cordon_max_x = make_cordon_spin(dock, -CORDON_LIMIT, CORDON_LIMIT, 128)
+	dock.cordon_max_y = make_cordon_spin(dock, -CORDON_LIMIT, CORDON_LIMIT, 128)
+	dock.cordon_max_z = make_cordon_spin(dock, -CORDON_LIMIT, CORDON_LIMIT, 128)
 	max_row.add_child(dock.cordon_max_x)
 	max_row.add_child(dock.cordon_max_y)
 	max_row.add_child(dock.cordon_max_z)
@@ -297,8 +308,23 @@ static func on_cordon_from_selection(dock: Object) -> void:
 			dock.cordon_max_y,
 			dock.cordon_max_z,
 		]
+		# Each assignment clamps to the control's range *and* fires
+		# `value_changed`, which reads all six spins straight back onto the level.
+		# Without this guard the cordon the selection produced was replaced by
+		# whatever the spins could hold, which is the shape
+		# `_sync_grid_settings_from_root()` already uses for the same six.
+		var was_syncing: bool = dock.syncing_grid
+		dock.syncing_grid = true
+		var clamped := false
 		for index in range(controls.size()):
 			if controls[index]:
 				controls[index].value = values[index]
+				if not is_equal_approx(controls[index].value, values[index]):
+					clamped = true
+		dock.syncing_grid = was_syncing
+		if clamped:
+			dock._set_status_warning(
+				"Cordon set past +/-%d; the spins cannot show it all" % int(CORDON_LIMIT)
+			)
 	if dock.cordon_enabled_check:
 		dock.cordon_enabled_check.button_pressed = true

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,755 tests across 199 scripts**: **3,748 passing tests**, seven intentional no-assert safety tests, and **18,686 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 13, 2026 contains **3,759 tests across 200 scripts**: **3,752 passing tests**, seven intentional no-assert safety tests, and **18,696 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 13, 2026 contains **3,796 tests across 204 scripts**: **3,789 passing tests**, seven intentional no-assert safety tests, and **18,842 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 13, 2026 contains **3,800 tests across 205 scripts**: **3,793 passing tests**, seven intentional no-assert safety tests, and **18,852 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_cordon_from_selection.gd
+++ b/tests/test_cordon_from_selection.gd
@@ -1,0 +1,107 @@
+extends GutTest
+
+## What Set Cordon from Selection leaves behind.
+##
+## The button puts an AABB on the level and then copies the six numbers into the
+## cordon spins. Each assignment clamps to the control's range and fires
+## `value_changed`, which reads all six spins straight back onto the level - so
+## without a guard the cordon the selection produced is replaced by whatever the
+## spins could hold, and the cordon is what decides which geometry gets baked.
+
+const DockScene = preload("res://addons/hammerforge/dock.tscn")
+
+
+func _fresh_root() -> LevelRoot:
+	var root := LevelRoot.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	return root
+
+
+func _dock(root: LevelRoot) -> Node:
+	var dock := DockScene.instantiate()
+	add_child_autoqfree(dock)
+	dock.level_root = root
+	dock.connected_root = root
+	dock._connect_root_signals()
+	return dock
+
+
+func _room_at(root: LevelRoot, centre: Vector3, brush_id: String) -> Node:
+	return (
+		root
+		. create_brush_from_info(
+			{
+				"shape": LevelRoot.BrushShape.BOX,
+				"size": Vector3(256, 256, 256),
+				"center": centre,
+				"operation": CSGShape3D.OPERATION_UNION,
+				"brush_id": brush_id,
+			}
+		)
+	)
+
+
+func test_the_cordon_contains_the_selection_it_was_set_from() -> void:
+	var root := _fresh_root()
+	var dock := _dock(root)
+	# Quake-family maps run well past 4096 per axis, and the structure builders'
+	# own schemas take a width or radius up to 4096 for one piece of geometry, so
+	# this is a level rather than a stress test.
+	var far := Vector3(12000, 0, 0)
+	var brush := _room_at(root, far, "cordon_far_room")
+	dock._selection_nodes = [brush]
+
+	dock._on_cordon_from_selection()
+	var cordon: AABB = root.cordon_aabb
+	assert_true(
+		cordon.has_point(far),
+		"the cordon must contain the brush it was set from, not a slab at the spin limit"
+	)
+	assert_gt(cordon.size.x, 0.0, "and it must not be zero width")
+
+
+func test_the_spins_and_the_level_agree_after_the_button() -> void:
+	var root := _fresh_root()
+	var dock := _dock(root)
+	var brush := _room_at(root, Vector3(12000, 0, 0), "cordon_agree_room")
+	dock._selection_nodes = [brush]
+
+	dock._on_cordon_from_selection()
+	var cordon: AABB = root.cordon_aabb
+	assert_almost_eq(dock.cordon_min_x.value, cordon.position.x, 0.01, "min x")
+	assert_almost_eq(dock.cordon_max_x.value, cordon.end.x, 0.01, "max x")
+	assert_almost_eq(dock.cordon_min_y.value, cordon.position.y, 0.01, "min y")
+	assert_almost_eq(dock.cordon_max_z.value, cordon.end.z, 0.01, "max z")
+
+
+func test_the_spin_range_covers_the_coordinates_a_level_holds() -> void:
+	var root := _fresh_root()
+	var dock := _dock(root)
+	assert_gte(
+		dock.cordon_max_x.max_value,
+		HFDockVisgroupHandler.CORDON_LIMIT,
+		"the control has to be able to show a room a level can contain"
+	)
+	assert_gt(
+		dock.cordon_max_x.max_value,
+		4096.0,
+		"one structure builder piece can be 4096 across on its own"
+	)
+
+
+func test_the_button_leaves_a_cordon_that_bakes_something() -> void:
+	var root := _fresh_root()
+	var dock := _dock(root)
+	var brush := _room_at(root, Vector3(12000, 0, 0), "cordon_bake_room")
+	dock._selection_nodes = [brush]
+
+	dock._on_cordon_from_selection()
+	assert_true(root.cordon_enabled, "the button turns the cordon on, which is the point of it")
+	# Which makes the cordon being right the difference between baking the room
+	# and baking nothing at all.
+	assert_true(
+		root.cordon_aabb.intersects(AABB(Vector3(12000 - 128, -128, -128), Vector3.ONE * 256)),
+		"the enabled cordon overlaps the geometry it was built from"
+	)

--- a/tools/vibe/scenarios/dock_cordon.gd
+++ b/tools/vibe/scenarios/dock_cordon.gd
@@ -63,8 +63,7 @@ func _a_selection_outside_the_spin_range() -> void:
 	note("the brush the cordon was set from is at", brush_position)
 	note("does the cordon contain it", bounds.has_point(brush_position))
 	if not bounds.has_point(brush_position):
-		known(
-			467,
+		flag(
 			"Set Cordon from Selection leaves a cordon that excludes the selection",
 			(
 				(


### PR DESCRIPTION
`on_cordon_from_selection()` put the right AABB on the level and then copied the
six numbers into the cordon spins, which were built with a range of +/-9999.

Each assignment clamps to that range and fires `value_changed`, and
`on_cordon_value_changed()` reads the six clamped spins straight back onto
`cordon_aabb`. A room at x = 12000 - one structure builder piece can be 4096
across on its own - collapsed the cordon to a zero-width slab at the limit. The
button also leaves the cordon switched on, so the next bake produced an empty
level, and the control that caused it read 9999 as though that were the number
the mapper chose.

- The write-back is guarded with `syncing_grid`, which is the shape
  `_sync_grid_settings_from_root()` already uses for the same six spins.
- The range covers the coordinates a level actually holds.
- A cordon that still will not fit the control says so rather than being clamped
  in silence.

Full suite: 3752 passing, 7 risky, 0 failing.

Fixes #467
