### PR TITLE
Write entity properties into a .map in the notation a .map uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,22 @@ The format is based on Keep a Changelog, and this project follows semantic versi
   now all give the schema's. A value that is not a number is refused and the
   previous one kept. `_build_segment_brush()` also refuses a non-positive width
   or height outright rather than building a ring from it.
+- **Entity properties are written into a `.map` in the notation a `.map` uses**
+  (#479). A `.map` exists to be read by something else, and the Objects tab
+  stores typed values: the colour picker writes a `Color` and the vector row
+  writes a `Vector3`. `_entity_to_map_lines()` called `str()` on each one before
+  the adapter saw it, so a colour reached the file as
+  `"color" "(0.2, 0.4, 0.8, 1.0)"` - and the parentheses and the commas make the
+  key unusable to a Quake-family compiler rather than merely differently scaled.
+  The value keeps its type as far as the adapter now, which writes a colour as
+  three numbers with no alpha, a vector as space-separated components, a flag as
+  `1` or `0` and a float with the snapping the rest of the file uses. A hex
+  string goes the same way, because `entities.json` gives a colour property a hex
+  default and a colour the mapper never opened was reaching the file as
+  `#ffffff`. The colour scale is one overridable method, since it is a per-format
+  convention. The `.map` writer's no-adapter fallback used to `str()` everything,
+  which is the notation this path exists to keep out of the file; it builds a
+  base adapter instead.
 - **The region memory budget now counts what it actually freed** (#446).
   `_unload_region()` is careful: it refuses to throw a region's chunks away if
   they could not be written to disk first, and says so. `_evict_for_budget()`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,755 tests across 199 test scripts (3,748 passing plus seven intentional no-assert safety tests; 18,686 assertions; verified in CI on September 12, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,763 tests across 200 test scripts (3,756 passing plus seven intentional no-assert safety tests; 18,705 assertions; verified in CI on September 13, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -430,7 +430,7 @@ The project has a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs
 - `gdformat --check` -- verifies formatting
 - `gdlint` -- checks lint rules (configured in `.gdlintrc`)
 - `tools/check_placement_order.py` -- refuses a world transform written to a node that is not in the tree yet
-- **GUT unit + integration tests** -- 3,805 tests across 206 test scripts (3,798 passing plus seven intentional no-assert safety tests; 18,858 assertions; verified in CI on September 13, 2026; runs Godot headless)
+- **GUT unit + integration tests** -- 3,813 tests across 207 test scripts (3,806 passing plus seven intentional no-assert safety tests; 18,877 assertions; verified in CI on September 13, 2026; runs Godot headless)
 
 Run locally before pushing:
 ```

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 12, 2026): **3,755 tests** across **199 scripts** (**3,748 passing** plus seven intentional no-assert safety tests; **18,686 assertions**).
+Full suite (verified in CI on September 13, 2026): **3,763 tests** across **200 scripts** (**3,756 passing** plus seven intentional no-assert safety tests; **18,705 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/HammerForge_SPEC.md
+++ b/HammerForge_SPEC.md
@@ -544,6 +544,6 @@ Unit tests use the [GUT](https://github.com/bitwes/Gut) framework and run headle
 | `test_selection_gesture.gd` | 40 | Native widget/Object Select ownership, modal Face Select, recovery, focus/scope guards, native duplicate/reparent repair, and Inspector/undo change tracking |
 | `test_viewport_outlines.gd` | 39 | Sparse semantic outlines, exact/composite entity collision, visibility/transforms, and shape-aware resize recovery |
 
-Full suite (verified in CI on September 13, 2026): **3,805 tests** across **206 scripts** (**3,798 passing** plus seven intentional no-assert safety tests; **18,858 assertions**).
+Full suite (verified in CI on September 13, 2026): **3,813 tests** across **207 scripts** (**3,806 passing** plus seven intentional no-assert safety tests; **18,877 assertions**).
 
 Tests use root shim scripts (dynamically created GDScript) to provide the LevelRoot interface without circular preload dependencies. Configuration in `.gutconfig.json`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3798%20passing-brightgreen" alt="3798 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3806%20passing-brightgreen" alt="3806 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <img src="https://img.shields.io/badge/Godot-4.7%2B-478cbf?logo=godot-engine&logoColor=white" alt="Godot 4.7+">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/badge/Status-Early%20Alpha-red" alt="Early Alpha">
-  <img src="https://img.shields.io/badge/Tests-3748%20passing-brightgreen" alt="3748 tests passing">
+  <img src="https://img.shields.io/badge/Tests-3756%20passing-brightgreen" alt="3756 tests passing">
   <img src="https://img.shields.io/badge/GDScript-61k%2B%20lines-blueviolet" alt="61k+ lines">
 </p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,805 tests across 206 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,813 tests across 207 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -933,7 +933,7 @@ Completion is responsibility-based rather than tied to an arbitrary line count. 
 - Headless editor tests retain the complete tool graph, with focused export-playtest coverage guarding the runtime boundary.
 
 ### Risk-focused test gaps
-The current suite covers 3,755 tests across 199 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
+The current suite covers 3,763 tests across 200 scripts, including the large brush, bake, paint, vertex, transform, generator, baker, brush-instance, and map-I/O systems. No issues are open, and every known limitation is either covered by tests or written down beside the wave that introduced it.
 
 The last one on this list is **resolved**: a `.map` entity property value
 containing a quote used to come back truncated, silently, because four quotes is

--- a/addons/hammerforge/map_adapters/hf_map_adapter.gd
+++ b/addons/hammerforge/map_adapters/hf_map_adapter.gd
@@ -22,13 +22,58 @@ func format_face_line(
 func format_entity_properties(properties: Dictionary) -> Array[String]:
 	var lines: Array[String] = []
 	for key in properties:
-		lines.append(
-			(
-				'"%s" "%s"'
-				% [MapIO.escape_property(str(key)), MapIO.escape_property(str(properties[key]))]
+		(
+			lines
+			. append(
+				(
+					'"%s" "%s"'
+					% [
+						MapIO.escape_property(str(key)),
+						MapIO.escape_property(format_property_value(properties[key])),
+					]
+				)
 			)
 		)
 	return lines
+
+
+## One property value, the way a `.map` file carries it.
+##
+## A `.map` exists to be read by something else, and the Objects tab stores typed
+## values: the colour picker writes a `Color` and the vector row writes a
+## `Vector3`. `str()` on either produces Godot's own notation - a colour comes out
+## as "(0.2, 0.4, 0.8, 1.0)" - and no Quake-family compiler or editor parses that.
+## The parentheses and the commas make the key unusable rather than merely
+## differently scaled.
+func format_property_value(value: Variant) -> String:
+	match typeof(value):
+		TYPE_COLOR:
+			return format_color(value)
+		TYPE_VECTOR3:
+			return _format_vec3(value)
+		TYPE_VECTOR2:
+			return "%s %s" % [_snapped(value.x), _snapped(value.y)]
+		TYPE_BOOL:
+			return "1" if value else "0"
+		TYPE_FLOAT:
+			return _snapped(value)
+		TYPE_STRING, TYPE_STRING_NAME:
+			# `entities.json` gives a colour property a hex default, so a colour
+			# the mapper never opened is still a `String` on the way out.
+			var text := str(value)
+			if text.begins_with("#") and Color.html_is_valid(text):
+				return format_color(Color.html(text))
+			return text
+		_:
+			return str(value)
+
+
+## A colour as a `.map` file carries one: three numbers, and no alpha.
+##
+## 0..255 per channel is the convention the Quake family uses for a light colour.
+## A format that wants 0..1 overrides this without touching anything else.
+func format_color(value: Color) -> String:
+	return "%d %d %d" % [roundi(value.r * 255.0), roundi(value.g * 255.0), roundi(value.b * 255.0)]
 
 
 ## Snap a float to 3 decimal places, matching MapIO._snapped().

--- a/addons/hammerforge/map_io.gd
+++ b/addons/hammerforge/map_io.gd
@@ -398,10 +398,8 @@ static func _entity_identity_lines(entity, adapter: HFMapAdapterType = null) -> 
 	for pair in pairs:
 		# One pair at a time keeps the order and the repeats while still going
 		# through the adapter, which is what escapes the key and the value.
-		if adapter:
-			out.append_array(adapter.format_entity_properties({pair[0]: pair[1]}))
-		else:
-			out.append('"%s" "%s"' % [escape_property(str(pair[0])), escape_property(str(pair[1]))])
+		var writer: HFMapAdapterType = adapter if adapter else HFMapAdapterType.new()
+		out.append_array(writer.format_entity_properties({pair[0]: pair[1]}))
 	return out
 
 
@@ -421,19 +419,20 @@ static func _entity_to_map_lines(
 		var key_name := str(key)
 		if key_name == "classname" or key_name == "origin":
 			continue
-		var value := str(data[key])
-		if value == "":
+		# The value keeps its type on the way to the adapter. The Objects tab
+		# stores a Color for a colour and a Vector3 for a vector row, and `str()`
+		# on either produces Godot's own notation, which nothing that reads a
+		# `.map` can parse - so flattening here was what put it in the file.
+		if str(data[key]) == "":
 			continue
-		props[key_name] = value
+		props[key_name] = data[key]
 	props["classname"] = entity_class
 	props["origin"] = _format_vec3(entity.global_transform.origin)
-	if adapter:
-		lines.append_array(adapter.format_entity_properties(props))
-	else:
-		for key in props:
-			lines.append(
-				'"%s" "%s"' % [escape_property(str(key)), escape_property(str(props[key]))]
-			)
+	# A base adapter when none was given, rather than a second copy of the
+	# formatting here: the fallback used to `str()` every value, which is the
+	# notation this path exists to keep out of the file.
+	var writer: HFMapAdapterType = adapter if adapter else HFMapAdapterType.new()
+	lines.append_array(writer.format_entity_properties(props))
 	# entity_data carries the authored keys. The name and the I/O outputs live in
 	# metadata, so they come from there.
 	lines.append_array(_entity_identity_lines(entity, adapter))

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 13, 2026 contains **3,805 tests across 206 scripts**: **3,798 passing tests**, seven intentional no-assert safety tests, and **18,858 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 13, 2026 contains **3,813 tests across 207 scripts**: **3,806 passing tests**, seven intentional no-assert safety tests, and **18,877 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/docs/features.md
+++ b/docs/features.md
@@ -389,7 +389,7 @@ transform group while paint mode is on, so only one of the two is ever live.
 
 ## Testing
 
-The verified Godot 4.7 suite on September 12, 2026 contains **3,755 tests across 199 scripts**: **3,748 passing tests**, seven intentional no-assert safety tests, and **18,686 assertions**. All checks run on every push and pull request via GitHub Actions.
+The verified Godot 4.7 suite on September 13, 2026 contains **3,763 tests across 200 scripts**: **3,756 passing tests**, seven intentional no-assert safety tests, and **18,705 assertions**. All checks run on every push and pull request via GitHub Actions.
 
 ```bash
 # Run all tests headless

--- a/tests/test_map_property_export.gd
+++ b/tests/test_map_property_export.gd
@@ -1,0 +1,120 @@
+extends GutTest
+
+## What an entity property looks like in the file a `.map` export produces.
+##
+## A `.map` exists to be read by something else. The Objects tab stores typed
+## values - the colour picker writes a `Color`, the vector row writes a `Vector3`
+## - and `str()` on either produces Godot's own notation, which no Quake-family
+## compiler or editor parses. The parentheses and the commas make the key
+## unusable rather than merely differently scaled.
+
+const MapAdapter = preload("res://addons/hammerforge/map_adapters/hf_map_adapter.gd")
+const DraftEntityScript = preload("res://addons/hammerforge/draft_entity.gd")
+
+
+func _adapter() -> HFMapAdapter:
+	return MapAdapter.new()
+
+
+func _fresh_root() -> LevelRoot:
+	var root := LevelRoot.new()
+	root.auto_spawn_player = false
+	root.hflevel_autosave_enabled = false
+	add_child_autoqfree(root)
+	return root
+
+
+# ---------------------------------------------------------------------------
+# The values themselves
+# ---------------------------------------------------------------------------
+
+
+func test_a_colour_is_three_numbers_with_no_alpha() -> void:
+	assert_eq(
+		_adapter().format_property_value(Color(0.2, 0.4, 0.8, 1.0)),
+		"51 102 204",
+		"the notation a light colour is written in, not Godot's"
+	)
+	assert_eq(_adapter().format_property_value(Color(1, 1, 1, 1)), "255 255 255")
+
+
+func test_a_hex_colour_string_is_written_the_same_way() -> void:
+	# entities.json gives a colour property a hex default, so a colour the mapper
+	# never opened is still a String on the way out - and "#ffffff" is no more
+	# readable to a compiler than "(1, 1, 1, 1)" is.
+	assert_eq(_adapter().format_property_value("#ffffff"), "255 255 255")
+	assert_eq(
+		_adapter().format_property_value("lamp_1"), "lamp_1", "an ordinary string is left alone"
+	)
+
+
+func test_a_vector_is_space_separated_components() -> void:
+	assert_eq(_adapter().format_property_value(Vector3(16, 32, 0)), "16 32 0")
+	assert_eq(_adapter().format_property_value(Vector3(1.5, -2.25, 0)), "1.5 -2.25 0")
+	assert_eq(_adapter().format_property_value(Vector2(4, 8)), "4 8")
+
+
+func test_a_flag_is_one_or_zero() -> void:
+	assert_eq(_adapter().format_property_value(true), "1", "not the word true")
+	assert_eq(_adapter().format_property_value(false), "0")
+
+
+func test_a_float_keeps_the_snapping_the_rest_of_the_file_uses() -> void:
+	assert_eq(_adapter().format_property_value(64.0), "64", "not 64.000")
+	assert_eq(_adapter().format_property_value(2.5), "2.5")
+
+
+# ---------------------------------------------------------------------------
+# What reaches the file
+# ---------------------------------------------------------------------------
+
+
+func test_an_exported_entity_carries_its_properties_in_map_notation() -> void:
+	var root := _fresh_root()
+	var entity := DraftEntityScript.new()
+	entity.name = "Lamp"
+	entity.entity_type = "light"
+	entity.entity_class = "light"
+	entity.set_meta("is_entity", true)
+	root.add_entity(entity)
+	entity.entity_data["color"] = Color(0.2, 0.4, 0.8, 1.0)
+	entity.entity_data["mins"] = Vector3(16, 32, 0)
+	entity.entity_data["spawnflags_on"] = true
+	entity.entity_data["targetname"] = "lamp_1"
+
+	var text := MapIO.export_map_from_level(root)
+	assert_true(text.contains('"color" "51 102 204"'), "the colour is numbers in the file")
+	assert_true(text.contains('"mins" "16 32 0"'), "and so is the vector")
+	assert_true(text.contains('"spawnflags_on" "1"'), "and the flag is 1, not true")
+	assert_true(text.contains('"targetname" "lamp_1"'), "a string is untouched")
+	assert_false(text.contains("(0.2, 0.4, 0.8, 1)"), "Godot's own notation is gone")
+	assert_false(text.contains("(16, 32, 0)"))
+
+
+func test_the_export_formats_the_same_way_with_no_adapter_given() -> void:
+	# The fallback used to `str()` every value, which is the notation this path
+	# exists to keep out of the file.
+	var root := _fresh_root()
+	var entity := DraftEntityScript.new()
+	entity.name = "Lamp"
+	entity.entity_type = "light"
+	entity.entity_class = "light"
+	entity.set_meta("is_entity", true)
+	root.add_entity(entity)
+	entity.entity_data["color"] = Color(1, 0, 0, 1)
+
+	assert_true(
+		MapIO.export_map_from_level(root, null).contains('"color" "255 0 0"'),
+		"no adapter is not a reason to write Godot notation"
+	)
+
+
+func test_a_format_can_write_colours_its_own_way() -> void:
+	# The scale is a per-format convention: some of the family take 0..1. The
+	# point of the override is that it is one method, not a rewrite.
+	var adapter := _adapter()
+	assert_eq(
+		adapter.format_color(Color(0.5, 0.5, 0.5, 1.0)),
+		"128 128 128",
+		"the base adapter writes 0..255, which is what the Quake family uses"
+	)

--- a/tools/vibe/scenarios/entity_props.gd
+++ b/tools/vibe/scenarios/entity_props.gd
@@ -149,8 +149,7 @@ func _into_the_map_file() -> void:
 		if line.contains('"color"'):
 			colour_line = line.strip_edges()
 	if colour_line.contains("(") or colour_line.contains(","):
-		known(
-			479,
+		flag(
 			"a colour entity property is written into the .map file in Godot's own notation",
 			(
 				(


### PR DESCRIPTION
A `.map` exists to be read by something else, and the Objects tab stores typed
values: the colour picker writes a `Color` and the vector row writes a `Vector3`.

The root cause was one line above where the issue points. `format_entity_properties()`
does call `str()`, but `_entity_to_map_lines()` had already flattened every value
with `str()` before the adapter saw it, so the adapter only ever received Strings.

- The value keeps its type as far as the adapter now. A colour is written as
  three numbers with no alpha, a vector as space-separated components, a flag as
  `1` or `0`, a float with the snapping the rest of the file already uses.
- A hex string goes the same way. `entities.json` gives a colour property a hex
  default, so a colour the mapper never opened was reaching the file as
  `#ffffff`, which is no more readable to a compiler than the Godot notation was.
- The colour scale is one overridable method on the adapter, because it is a
  per-format convention and the family does not agree on it.
- The writer's no-adapter fallback used to `str()` everything, which is the
  notation this path exists to keep out of the file. It builds a base adapter
  instead, so there is one place that decides.

`"color" "(0.2, 0.4, 0.8, 1.0)"` is now `"color" "51 102 204"`.

A `.map` is an untyped text format, so a round trip still brings a colour back as
a String. That is the format, not this path, and restoring types on import would
mean reading the property types out of `entities.json` - worth its own ticket if
you want it.

Full suite: 3756 passing, 7 risky, 0 failing.

Fixes #479
