### PR TITLE
Bake the materials the faces carry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,21 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   rebind list also showed two rows called "Extrude Up" and two called "Extrude
   Down", because `get_action_label()` gave the same name to an action and its
   alias; the aliases are named as aliases now.
+- **Per-face materials reach the baked mesh** (#466). The bake has two paths: the
+  face-material path triangulates each face and resolves its own material, and
+  the CSG path does not. Which one runs was decided by
+  `bake_use_face_materials`, which defaulted to false, with the check box that
+  mirrors it unticked inside the Advanced fold of the Test tab. So the Materials
+  panel, the face selection filters, "Apply to Selected Faces" and the UV
+  controls all worked on the preview and stopped at the bake: a mapper textured a
+  level, pressed Bake, and got one material over everything with nothing said
+  about it. The only log line on that path fired the other way round - when the
+  flag was *on* and a cut forced the CSG path - so the silent case was the
+  default one. The setting now defaults on, and the automatic fallback to CSG for
+  a level with structural subtractors is unchanged, since independent face
+  triangulation has no boolean subtraction stage and that fallback is what keeps
+  the cuts. Turning it off is still a choice, and a bake that drops face
+  materials because of it now says so.
 - **The operation timeline's Replay button can be clicked, and its glyphs name
   the operation** (#437, #438). The button lives in the panel header, outside
   the entry it applies to, and was shown on hover and hidden again on

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,755 tests across 199 test scripts (3,748 passing plus seven intentional no-assert safety tests; 18,686 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,760 tests across 200 test scripts (3,753 passing plus seven intentional no-assert safety tests; 18,692 assertions; verified in CI on September 13, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,800 tests across 205 test scripts (3,793 passing plus seven intentional no-assert safety tests; 18,852 assertions; verified in CI on September 13, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,805 tests across 206 test scripts (3,798 passing plus seven intentional no-assert safety tests; 18,858 assertions; verified in CI on September 13, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,755 tests** across **199 scripts** (**3,748 passing** plus seven intentional no-assert safety tests; **18,686 assertions**).
+Full suite (verified in CI on September 13, 2026): **3,760 tests** across **200 scripts** (**3,753 passing** plus seven intentional no-assert safety tests; **18,692 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 13, 2026): **3,800 tests** across **205 scripts** (**3,793 passing** plus seven intentional no-assert safety tests; **18,852 assertions**).
+Full suite (verified in CI on September 13, 2026): **3,805 tests** across **206 scripts** (**3,798 passing** plus seven intentional no-assert safety tests; **18,858 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3793%20passing-brightgreen" alt="3793 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3798%20passing-brightgreen" alt="3798 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3748%20passing-brightgreen" alt="3748 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3753%20passing-brightgreen" alt="3753 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,800 tests across 205 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,805 tests across 206 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,755 tests across 199 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,760 tests across 200 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/level_root.gd
+++ b/addons/hammerforge/level_root.gd
@@ -135,7 +135,14 @@ var _bake_lightmap_texel_size: float = 0.1
 		)
 	get:
 		return _bake_lightmap_texel_size
-@export var bake_use_face_materials: bool = false
+## Whether the bake triangulates each face and resolves its own material.
+##
+## Off, the CSG path runs and every face of the level comes out on one surface
+## with one material: the Materials panel, the face selection filters, "Apply to
+## Selected Faces" and the UV controls all work on the preview and stop at the
+## bake. `HFBakeSystem` falls back to CSG on its own, and says so, for a level
+## with structural subtractors - which is the case this path cannot serve.
+@export var bake_use_face_materials: bool = true
 @export var bake_navmesh: bool = false
 var _bake_navmesh_cell_size: float = 0.3
 @export var bake_navmesh_cell_size: float = 0.3:

--- a/addons/hammerforge/systems/hf_bake_system.gd
+++ b/addons/hammerforge/systems/hf_bake_system.gd
@@ -535,6 +535,21 @@ func _has_positive_structural_brush(container: Node3D) -> bool:
 	return false
 
 
+## Whether any face of the level has been given its own material.
+##
+## Worth saying out loud before a bake drops them: the Materials panel, the face
+## filters and "Apply to Selected Faces" all work on the preview whether or not
+## the bake is going to carry the result.
+func _faces_carry_materials() -> bool:
+	for brush in collect_face_bake_brushes():
+		if not (is_instance_valid(brush) and brush is DraftBrush):
+			continue
+		for face in (brush as DraftBrush).faces:
+			if face and face.material_idx >= 0:
+				return true
+	return false
+
+
 func _has_effective_structural_subtractors() -> bool:
 	for container in [root.draft_brushes_node, root.generated_floors, root.generated_walls]:
 		if _container_has_effective_subtractor(container):
@@ -716,6 +731,14 @@ func _bake_impl(
 		# Keep every effective cutter by switching this bake to CSG.
 		bake_options["use_face_materials"] = false
 		root._log("Face-material bake switched to CSG to preserve active cuts")
+	elif not root.bake_use_face_materials and _faces_carry_materials():
+		# The only log on this path used to fire the other way round, so the
+		# silent case was a mapper texturing a level, pressing Bake and getting one
+		# material over everything with nothing said about it.
+		root.emit_signal(
+			"user_message", "Per-face materials were not baked: Use Face Materials is off", 1
+		)
+		root._log("Per-face materials dropped: the CSG path resolves one material per brush")
 	if not _has_positive_structural_sources():
 		baked = _bake_heightmap_only(layer)
 		if baked == null and _has_nonstructural_sources():

--- a/addons/hammerforge/ui/manage_tab_builder.gd
+++ b/addons/hammerforge/ui/manage_tab_builder.gd
@@ -77,7 +77,7 @@ func build(parent: Control) -> void:
 	dock.bake_lightmap_uv2 = dock._make_check("Lightmap UV2")
 	adv.add_child(dock.bake_lightmap_uv2)
 
-	dock.bake_use_face_materials = dock._make_check("Use Face Materials")
+	dock.bake_use_face_materials = dock._make_check("Use Face Materials", true)
 	adv.add_child(dock.bake_use_face_materials)
 
 	dock.bake_lightmap_texel_row = HBoxContainer.new()

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 13, 2026 contains **3,800 tests across 205 scripts**: **3,793 passing tests**, seven intentional no-assert safety tests, and **18,852 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 13, 2026 contains **3,805 tests across 206 scripts**: **3,798 passing tests**, seven intentional no-assert safety tests, and **18,858 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,755 tests across 199 scripts**: **3,748 passing tests**, seven intentional no-assert safety tests, and **18,686 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 13, 2026 contains **3,760 tests across 200 scripts**: **3,753 passing tests**, seven intentional no-assert safety tests, and **18,692 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_bake_face_materials_default.gd
+++ b/tests/test_bake_face_materials_default.gd
@@ -1,0 +1,116 @@
+extends GutTest
+
+## Whether the materials a mapper painted reach the baked mesh.
+##
+## The bake has two paths. The face-material path triangulates each face and
+## resolves its own material; the CSG path does not, and every face of the level
+## comes out on one surface. Which one runs is decided by
+## `bake_use_face_materials`, and the check box that mirrors it sits inside the
+## Advanced fold of the Test tab - so the Materials panel, the face selection
+## filters, "Apply to Selected Faces" and the UV controls all worked on the
+## preview and stopped at the bake, with nothing said about it.
+
+
+func _fresh_root() -> LevelRoot:
+	var root := LevelRoot.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	return root
+
+
+func _palette_material(colour: Color) -> StandardMaterial3D:
+	var mat := StandardMaterial3D.new()
+	mat.albedo_color = colour
+	return mat
+
+
+func test_a_fresh_level_bakes_the_materials_its_faces_carry() -> void:
+	var root := _fresh_root()
+	assert_true(
+		root.bake_use_face_materials,
+		"a mapper who textures a level and presses Bake gets what they textured"
+	)
+
+
+func test_the_dock_check_box_agrees_with_the_level_it_mirrors() -> void:
+	var source := FileAccess.get_file_as_string("res://addons/hammerforge/ui/manage_tab_builder.gd")
+	assert_true(
+		source.contains('_make_check("Use Face Materials", true)'),
+		"an unticked box in front of a level that has it on is the same defect the other way"
+	)
+
+
+func test_a_level_with_structural_subtractors_still_falls_back_to_csg() -> void:
+	var root := _fresh_root()
+	# Independent face triangulation has no boolean subtraction stage, so the
+	# fallback is what keeps a cut. Defaulting the flag on must not cost that.
+	var source := FileAccess.get_file_as_string(
+		"res://addons/hammerforge/systems/hf_bake_system.gd"
+	)
+	assert_true(
+		source.contains("not _has_effective_structural_subtractors()"),
+		"the face-material path is still gated on the level having no effective cutters"
+	)
+	assert_true(
+		source.contains("Face-material bake switched to CSG to preserve active cuts"),
+		"and the fallback still says so"
+	)
+
+
+func test_a_bake_that_drops_face_materials_says_so() -> void:
+	var root := _fresh_root()
+	root.bake_use_face_materials = false
+	root.set_materials([_palette_material(Color.RED), _palette_material(Color.BLUE)])
+	var brush = (
+		root
+		. create_brush_from_info(
+			{
+				"shape": LevelRoot.BrushShape.BOX,
+				"size": Vector3(64, 64, 64),
+				"center": Vector3.ZERO,
+				"operation": CSGShape3D.OPERATION_UNION,
+				"brush_id": "face_material_brush",
+			}
+		)
+	)
+	brush.faces[0].material_idx = 1
+
+	var messages: Array = []
+	root.user_message.connect(func(text: String, _severity: int) -> void: messages.append(text))
+	await root.bake(true, false, 0)
+
+	var said := false
+	for text in messages:
+		if str(text).contains("Per-face materials"):
+			said = true
+	assert_true(
+		said, "turning the flag off is a choice; losing the materials without being told is not"
+	)
+
+
+func test_a_bake_with_no_face_materials_says_nothing_about_them() -> void:
+	var root := _fresh_root()
+	root.bake_use_face_materials = false
+	(
+		root
+		. create_brush_from_info(
+			{
+				"shape": LevelRoot.BrushShape.BOX,
+				"size": Vector3(64, 64, 64),
+				"center": Vector3.ZERO,
+				"operation": CSGShape3D.OPERATION_UNION,
+				"brush_id": "plain_brush",
+			}
+		)
+	)
+
+	var messages: Array = []
+	root.user_message.connect(func(text: String, _severity: int) -> void: messages.append(text))
+	await root.bake(true, false, 0)
+
+	var said := false
+	for text in messages:
+		if str(text).contains("Per-face materials"):
+			said = true
+	assert_false(said, "a level with nothing painted on it has nothing to warn about")

--- a/tools/vibe/scenarios/bake_materials.gd
+++ b/tools/vibe/scenarios/bake_materials.gd
@@ -92,8 +92,7 @@ func _two_materials_on_one_brush() -> void:
 	note("distinct materials on them", _distinct(with_flag))
 
 	if _distinct(as_shipped) < 2 and _distinct(with_flag) >= 2:
-		known(
-			466,
+		flag(
 			"per-face materials do not reach the bake a level starts with",
 			(
 				(


### PR DESCRIPTION
The bake has two paths. The face-material path triangulates each face and
resolves its own material; the CSG path does not, and every face of the level
comes out on one surface. Which one runs was decided by
`bake_use_face_materials`, which defaulted to false, with the check box that
mirrors it unticked inside the Advanced fold of the Test tab.

So the Materials panel, the face selection filters, "Apply to Selected Faces" and
the UV controls all worked on the preview and stopped at the bake. A mapper
textured a level, pressed Bake, and got one material over everything. The only
log line on that path fired the other way round - when the flag was on and a cut
forced CSG - so the silent case was the default one.

- The setting defaults on, and so does the check box, so the two agree at
  startup.
- The automatic fallback to CSG for a level with structural subtractors is
  untouched. Independent face triangulation has no boolean subtraction stage and
  that fallback is what keeps the cuts; a test pins it.
- Turning the flag off is still a choice. A bake that drops face materials
  because of it now says so, and a level with nothing painted says nothing.

A fresh level with two palette materials on one brush bakes 2 surfaces with 2
distinct materials, where it was 1 and 1.

Full suite: 3753 passing, 7 risky, 0 failing.

Fixes #466
